### PR TITLE
[codex] Update Draft release notes for FreeCAD 1.2

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -183,18 +183,16 @@ ToDo (last check: 20260430, #27222):
 
 == Draft Workbench == <!--T:27-->
 
-</translate>
-ToDo (last check: 20260430, #29258):
-* https://github.com/FreeCAD/FreeCAD/pull/26571
-* https://github.com/FreeCAD/FreeCAD/pull/26950
-* https://github.com/FreeCAD/FreeCAD/pull/27979
-* https://github.com/FreeCAD/FreeCAD/pull/27987
-* https://github.com/FreeCAD/FreeCAD/pull/28324
-* https://github.com/FreeCAD/FreeCAD/pull/29142
-* https://github.com/FreeCAD/FreeCAD/pull/29298
-<translate>
-
 === Further Draft improvements === <!--T:28-->
+
+<!--T:78-->
+* Draft snapping now supports B-spline knots. [https://github.com/FreeCAD/FreeCAD/pull/26571 Pull request #26571]
+* Draft in-command shortcut preferences can now contain multiple characters, making localized single-character shortcuts possible. [https://github.com/FreeCAD/FreeCAD/pull/26950 Pull request #26950]
+* The [[Draft_SelectPlane|Working Plane]] command now moves the working plane origin to a pre-selected vertex without changing its orientation. [https://github.com/FreeCAD/FreeCAD/pull/27979 Pull request #27979]
+* Draft angular dimensions now create extension lines correctly in angular mode. [https://github.com/FreeCAD/FreeCAD/pull/27987 Pull request #27987]
+* [[Draft_PolarArray|Polar Array]] and [[Draft_CircularArray|Circular Array]] are now aware of the active working plane. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
+* SVG import can now approximate suitable curves to arcs and lines. [https://github.com/FreeCAD/FreeCAD/pull/29142 Pull request #29142]
+* Draft angular dimensions now honor overshoot settings. [https://github.com/FreeCAD/FreeCAD/pull/29298 Pull request #29298]
 
 == FEM Workbench == <!--T:29-->
 


### PR DESCRIPTION
## Summary

- Replace the Draft Workbench TODO link list with release-note bullets for merged FreeCAD PRs.
- Keep the original PR references and existing release-note structure.

## Validation

- `git diff --check`
- Verified referenced wiki pages exist: `Draft_SelectPlane`, `Draft_PolarArray`, `Draft_CircularArray`
- Verified `<translate>` tag count is balanced: `3` open / `3` close

