### PR TITLE
[codex] Document Draft angular dimension overshoot support

### DIFF
--- a/wiki/Draft_Dimension.wikitext
+++ b/wiki/Draft_Dimension.wikitext
@@ -196,9 +196,9 @@ A Draft Dimension object is derived from an [[App_FeaturePython|App FeaturePytho
 * {{PropertyView|Arrow Size Start|Length}}: idem at the start of the dimension line or arc. {{Version|1.1}}
 * {{PropertyView|Arrow Type End|Enumeration}}: specifies the type of symbol displayed at the end of the dimension line or arc, which can be {{value|Dot}}, {{value|Circle}}, {{value|Arrow}}, {{value|Tick}}, {{value|Tick-2}} or {{value|None}}. {{Version|1.1}}
 * {{PropertyView|Arrow Type Start|Enumeration}}: idem at the start of the dimension line or arc. {{Version|1.1}}
-* {{PropertyView|Dim Overshoot|Distance}}: specifies the additional length added to the dimension line. Not used for angular dimensions.
-* {{PropertyView|Ext Lines|Distance}}: specifies the length of the extension lines that go from the dimension line to the measured points. Use {{Value|0}} for full extension lines. A negative value defines the gap between the ends of the extension lines and the measured points. A positive value defines the maximum length of the extension lines. Only used for linear dimensions.
-* {{PropertyView|Ext Overshoot|Distance}}: specifies the additional length of the extension lines beyond the dimension line. Not used for angular dimensions.
+* {{PropertyView|Dim Overshoot|Distance}}: specifies the additional length added to the dimension line or arc. {{Version|1.2}}: this property is also used for angular dimensions.
+* {{PropertyView|Ext Lines|Distance}}: specifies the length of the extension lines that go from the dimension line or arc to the measured points. Use {{Value|0}} for full extension lines. A negative value defines the gap between the ends of the extension lines and the measured points. A positive value defines the maximum length of the extension lines. {{Version|1.2}}: this property is also used for angular dimensions.
+* {{PropertyView|Ext Overshoot|Distance}}: specifies the additional length of the extension lines beyond the dimension line or arc. {{Version|1.2}}: this property is also used for angular dimensions.
 * {{PropertyView|Flip Arrows|Bool}}: specifies whether to flip the orientation of the symbols at the ends of the dimension line or arc. Only works if the symbols are arrows.
 * {{PropertyView|Line Color|Color}}: specifies the color of the dimension line or arc, and the arrows.
 * {{PropertyView|Line Width|Float}}: specifies the width of the lines or arc belonging to the dimension.


### PR DESCRIPTION
## Summary

- Update Draft Dimension view-property docs for FreeCAD 1.2 angular dimension support.
- Remove outdated notes saying `Dim Overshoot`, `Ext Lines`, and `Ext Overshoot` are not used for angular dimensions.
- Reference the new behavior as version 1.2 in the existing property descriptions.

## Sources

- https://github.com/FreeCAD/FreeCAD/pull/27987
- https://github.com/FreeCAD/FreeCAD/pull/29298

## Validation

- `git diff --check`
- Verified `<translate>` tag count remains balanced: 6 open / 6 close
- Verified no new wiki links were introduced