### PR TITLE
name of main branch is "main" rather than "master"

### DIFF
--- a/wiki/Compile_on_Windows.wikitext
+++ b/wiki/Compile_on_Windows.wikitext
@@ -436,7 +436,7 @@ FreeCAD is very actively developed. Therefore its source code changes almost dai
 <!--T:164-->
 When using the [https://en.wikipedia.org/wiki/Comparison_of_Git_GUIs Git frontend] TortoiseGit:
 # Right-click on your FreeCAD source code folder in the Windows file explorer and select '''Pull''' in the context menu.
-# A dialog will appear. Select there what development branch you want to get. '''master''' is the main branch. Therefore use this unless you want to compile a special new feature from a branch that has not yet been merged to ''master''. (For more about Git branches, see [[Source_code_management#Git_development_process|Git development process]].)
+# A dialog will appear. Select there what development branch you want to get. '''main''' is the main branch. Therefore use this unless you want to compile a special new feature from a branch that has not yet been merged to ''main''. (For more about Git branches, see [[Source_code_management#Git_development_process|Git development process]].)
 
 <!--T:198-->
 Finally click '''OK'''.
@@ -448,12 +448,12 @@ Open a terminal (command prompt) and switch there to your source directory. Then
 
 </translate>
 {{Code|code=
-git pull https://github.com/FreeCAD/FreeCAD.git master
+git pull https://github.com/FreeCAD/FreeCAD.git main
 }}
 <translate>
 
 <!--T:167-->
-where ''master'' the the name of the main development branch. If you want to get code from another branch, use its name instead of ''master''.
+where ''main'' the the name of the main development branch. If you want to get code from another branch, use its name instead of ''main''.
 
 ===Recompilation=== <!--T:168-->
 


### PR DESCRIPTION
updated instructions on windows compilations about how to pull the git repo of FreeCAD since the name of the main branch is "main"