### PR TITLE
[codex] Fix duplicate release note translation marker

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -198,6 +198,9 @@ ToDo (last check: 20260430, #27222):
 
 == Draft Workbench == <!--T:27-->
 
+=== Further Draft improvements === <!--T:28-->
+
+<!--T:83-->
 * Draft snapping now supports B-spline knots. [https://github.com/FreeCAD/FreeCAD/pull/26571 Pull request #26571]
 * Draft in-command shortcut preferences can now contain multiple characters, making localized single-character shortcuts possible. [https://github.com/FreeCAD/FreeCAD/pull/26950 Pull request #26950]
 * The [[Draft_SelectPlane|Working Plane]] command now moves the working plane origin to a pre-selected vertex without changing its orientation. [https://github.com/FreeCAD/FreeCAD/pull/27979 Pull request #27979]
@@ -205,8 +208,6 @@ ToDo (last check: 20260430, #27222):
 * [[Draft_PolarArray|Polar Array]] and [[Draft_CircularArray|Circular Array]] are now aware of the active working plane. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
 * SVG import can now approximate suitable curves to arcs and lines. [https://github.com/FreeCAD/FreeCAD/pull/29142 Pull request #29142]
 * Draft angular dimensions now honor overshoot settings. [https://github.com/FreeCAD/FreeCAD/pull/29298 Pull request #29298]
-
-=== Further Draft improvements === <!--T:28-->
 
 == FEM Workbench == <!--T:29-->
 


### PR DESCRIPTION
## Summary
- change the Draft Workbench release-note translation marker from T:78 to T:83
- leave the existing Part Design T:78 marker unchanged
- avoid marker collisions with open release-note PRs that use T:79-T:82

## Validation
- git diff --check
- rg duplicate marker check: no duplicate <!--T:n--> markers in wiki/Release_notes_1.2.wikitext

Related to #30.