### PR TITLE
[codex] Document Draft in-command shortcut alternatives

### DIFF
--- a/wiki/Draft_Preferences.wikitext
+++ b/wiki/Draft_Preferences.wikitext
@@ -27,7 +27,7 @@ There are five pages: [[#General|General]], [[#Interface|Interface]], [[#Grid_an
 Some advanced preferences can only be changed in the [[Std_DlgParameter|Parameter Editor]]. See [[Fine-tuning#Draft_Workbench|Fine-tuning]].
 
 <!--T:152-->
-This page has been updated for version 1.1.
+This page has been updated for version 1.2.
 
 == General == <!--T:3-->
 
@@ -145,7 +145,7 @@ On this page you can specify the following:
 <!--T:47-->
 |-
 | {{MenuCommand|In-Command Shortcuts}}
-| These shortcuts only work when a [[Draft_Workbench|Draft]] or [[BIM Workbench|BIM]] command is active. Note that not all commands support all shortcuts.
+| These shortcuts only work when a [[Draft_Workbench|Draft]] or [[BIM Workbench|BIM]] command is active. Note that not all commands support all shortcuts. {{Version|1.2}}: A preference can contain more than one character so that alternative single-key shortcuts can be configured. Each character is recognized separately.
 
 <!--T:49-->
 |-


### PR DESCRIPTION
## Summary

- Update the Draft Preferences page for FreeCAD 1.2.
- Document that in-command shortcut preferences can contain multiple alternative single-key characters.
- Note that each configured character is recognized separately.

## Source

- https://github.com/FreeCAD/FreeCAD/pull/26950

## Validation

- `git diff --check`
- Verified `<translate>` tag count remains balanced: 7 open / 7 close
- Verified no new wiki links were introduced