### PR TITLE
Add recent FreeCAD 1.2 release note entries

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -48,6 +48,8 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * There is now a [[Image:Std_ToggleBottomPanels.svg|16px]] Toggle Bottom Panels button and a shortcut {{KEY|Ctrl}} + {{KEY|O}} to toggle the bottom panels ([[Report_View|Report View]] and [[Python_Console|Python Console]]). [https://github.com/FreeCAD/FreeCAD/pull/28598 Pull request #28598]
 * The [[Image:Std_AlignToSelection.svg|24px]] [[Std_AlignToSelection|Align to Selection]] command now supports multi-selection. [https://github.com/FreeCAD/FreeCAD/pull/29182 Pull request #29182]
 * Double-clicking on an expression field now clears the expression and keeps the current value. If no change is made, the expression is restored after losing focus. [https://github.com/FreeCAD/FreeCAD/pull/29414 Pull request #29414]
+* SpaceMouse rotations now honor the active navigation rotation center mode, including ''Object center'' and ''Drag at cursor'' modes. [https://github.com/FreeCAD/FreeCAD/pull/29998 Pull request #29998]
+* The VarSet ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 
 == Core system and API == <!--T:10-->
 
@@ -195,6 +197,7 @@ ToDo (last check: 20260430, #27222):
 * A new Rotary Surface operation was added for 4th axis surfacing. [https://github.com/FreeCAD/FreeCAD/pull/29751 Pull request #29751]
 * The job creation and editing dialogs were improved. Job creation now includes a unit schema selector, template description was added to the json and there is a machine selector, as well as a button to create new machines on the General tab. Several other widgets within those panels were also enhanced. [https://github.com/FreeCAD/FreeCAD/pull/29861 Pull request #29861]
 * {{Incode|MachineState.G0F}}, and {{Incode|.ReturnMode}} were added for [[CAM_Drilling|Drilling]] commands. [https://github.com/FreeCAD/FreeCAD/pull/29892 Pull request #29892]
+* CAM drilling cycle expansion now uses MachineState for more accurate machine state tracking while expanding drilling cycles. [https://github.com/FreeCAD/FreeCAD/pull/30112 Pull request #30112]
 
 == Draft Workbench == <!--T:27-->
 
@@ -242,6 +245,7 @@ ToDo (last check: 20260430, #27222):
 * The [[Image:FEM_ConstraintSectionPrint.svg|24px]] [[FEM_ConstraintSectionPrint|Section print]] feature can now be used with the [[Image:FEM_SolverZ88.svg|24px]] [[FEM_SolverZ88|Z88 solver]]. [https://github.com/FreeCAD/FreeCAD/pull/29188 Pull request #29188]
 * Materials now have the ''Material Name'' property, making it easier to identify the actual materials represented by the material objects in the Analysis container. [https://github.com/FreeCAD/FreeCAD/pull/29609 Pull request #29609]
 * Three new [[Image:FEM_Examples.svg|24px]] [[FEM_Examples|FEM examples]] were added for [[Image:FEM_SolverCalculixCcxtools.svg|24px]] [[FEM_SolverCalculixCcxtools|CalculiX]]: basic 1D fluid network, axisymmetric shaft and plane stress plate with a hole. [https://github.com/FreeCAD/FreeCAD/pull/29697 Pull request #29697] and [https://github.com/FreeCAD/FreeCAD/pull/29711 Pull request #29711]
+* Several CalculiX preference labels were renamed for clarity, including geometrical nonlinearity, advanced solver controls, eigenmode count, and frequency bounds. [https://github.com/FreeCAD/FreeCAD/pull/30099 Pull request #30099]
 
 == Inspection Workbench == <!--T:32-->
 


### PR DESCRIPTION
## Summary
- add recent UI, VarSet, CAM, and FEM entries to `Release_notes_1.2`
- reference the merged FreeCAD PRs that introduced each change

## Validation
- confirmed issue #30 is open and has no comments
- confirmed there is no existing PR in this repo mentioning `Release_notes_1.2`
- confirmed the referenced FreeCAD PRs are merged

