### PR TITLE
[codex] Document CAM Adaptive 1.2 updates

### DIFF
--- a/wiki/CAM_Adaptive.wikitext
+++ b/wiki/CAM_Adaptive.wikitext
@@ -24,7 +24,7 @@
 The [[Image:CAM_Adaptive.svg|24px]] [[CAM_Adaptive|CAM Adaptive]] command creates clearing and profiling paths. The operation varies cutter engagement so that the material removal never exceeds a maximum value.
 
 <!--T:40-->
-Since FreeCAD 1.2 the operation supports rest machining. Its helix entry settings use the same naming style as the [[CAM_Helix|Helix]] operation.
+{{Version|1.2}}: the operation supports rest machining. Its helix entry settings use the same naming style as the [[CAM_Helix|Helix]] operation.
 
 ==Usage== <!--T:5-->
 

--- a/wiki/CAM_Adaptive.wikitext
+++ b/wiki/CAM_Adaptive.wikitext
@@ -23,6 +23,9 @@
 <!--T:4-->
 The [[Image:CAM_Adaptive.svg|24px]] [[CAM_Adaptive|CAM Adaptive]] command creates clearing and profiling paths. The operation varies cutter engagement so that the material removal never exceeds a maximum value.
 
+<!--T:40-->
+Since FreeCAD 1.2 the operation supports rest machining and uses the same helix-entry generator and naming style as the [[CAM_Helix|Helix]] operation.
+
 ==Usage== <!--T:5-->
 
 <!--T:6-->
@@ -38,6 +41,8 @@ Usage instructions for the [[CAM_Adaptive|Adaptive]] operation are presented her
 # Configure settings in the Operations tab:
 ## ('''See the [[#Properties|Properties]] → Adaptive section below.''')
 ## Set the Step Over value as a percentage of the diameter of the Tool.
+## Optionally enable {{MenuCommand|Use rest machining}} to skip regions already cleared by previous operations.
+## Adjust the {{MenuCommand|Helix Parameters}} if the automatic helix entry needs a different pitch, ramp angle, cone angle, or entry diameter range.
 # If you wish to preview the result before accepting the settings, click {{Button|Apply}}
 # Click {{Button|OK}} button to confirm and generate paths.
 
@@ -59,18 +64,22 @@ Usage instructions for the [[CAM_Adaptive|Adaptive]] operation are presented her
 {{TitleProperty|Adaptive}}
 
 <!--T:14-->
+* {{PropertyData|Finishing Profile}}: Take a finishing profile path at the end of the operation.
 * {{PropertyData|Force Inside-Out}}: Force plunging into material inside and clearing towards the edges
-* {{PropertyData|Helix Angle}}: Helix ramp entry angle (degrees)
 * {{PropertyData|Helix Cone Angle}}: Angle (degrees) of conical helix
-* {{PropertyData|Helix Diameter Limit}}: Limit helix entry diameter, if limit larger than tool diameter or 0, tool diameter is used
+* {{PropertyData|Helix Max Diameter Percent}}: Maximum and nominal helix entry diameter, as a percentage of the tool diameter.
+* {{PropertyData|Helix Max Pitch}}: Maximum descent in a single revolution of the helix. Set to {{Value|0}} to disable limitation by pitch.
+* {{PropertyData|Helix Max Ramp Angle}}: Maximum allowable helix ramp entry angle. Set to {{Value|0}} to disable limitation by ramp angle.
+* {{PropertyData|Helix Min Diameter Percent}}: Minimum acceptable helix entry diameter, as a percentage of the tool diameter.
 * {{PropertyData|Keep Tool Down Ratio}}: Max length of keep tool down path compared to direct distance between points
 * {{PropertyData|Lift Distance}}: Lift distance for rapid moves
 * {{PropertyData|Operation Type}}: Type of adaptive operation: Clearing or Profiling
 * {{PropertyData|Side}}: Side of selected faces that tool should cut: Inside or Outside
 * {{PropertyData|Step Over}}: Percent of cutter diameter to step over on each pass
-* {{PropertyData|Stock to Leave}}: How much stock to leave (i.e. for a separate finishing operation)
+* {{PropertyData|Stock to Leave}}: How much stock to leave in the XY plane, i.e. for a separate finishing operation.
 * {{PropertyData|Tolerance}}: Influences accuracy and performance
-* {{PropertyData|Use Helix Arcs}}: Use Arcs (G2) for helix ramp
+* {{PropertyData|Use Outline}}: Use the outline of the base geometry.
+* {{PropertyData|Use Rest Machining}}: Skip machining regions that have already been cleared by previous operations.
 
 <!--T:15-->
 {{TitleProperty|Base}}
@@ -144,17 +153,24 @@ This section is simply a layout map of the settings in the window editor for the
 
 <!--T:30-->
 * {{PropertyData|Tool Controller}}
+* {{PropertyData|Coolant}}
+* {{PropertyData|Edit Tool Controller}}
 * {{PropertyData|Cut Region}} (Side)
 * {{PropertyData|Operation Type}}
 * {{PropertyData|Step Over Percent}}
 * {{PropertyData|Accuracy vs Performance}} (Tolerance)
-* {{PropertyData|Helix Ramp Angle}}
-* {{PropertyData|Helix Cone Angle}}
-* {{PropertyData|Helix Max Diameter}} (Helix Diameter Limit)
 * {{PropertyData|Lift Distance}}
 * {{PropertyData|Keep Tool Down Ratio}}
-* {{PropertyData|Stock to Leave}}
+* {{PropertyData|XY Stock to Leave}} (Stock to Leave)
 * {{PropertyData|Force Clearing Inside-Out}}
+* {{PropertyData|Finishing Profile}}
+* {{PropertyData|Use Outline}}
+* {{PropertyData|Use Rest Machining}}
+* {{PropertyData|Max Pitch}} (Helix Max Pitch)
+* {{PropertyData|Max Ramp Angle}} (Helix Max Ramp Angle)
+* {{PropertyData|Cone Angle}} (Helix Cone Angle)
+* {{PropertyData|Max Diameter}} (Helix Max Diameter Percent)
+* {{PropertyData|Min Diameter}} (Helix Min Diameter Percent)
 * {{PropertyData|Stop}}
 
 ==Known Issues== <!--T:35-->

--- a/wiki/CAM_Adaptive.wikitext
+++ b/wiki/CAM_Adaptive.wikitext
@@ -24,7 +24,7 @@
 The [[Image:CAM_Adaptive.svg|24px]] [[CAM_Adaptive|CAM Adaptive]] command creates clearing and profiling paths. The operation varies cutter engagement so that the material removal never exceeds a maximum value.
 
 <!--T:40-->
-Since FreeCAD 1.2 the operation supports rest machining and uses the same helix-entry generator and naming style as the [[CAM_Helix|Helix]] operation.
+Since FreeCAD 1.2 the operation supports rest machining. Its helix entry settings use the same naming style as the [[CAM_Helix|Helix]] operation.
 
 ==Usage== <!--T:5-->
 
@@ -41,8 +41,8 @@ Usage instructions for the [[CAM_Adaptive|Adaptive]] operation are presented her
 # Configure settings in the Operations tab:
 ## ('''See the [[#Properties|Properties]] → Adaptive section below.''')
 ## Set the Step Over value as a percentage of the diameter of the Tool.
-## Optionally enable {{MenuCommand|Use rest machining}} to skip regions already cleared by previous operations.
-## Adjust the {{MenuCommand|Helix Parameters}} if the automatic helix entry needs a different pitch, ramp angle, cone angle, or entry diameter range.
+## Optionally enable {{MenuCommand|Use rest machining}} to skip areas already cleared by previous operations.
+## Adjust the {{MenuCommand|Helix Parameters}} if the helix entry needs a different pitch, ramp angle, cone angle, or entry diameter range.
 # If you wish to preview the result before accepting the settings, click {{Button|Apply}}
 # Click {{Button|OK}} button to confirm and generate paths.
 
@@ -64,22 +64,22 @@ Usage instructions for the [[CAM_Adaptive|Adaptive]] operation are presented her
 {{TitleProperty|Adaptive}}
 
 <!--T:14-->
-* {{PropertyData|Finishing Profile}}: Take a finishing profile path at the end of the operation.
+* {{PropertyData|Finishing Profile}}: Take a finishing profile path at the end of the operation
 * {{PropertyData|Force Inside-Out}}: Force plunging into material inside and clearing towards the edges
 * {{PropertyData|Helix Cone Angle}}: Angle (degrees) of conical helix
-* {{PropertyData|Helix Max Diameter Percent}}: Maximum and nominal helix entry diameter, as a percentage of the tool diameter.
-* {{PropertyData|Helix Max Pitch}}: Maximum descent in a single revolution of the helix. Set to {{Value|0}} to disable limitation by pitch.
-* {{PropertyData|Helix Max Ramp Angle}}: Maximum allowable helix ramp entry angle. Set to {{Value|0}} to disable limitation by ramp angle.
-* {{PropertyData|Helix Min Diameter Percent}}: Minimum acceptable helix entry diameter, as a percentage of the tool diameter.
+* {{PropertyData|Helix Max Diameter Percent}}: Maximum and nominal helix entry diameter, as a percentage of the tool diameter
+* {{PropertyData|Helix Max Pitch}}: Maximum descent in a single revolution of the helix. Set to {{Value|0}} to disable limitation by pitch
+* {{PropertyData|Helix Max Ramp Angle}}: Maximum allowable helix ramp entry angle. Set to {{Value|0}} to disable limitation by ramp angle
+* {{PropertyData|Helix Min Diameter Percent}}: Minimum acceptable helix entry diameter, as a percentage of the tool diameter
 * {{PropertyData|Keep Tool Down Ratio}}: Max length of keep tool down path compared to direct distance between points
 * {{PropertyData|Lift Distance}}: Lift distance for rapid moves
 * {{PropertyData|Operation Type}}: Type of adaptive operation: Clearing or Profiling
 * {{PropertyData|Side}}: Side of selected faces that tool should cut: Inside or Outside
 * {{PropertyData|Step Over}}: Percent of cutter diameter to step over on each pass
-* {{PropertyData|Stock to Leave}}: How much stock to leave in the XY plane, i.e. for a separate finishing operation.
+* {{PropertyData|Stock to Leave}}: How much stock to leave in the XY plane, i.e. for a separate finishing operation
 * {{PropertyData|Tolerance}}: Influences accuracy and performance
-* {{PropertyData|Use Outline}}: Use the outline of the base geometry.
-* {{PropertyData|Use Rest Machining}}: Skip machining regions that have already been cleared by previous operations.
+* {{PropertyData|Use Outline}}: Use the outline of the base geometry
+* {{PropertyData|Use Rest Machining}}: Skip areas that have already been cleared by previous operations
 
 <!--T:15-->
 {{TitleProperty|Base}}


### PR DESCRIPTION
Summary:
- update CAM Adaptive for FreeCAD 1.2 rest machining support
- refresh the helix-entry property names and task-panel labels for the Helix generator changes
- document current Adaptive task-panel items such as Use outline, Use rest machining, XY stock to leave, and helix min/max diameter controls

Source changes reflected:
- FreeCAD/FreeCAD#27908 added Adaptive rest machining
- FreeCAD/FreeCAD#22357 moved Adaptive helix properties to the Adaptive Helix Entry group and renamed Helix Max Ramp Angle / Helix Max Pitch
- FreeCAD/FreeCAD#23980 added automatic helix entrance diameter selection with min/max diameter controls

Part of #25.