### PR TITLE
[codex] Update BIM release notes for FreeCAD 1.2

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -106,26 +106,24 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 
 == BIM Workbench == <!--T:23-->
 
-</translate>
-ToDo (last check: 20260430, #27222):
-* https://github.com/FreeCAD/FreeCAD/pull/24078
-* https://github.com/FreeCAD/FreeCAD/pull/24190
-* https://github.com/FreeCAD/FreeCAD/pull/24550
-* https://github.com/FreeCAD/FreeCAD/pull/24595
-* https://github.com/FreeCAD/FreeCAD/pull/25086
-* https://github.com/FreeCAD/FreeCAD/pull/25147
-* https://github.com/FreeCAD/FreeCAD/pull/26758
-* https://github.com/FreeCAD/FreeCAD/pull/27222
-* https://github.com/FreeCAD/FreeCAD/pull/27375
-* https://github.com/FreeCAD/FreeCAD/pull/27381
-* https://github.com/FreeCAD/FreeCAD/pull/27420
-* https://github.com/FreeCAD/FreeCAD/pull/27746
-* https://github.com/FreeCAD/FreeCAD/pull/28036
-* https://github.com/FreeCAD/FreeCAD/pull/28104
-* https://github.com/FreeCAD/FreeCAD/pull/28504
-<translate>
-
 === Further BIM improvements === <!--T:24-->
+
+<!--T:79-->
+* A new [[BIM_Report|BIM Report]] command can create spreadsheet schedules from BIM models with an SQL-like query language, multi-statement reports, templates, presets, live validation, preview, and a Python scripting API. [https://github.com/FreeCAD/FreeCAD/pull/24078 Pull request #24078]
+* Hybrid IFC files now support relative paths. [https://github.com/FreeCAD/FreeCAD/pull/24190 Pull request #24190]
+* Wall base objects can now be removed while preserving the wall's placement and parametric behavior when supported. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
+* Walls can now be created without a base object, with placement and length stored directly on the wall. [[Draft_Stretch|Draft Stretch]] was also extended to support baseless walls. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]
+* The BIM Project command was moved from the toolbar to the Utils menu, and the related project manager defaults and labels were clarified. [https://github.com/FreeCAD/FreeCAD/pull/25086 Pull request #25086]
+* The BIM toolbar layout was reorganized to group related commands and reduce visual clutter. [https://github.com/FreeCAD/FreeCAD/pull/25147 Pull request #25147]
+* Wall editing gained a task panel box for common wall options, allowing width, height, and alignment changes without using the Property Editor. [https://github.com/FreeCAD/FreeCAD/pull/26758 Pull request #26758]
+* A new [[BIM_Covering|BIM Covering]] command and ArchCovering object were added for parametric architectural finishes such as floors, wall claddings, ceiling tiles, facade panels, and tile layouts. [https://github.com/FreeCAD/FreeCAD/pull/27222 Pull request #27222]
+* A Sliding Door window preset was added, including an opening property and a Tree View context command to invert the sliding direction. [https://github.com/FreeCAD/FreeCAD/pull/27375 Pull request #27375]
+* Window editing gained a task panel box for common options such as height, width, and opening. [https://github.com/FreeCAD/FreeCAD/pull/27381 Pull request #27381]
+* Window type handling was improved, including support for LinkGroup containers and safer property binding for empty values. [https://github.com/FreeCAD/FreeCAD/pull/27420 Pull request #27420]
+* Quick-access options task boxes were added for several BIM objects, exposing common properties directly in the task panel. [https://github.com/FreeCAD/FreeCAD/pull/27746 Pull request #27746]
+* Nudge shortcuts were changed to conflict-free {{KEY|Alt}} shortcuts. [https://github.com/FreeCAD/FreeCAD/pull/28036 Pull request #28036]
+* BIM link processing was refactored and a new [[BIM_Link|BIM Link]] command was added as a BIM-friendly wrapper around [[Std_LinkMake|Std LinkMake]]. [https://github.com/FreeCAD/FreeCAD/pull/28104 Pull request #28104]
+* Site editing gained a dedicated task panel with live controls for location, diagrams, and sun position, plus related selection and property-group UX improvements. [https://github.com/FreeCAD/FreeCAD/pull/28504 Pull request #28504]
 
 == CAM Workbench == <!--T:25-->
 

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -109,7 +109,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 === Further BIM improvements === <!--T:24-->
 
 <!--T:82-->
-* A new [[BIM_Report|BIM Report]] command can create spreadsheet schedules from BIM models with an SQL-like query language, multi-statement reports, templates, presets, live validation, preview, and a Python scripting API. [https://github.com/FreeCAD/FreeCAD/pull/24078 Pull request #24078]
+* A new [[BIM_Report|BIM Report]] command was added for creating model schedules and reports in a Spreadsheet. A report object can store one or more SQL-like statements, pipeline the result of one statement into the next, and query object properties, nested properties, parents, children and aggregates. Its task panel includes syntax highlighting, property-name autocompletion, live validation, object counts, query preview, bundled report and query presets, user preset management, and a Python scripting API through {{Incode|Arch.selectObjects()}} and {{Incode|Arch.selectObjectsFromPipeline()}}. [https://github.com/FreeCAD/FreeCAD/pull/24078 Pull request #24078]
 * Hybrid IFC files now support relative paths. [https://github.com/FreeCAD/FreeCAD/pull/24190 Pull request #24190]
 * Wall base objects can now be removed while preserving the wall's placement and parametric behavior when supported. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
 * Walls can now be created without a base object, with placement and length stored directly on the wall. [[Draft_Stretch|Draft Stretch]] was also extended to support baseless walls. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -108,7 +108,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 
 === Further BIM improvements === <!--T:24-->
 
-<!--T:79-->
+<!--T:82-->
 * A new [[BIM_Report|BIM Report]] command can create spreadsheet schedules from BIM models with an SQL-like query language, multi-statement reports, templates, presets, live validation, preview, and a Python scripting API. [https://github.com/FreeCAD/FreeCAD/pull/24078 Pull request #24078]
 * Hybrid IFC files now support relative paths. [https://github.com/FreeCAD/FreeCAD/pull/24190 Pull request #24190]
 * Wall base objects can now be removed while preserving the wall's placement and parametric behavior when supported. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]


### PR DESCRIPTION
## Summary

- Replace the BIM Workbench TODO link list with release-note bullets for merged FreeCAD PRs.
- Keep original PR references and the existing release-note section structure.

## Validation

- `git diff --check`
- Verified referenced wiki pages exist: `BIM_Report`, `Draft_Stretch`, `BIM_Covering`, `BIM_Link`, `Std_LinkMake`
- Verified `<translate>` tag count is balanced: `3` open / `3` close

