### PR TITLE
[codex] Document CAM DressupTag 1.2 updates

### DIFF
--- a/wiki/CAM_DressupTag.wikitext
+++ b/wiki/CAM_DressupTag.wikitext
@@ -43,7 +43,7 @@ A video explanation of this feature is given at: https://www.youtube.com/watch?v
 * '''Width''' : Overall width of the tag.
 
 <!--T:12-->
-{{Version|1.2}}: The segmentation precision for complex shapes follows the Job's {{PropertyData|Geometry Tolerance}} value. A hidden {{PropertyData|Approximation}} property can reduce commands for paths containing non-horizontal arc moves, such as helix paths.
+{{Version|1.2}}: Tag generation for complex curves follows the Job's {{PropertyData|Geometry Tolerance}} value.
 
 <!--T:9-->
 Tags are automatically generated evenly spaced along the contour, beginning with the largest edge. You have the option to delete any you don't like or change their locations so that they appear on the convex parts of the job where it will be easier to file off the excess material.

--- a/wiki/CAM_DressupTag.wikitext
+++ b/wiki/CAM_DressupTag.wikitext
@@ -43,13 +43,13 @@ A video explanation of this feature is given at: https://www.youtube.com/watch?v
 * '''Width''' : Overall width of the tag.
 
 <!--T:12-->
-{{Version|1.2}}: The segmentation precision for complex shapes follows the Job's {{PropertyData|Geometry Tolerance}} value. A hidden {{PropertyData|Approximation}} property is also available and disabled by default; it can reduce the number of commands for paths containing non-horizontal arc moves, such as helix paths.
+{{Version|1.2}}: The segmentation precision for complex shapes follows the Job's {{PropertyData|Geometry Tolerance}} value. A hidden {{PropertyData|Approximation}} property can reduce commands for paths containing non-horizontal arc moves, such as helix paths.
 
 <!--T:9-->
 Tags are automatically generated evenly spaced along the contour, beginning with the largest edge. You have the option to delete any you don't like or change their locations so that they appear on the convex parts of the job where it will be easier to file off the excess material.
 
 <!--T:13-->
-{{Version|1.2}}: Automatic tag placement can process several closed paths in the same dressup.
+{{Version|1.2}}: Automatic tag placement can process several closed paths in one dressup.
 
 
 <!--T:11-->

--- a/wiki/CAM_DressupTag.wikitext
+++ b/wiki/CAM_DressupTag.wikitext
@@ -30,20 +30,26 @@ A video explanation of this feature is given at: https://www.youtube.com/watch?v
 ==Usage== <!--T:4-->
 
 <!--T:5-->
-# Select a contour or profile path objects.
+# Select one or more contour or profile path objects.
 # Select the {{MenuCommand|CAM → Path Dressup → [[Image:CAM_DressupTag.svg|16px]] Tag}} option from the menu.
 
 ==Options== <!--T:6-->
 
 <!--T:7-->
-* '''Angle''' : Controls the angle of plunge and ascent when a tag is crated.
+* '''Angle''' : Controls the angle of plunge and ascent when a tag is created.
 * '''Height''' : Controls the height of the tag top from the bottom of the profile cut.
 * '''Radius''' : Radius of the fillet for the tag.
 * '''Segmentation Factor''' : Number of segments to approximate a rounded tag.
 * '''Width''' : Overall width of the tag.
 
+<!--T:12-->
+{{Version|1.2}}: The segmentation precision for complex shapes follows the Job's {{PropertyData|Geometry Tolerance}} value. A hidden {{PropertyData|Approximation}} property is also available and disabled by default; it can reduce the number of commands for paths containing non-horizontal arc moves, such as helix paths.
+
 <!--T:9-->
-Tags are automatically generated evenly spaced along the contour, beginning with the largest edge. You have the option to delete any you don't like or change their locations so that they appear on the convex parts of the job where it will be easier to file off the excess material.  
+Tags are automatically generated evenly spaced along the contour, beginning with the largest edge. You have the option to delete any you don't like or change their locations so that they appear on the convex parts of the job where it will be easier to file off the excess material.
+
+<!--T:13-->
+{{Version|1.2}}: Automatic tag placement can process several closed paths in the same dressup.
 
 
 <!--T:11-->


### PR DESCRIPTION
## Summary
- document CAM DressupTag support for several selected contour/profile paths
- document FreeCAD 1.2 use of Job Geometry Tolerance for complex curve tag generation
- fix a small typo in the Angle option text

## Sources
- FreeCAD/FreeCAD#22468
- FreeCAD/FreeCAD#26127

## Validation
- git diff --check
- duplicate translation marker check for wiki/CAM_DressupTag.wikitext
- translate tag balance: 1 open / 1 close

Related to #25.