### PR TITLE
[codex] Document CAM Helix 1.2 pitch controls

### DIFF
--- a/wiki/CAM_Helix.wikitext
+++ b/wiki/CAM_Helix.wikitext
@@ -43,7 +43,7 @@ The [[Image:CAM_Helix.svg|24px]] [[CAM_Helix|CAM Helix]] command appends a helic
 '''Extra Offset''' adds a margin of material to be left unmachined. This is typically to allow a light finishing pass as a separate operation.
 
 <!--T:27-->
-Since FreeCAD 1.2, '''Helix Max Pitch''' replaces ''Helix Pitch'' and limits the maximum helix pitch when non-zero.
+{{Version|1.2}}: '''Helix Max Pitch''' replaces ''Helix Pitch'' and limits the maximum helix pitch when non-zero.
 
 <!--T:28-->
 '''Helix Max Ramp Angle''' limits the ramp-entry angle when non-zero. The pitch is calculated for each helix radius.

--- a/wiki/CAM_Helix.wikitext
+++ b/wiki/CAM_Helix.wikitext
@@ -32,7 +32,7 @@ The [[Image:CAM_Helix.svg|24px]] [[CAM_Helix|CAM Helix]] command appends a helic
 * You will be prompted with a "Choose a Tool Controller" pop-up window to select a Tool Controller. In older versions, in the {{KEY|[[Image:CAM_Helix.svg|24px]]}} Operation tab, choose a Tool controller and confirm by pressing {{Button|Apply}}.
 * Open the Base Geometry tab. All available holes compatible with the Helix tool in the Job Model will be selectable for processing. In the [[3D_View|3D View]] select the holes by their edge or wall face and add them with the {{Button|Add}} button. Check that they appear in the list. Confirm that the list matches the holes that are intended for processing.
 * To remove holes select them in the list and press the {{Button|Remove}} button.
-* Ensure Start Depth, Final Depth and the helix pitch limits are correct, and adjust if not.
+* Ensure Start Depth, Final Depth and the helix pitch and ramp limits are correct, and adjust if not.
 * Ensure Safe and Clearance Heights are correct.
 * In the Operation tab, specify the helix Starting surface (outside/inside), cutting Direction (climb/conventional), and Step Over percentage.
 * Click {{Button|Apply}} to create or update the path, {{Button|OK}} to apply and close the panel, or {{Button|Cancel}} to abort and close the panel.
@@ -43,10 +43,10 @@ The [[Image:CAM_Helix.svg|24px]] [[CAM_Helix|CAM Helix]] command appends a helic
 '''Extra Offset''' adds a margin of material to be left unmachined. This is typically to allow a light finishing pass as a separate operation.
 
 <!--T:27-->
-{{Version|1.2}}: The former ''Helix Pitch'' property was renamed to ''Helix Max Pitch''. Set it to a non-zero value to limit the maximum pitch of the helix.
+Since FreeCAD 1.2, '''Helix Max Pitch''' replaces ''Helix Pitch'' and limits the maximum helix pitch when non-zero.
 
 <!--T:28-->
-{{Version|1.2}}: The ''Helix Max Ramp Angle'' property was added. Set it to a non-zero value to limit the ramp-entry angle; the pitch is then calculated for each helix radius.
+'''Helix Max Ramp Angle''' limits the ramp-entry angle when non-zero. The pitch is calculated for each helix radius.
 
 <!--T:23-->
 '''Start Radius''' is not available in the ''Helix'' task panel but can be edited directly in the [[Property_View|Property View]].

--- a/wiki/CAM_Helix.wikitext
+++ b/wiki/CAM_Helix.wikitext
@@ -32,7 +32,7 @@ The [[Image:CAM_Helix.svg|24px]] [[CAM_Helix|CAM Helix]] command appends a helic
 * You will be prompted with a "Choose a Tool Controller" pop-up window to select a Tool Controller. In older versions, in the {{KEY|[[Image:CAM_Helix.svg|24px]]}} Operation tab, choose a Tool controller and confirm by pressing {{Button|Apply}}.
 * Open the Base Geometry tab. All available holes compatible with the Helix tool in the Job Model will be selectable for processing. In the [[3D_View|3D View]] select the holes by their edge or wall face and add them with the {{Button|Add}} button. Check that they appear in the list. Confirm that the list matches the holes that are intended for processing.
 * To remove holes select them in the list and press the {{Button|Remove}} button.
-* Ensure Start Depth, Final Depth and Step Down (the pitch of the helix) are correct, and adjust if not.
+* Ensure Start Depth, Final Depth and the helix pitch limits are correct, and adjust if not.
 * Ensure Safe and Clearance Heights are correct.
 * In the Operation tab, specify the helix Starting surface (outside/inside), cutting Direction (climb/conventional), and Step Over percentage.
 * Click {{Button|Apply}} to create or update the path, {{Button|OK}} to apply and close the panel, or {{Button|Cancel}} to abort and close the panel.
@@ -41,6 +41,12 @@ The [[Image:CAM_Helix.svg|24px]] [[CAM_Helix|CAM Helix]] command appends a helic
 
 <!--T:16-->
 '''Extra Offset''' adds a margin of material to be left unmachined. This is typically to allow a light finishing pass as a separate operation.
+
+<!--T:27-->
+{{Version|1.2}}: The former ''Helix Pitch'' property was renamed to ''Helix Max Pitch''. Set it to a non-zero value to limit the maximum pitch of the helix.
+
+<!--T:28-->
+{{Version|1.2}}: The ''Helix Max Ramp Angle'' property was added. Set it to a non-zero value to limit the ramp-entry angle; the pitch is then calculated for each helix radius.
 
 <!--T:23-->
 '''Start Radius''' is not available in the ''Helix'' task panel but can be edited directly in the [[Property_View|Property View]].
@@ -54,7 +60,7 @@ If this parameter is set to a negative value, it can allow a smaller helix radiu
 ==Comments== <!--T:20-->
 
 <!--T:21-->
-* Step Down is not respected exactly. It is always rounded to give a complete number of turns from Start Depth to Final Depth.
+* The helix pitch limit is not respected exactly. It is always rounded to give a complete number of turns from Start Depth to Final Depth.
 * Similarly Step Over is not respected exactly. It is always rounded to give a number of equal steps.
 
 <!--T:22-->


### PR DESCRIPTION
## Summary
- update CAM Helix usage text for the FreeCAD 1.2 helix pitch controls
- document the Helix Pitch rename to Helix Max Pitch
- document the new Helix Max Ramp Angle property
- update the comments section to describe pitch-limit rounding instead of Step Down rounding

## Source
- FreeCAD/FreeCAD#29286

## Validation
- git diff --check
- duplicate translation marker check for wiki/CAM_Helix.wikitext
- translate tag balance: 2 open / 2 close

Related to #25.