### PR TITLE
[codex] Document CAM Pocket Shape angle rename

### DIFF
--- a/wiki/CAM_Pocket_Shape.wikitext
+++ b/wiki/CAM_Pocket_Shape.wikitext
@@ -40,7 +40,7 @@ The CAM Pocket Shape object is made to be part of a [[Image:CAM_Job.svg|16px]] [
 # Adjust the desired properties.
 
 <!--T:63-->
-{{Version|1.2}}: A custom start point can be set directly from the task panel when {{PropertyData|Use Start Point}} is enabled.
+If {{PropertyData|Use Start Point}} is enabled, a custom start point can be set directly from the task panel.
 
 ==Properties== <!--T:15-->
 
@@ -116,7 +116,7 @@ Note: It is suggested that you do not edit the Placement property of path operat
 * {{PropertyData|Start At}}: Start pocketing at center or boundary.
 * {{PropertyData|Step Over}}: Select the horizontal step over ('''Percent''' of tool diameter: 100% = tool diameter).
 * {{PropertyData|Use Outline}}: Uses the outline of the base geometry.
-* {{PropertyData|Angle}}: Angle of the clearing pattern relative to the X-axis. {{Version|1.2}}: This property was formerly named {{PropertyData|Zig Zag Angle}} and is hidden when {{PropertyData|Offset Pattern}} is set to {{Value|Offset}}.
+* {{PropertyData|Angle}}: Angle of the clearing pattern relative to the X-axis. This property was formerly named {{PropertyData|Zig Zag Angle}}. It is hidden when {{PropertyData|Offset Pattern}} is set to {{Value|Offset}}.
 * {{PropertyData|SortingMode}}: Controls how multiple selected base geometries are ordered. {{Value|Automatic}} uses automatic sorting. {{Value|Manual}} follows the selection order.
 
 <!--T:41-->

--- a/wiki/CAM_Pocket_Shape.wikitext
+++ b/wiki/CAM_Pocket_Shape.wikitext
@@ -39,6 +39,9 @@ The CAM Pocket Shape object is made to be part of a [[Image:CAM_Job.svg|16px]] [
 #* Select the {{MenuCommand|CAM → [[Image:CAM_Pocket_Shape.svg|16px]] Pocket Shape}} option from the menu.
 # Adjust the desired properties.
 
+<!--T:63-->
+{{Version|1.2}}: A custom start point can be set directly from the task panel when {{PropertyData|Use Start Point}} is enabled.
+
 ==Properties== <!--T:15-->
 
 <!--T:29-->
@@ -113,7 +116,7 @@ Note: It is suggested that you do not edit the Placement property of path operat
 * {{PropertyData|Start At}}: Start pocketing at center or boundary.
 * {{PropertyData|Step Over}}: Select the horizontal step over ('''Percent''' of tool diameter: 100% = tool diameter).
 * {{PropertyData|Use Outline}}: Uses the outline of the base geometry.
-* {{PropertyData|Zig Zag Angle}}: Angle of the zigzag pattern. (Select the path angle relative to X-axis.)
+* {{PropertyData|Angle}}: Angle of the clearing pattern relative to the X-axis. {{Version|1.2}}: This property was formerly named {{PropertyData|Zig Zag Angle}} and is hidden when {{PropertyData|Offset Pattern}} is set to {{Value|Offset}}.
 * {{PropertyData|SortingMode}}: Controls how multiple selected base geometries are ordered. {{Value|Automatic}} uses automatic sorting. {{Value|Manual}} follows the selection order.
 
 <!--T:41-->
@@ -177,9 +180,15 @@ This section is simply a layout map of the settings in the window editor for the
 * {{PropertyData|Tool Controller}}
 * {{PropertyData|Cut Mode}}
 * {{PropertyData|Pattern}} (Offset Pattern)
-* {{PropertyData|Angle}} (Zig Zag Angle)
+* {{PropertyData|Angle}}
 * {{PropertyData|Step Over Percent}} (Step Over)
 * {{PropertyData|Pass Extension}}: The distance the facing operation will extend beyond the <u>boundary shape</u> (base geometry)
+
+===Start Point=== <!--T:64-->
+
+<!--T:65-->
+* {{PropertyData|Use Start Point}}
+* {{PropertyData|Start Point}}
 
 ==Scripting== <!--T:61-->
 

--- a/wiki/CAM_Pocket_Shape.wikitext
+++ b/wiki/CAM_Pocket_Shape.wikitext
@@ -39,9 +39,6 @@ The CAM Pocket Shape object is made to be part of a [[Image:CAM_Job.svg|16px]] [
 #* Select the {{MenuCommand|CAM → [[Image:CAM_Pocket_Shape.svg|16px]] Pocket Shape}} option from the menu.
 # Adjust the desired properties.
 
-<!--T:63-->
-If {{PropertyData|Use Start Point}} is enabled, a custom start point can be set directly from the task panel.
-
 ==Properties== <!--T:15-->
 
 <!--T:29-->
@@ -183,12 +180,6 @@ This section is simply a layout map of the settings in the window editor for the
 * {{PropertyData|Angle}}
 * {{PropertyData|Step Over Percent}} (Step Over)
 * {{PropertyData|Pass Extension}}: The distance the facing operation will extend beyond the <u>boundary shape</u> (base geometry)
-
-===Start Point=== <!--T:64-->
-
-<!--T:65-->
-* {{PropertyData|Use Start Point}}
-* {{PropertyData|Start Point}}
 
 ==Scripting== <!--T:61-->
 


### PR DESCRIPTION
## Summary
- update the Pocket Shape property name from Zig Zag Angle to Angle
- document that Angle is hidden for the Offset pattern
- remove the unsupported task-panel Start Point documentation after rechecking the source PR

## Sources
- FreeCAD/FreeCAD#26842

## Validation
- git diff --check
- duplicate translation marker check for wiki/CAM_Pocket_Shape.wikitext
- translate tag balance: 4 open / 4 close

Related to #25.