### PR TITLE
PYTHON_* no longer exist in the makefiles.

### DIFF
--- a/wiki/Compile_on_Windows.wikitext
+++ b/wiki/Compile_on_Windows.wikitext
@@ -145,11 +145,6 @@ If it fails with the message that Visual Studio could not be found, the CMake su
 # On the right side you should now see that the component ''Visual C++ tools for CMake'' will be installed.
 # Install it.
 
-<!--T:219-->
-If it fails with a message about the wrong Python version or missing Python, then:
-# Use the "Search:" box in CMake to search for the string "Python"
-# If you see there a path like ''C:/Program Files/Python38/python.exe'', CMake recognized the Python that is already installed on your PC, but that version is not compatible with the LibPack. Since the LibPack includes a compatible version of Python, modify the following Python settings in CMake to its paths (assuming the LibPack is in the folder ''D:/FreeCAD-build/FreeCADLibs_2_8_x64_VC2019''):<br>[[File:CMake_Python_settings.png]]
-
 <!--T:153-->
 If there is no error about Visual Studio or Python, everything is fine, but CMake does not yet know all necessary settings. Therefore now:
 # Search in CMake for the variable '''FREECAD_LIBPACK_DIR''' and specify the location of the LibPack folder you downloaded earlier.
@@ -255,12 +250,6 @@ If you don't get any errors you are done. '''Congratulations!''' You can exit MS
 '''Important:''' Since Visual Studio 17.4 you cannot use the code optimization that is on by default for the target '''SketcherGui'''. If you do, angle constraints will be misplaced in sketches. To fix this, right-click on this target in the MSVC solution explorer and select the last entry '''Properties''' in the context menu. In the appearing dialog go to C/C++ → Optimization and there disable the setting '''Optimization'''. Finally build the target '''ALL_BUILD''' again.
 
 ==== Debug Build ==== <!--T:222-->
-
-<!--T:223-->
-For a debug build it is necessary that the Python is used that is included in the LibPack. To assure this:
-#  Search in the CMake GUI for "Python"
-#  If you see there a path like ''C:/Program Files/Python38/python.exe'', CMake recognized the Python that is installed on your PC and not the one of the LibPack. In this case adapt these different Python settings in CMake to this (assuming the LibPack is in the folder ''D:\FreeCAD-build\FreeCADLibs_12.5.2_x64_VC17''):
-[[File:CMake_Python_settings.png]]
 
 <!--T:256-->
 As prerequisite for the debug build, you need to do this:


### PR DESCRIPTION
These parameters are automatically taken from LIBPACK so the advice is not relevant anymore.