### PR TITLE
[codex] Document BIM site task panel

### DIFF
--- a/wiki/Arch_Site.wikitext
+++ b/wiki/Arch_Site.wikitext
@@ -40,6 +40,9 @@ The '''Arch Site''' is a special object that combines properties of a standard F
 * You can add volumes to be added or subtracted from the base terrain, by double-clicking the Site, and adding objects to its Additions or Subtractions groups. The objects must be solids.
 * The {{PropertyData|Extrusion Vector}} property can be used to solve some problems that can appear when the terrain is an open shell and there are additions and/or subtractions. In order to perform those additions/subtractions, the open shell is extruded into a solid, which is then appropriately unioned/subtracted. Depending on the terrain topology, this extrusion might fail with the default extrusion vector. You might then be able to remedy the problem by changing this to a different value. This property is ignored if the terrain is a solid.
 
+<!--T:47-->
+* {{Version|1.2}}: Double-clicking a Site opens a dedicated task panel. It groups location controls, diagram toggles and sun position controls, and updates the related properties live. If neither Ladybug nor pysolar is installed, the solar diagram and sun position controls are disabled.
+
 ==Properties== <!--T:12-->
 
 === Data === <!--T:37-->
@@ -74,24 +77,39 @@ The '''Arch Site''' is a special object that combines properties of a standard F
 === View === <!--T:38-->
 
 <!--T:42-->
-{{Properties_Title|Compass}}
+{{Properties_Title|Diagrams}}
 
 <!--T:43-->
-* {{PropertyView|Compass|Bool}}: Default is {{Value|False}}. Shows or hides the compass.
-* {{PropertyView|Compass Position|Vector}}: The position of the compass relative to the site placement.
-* {{PropertyView|Compass Rotation|Angle}}: The rotation of the compass relative to the site.
-* {{PropertyView|Update Declination|Bool}}: Default is {{Value|False}}. Update the declination value based on the compass rotation.
-
-<!--T:44-->
-{{Properties_Title|Site}}
-
-<!--T:26-->
-* {{PropertyView|Orientation|Enumeration}}: Default is {{Value|Project North}}. When set to {{Value|True North}} the whole geometry will be rotated to match the true north of this site.
 * {{PropertyView|Solar Diagram|Bool}}: Default is {{Value|False}}. Shows or hides the sun path diagram. See [[#Solar_and_wind_diagrams|Solar and wind diagrams]].
+* {{PropertyView|Compass|Bool}}: Default is {{Value|False}}. Shows or hides the compass.
+* {{PropertyView|Show Sun Position|Bool}}: Shows or hides the sun position and hour markers.
+* {{PropertyView|Wind Rose|Bool}}: Default is {{value|False}}. Shows or hides the wind rose (requires the '''EPW File''' data property filled, and the Ladybug Python module installed. See [[#Solar_and_wind_diagrams|Solar and wind diagrams]]).
+
+<!--T:48-->
+{{Properties_Title|Solar Diagram}}
+
+<!--T:49-->
 * {{PropertyView|Solar Diagram Color|Color}}: The color of the sun path diagram.
 * {{PropertyView|Solar Diagram Position|Vector}}: The position of the sun path diagram.
 * {{PropertyView|Solar Diagram Scale|Float}}: The scale of the sun path diagram.
-* {{PropertyView|Wind Rose|Bool}}: Default is {{value|False}}. Shows or hides the wind rose diagram (requires the '''EPW File''' data property filled, and the Ladybug Python module installed. See [[#Solar_and_wind_diagrams|Solar and wind diagrams]]).
+
+<!--T:50-->
+{{Properties_Title|Compass}}
+
+<!--T:51-->
+* {{PropertyView|Compass Position|Vector}}: The position of the compass relative to the site placement.
+* {{PropertyView|Compass Rotation|Angle}}: The rotation of the compass relative to the site.
+* {{PropertyView|Orientation|Enumeration}}: Default is {{Value|Project North}}. When set to {{Value|True North}} the whole geometry will be rotated to match the true north of this site.
+* {{PropertyView|Update Declination|Bool}}: Default is {{Value|False}}. Update the declination value based on the compass rotation.
+
+<!--T:52-->
+{{Properties_Title|Sun Position}}
+
+<!--T:53-->
+* {{PropertyView|Show Hour Labels|Bool}}: Shows or hides the hour labels for the sun position diagram.
+* {{PropertyView|Sun Date Day|Integer}}: The day used to display the sun position.
+* {{PropertyView|Sun Date Month|Integer}}: The month used to display the sun position.
+* {{PropertyView|Sun Time Hour|Float}}: The hour used to display the sun position.
 
 == Typical workflow == <!--T:14-->
 


### PR DESCRIPTION
## Summary
- document the FreeCAD 1.2 Site task panel opened by double-clicking a Site
- update the Arch Site View property groups to match FreeCAD/FreeCAD#28504
- add the new sun position properties documented by the upstream BIM change

## Property group mapping
- Diagrams: Solar Diagram, Compass, Show Sun Position, Wind Rose
- Solar Diagram: Solar Diagram Color, Solar Diagram Position, Solar Diagram Scale
- Compass: Compass Position, Compass Rotation, Orientation, Update Declination
- Sun Position: Show Hour Labels, Sun Date Day, Sun Date Month, Sun Time Hour

## Source
- FreeCAD/FreeCAD#28504

## Validation
- git diff --check
- duplicate translation marker check for wiki/Arch_Site.wikitext
- translate tag balance: 6 open / 6 close

Related to #26.