### PR TITLE
[codex] Document Draft B-spline knot snapping

### DIFF
--- a/wiki/Draft_Snap.wikitext
+++ b/wiki/Draft_Snap.wikitext
@@ -65,7 +65,7 @@ Note that circular edges do not have to be full circles.
 * [[Image:Draft_Snap_Parallel.svg|32px]] [[Draft_Snap_Parallel|Snap Parallel]]: snaps to an imaginary line parallel to straight edges.
 
 <!--T:33-->
-* [[Image:Draft_Snap_Special.svg|32px]] [[Draft_Snap_Special|Snap Special]]: snaps to special points defined by the object.
+* [[Image:Draft_Snap_Special.svg|32px]] [[Draft_Snap_Special|Snap Special]]: snaps to special points defined by the object, and ({{Version|1.2}}) to the knots of B-spline edges.
 
 <!--T:34-->
 * [[Image:Draft_Snap_Near.svg|32px]] [[Draft_Snap_Near|Snap Near]]: snaps to the nearest point on faces and edges.


### PR DESCRIPTION
## Summary

- Update the Draft Snap page to document FreeCAD 1.2 B-spline knot snapping.
- Mention that Snap Special can snap to knots of B-spline edges.

## Source

- https://github.com/FreeCAD/FreeCAD/pull/26571

## Validation

- `git diff --check`
- Verified `<translate>` tag count remains balanced: 5 open / 5 close
- Verified no new wiki links were introduced