### PR TITLE
[codex] Document Draft SVG curve approximation

### DIFF
--- a/wiki/Draft_SVG.wikitext
+++ b/wiki/Draft_SVG.wikitext
@@ -38,6 +38,9 @@ The following SVG objects can be imported:
 * POLYGON objects
 * POLYLINE objects
 
+<!--T:30-->
+{{Version|1.2}}: Ellipses, hyperbolas, parabolas, and Bézier and B-spline curves can optionally be approximated by arcs and lines during import. See [[#Preferences|Preferences]].
+
 ===Limitations=== <!--T:22-->
 
 <!--T:23-->
@@ -73,6 +76,9 @@ The [https://inkscape.org/ Inkscape] SVG Editor currently works only with 90 DPI
 
 <!--T:27-->
 See [[Import_Export_Preferences|Import Export Preferences]].
+
+<!--T:31-->
+* {{Version|1.2}}: {{MenuCommand|Maximum deviation for approximation of complex curves}} sets the maximum deviation used when approximating supported complex curves to arcs and lines during import. Set it to {{Value|0}} to disable approximation.
 
 ==Scripting== <!--T:13-->
 


### PR DESCRIPTION
## Summary

- Update the Draft SVG page for FreeCAD 1.2 SVG import approximation support.
- Document that supported complex curves can be approximated by arcs and lines during import.
- Add the related import preference and note that `0` disables approximation.

## Context

This addresses part of #27 and follows FreeCAD PR #29142.

## Validation

- `git diff --check`
- Verified `<translate>` tag count remains balanced: 5 open / 5 close
- Verified translation markers `T:30` and `T:31` are new within this page