### PR TITLE
[codex] Document CAM Engrave 1.2 updates

### DIFF
--- a/wiki/CAM_Engrave.wikitext
+++ b/wiki/CAM_Engrave.wikitext
@@ -24,7 +24,7 @@
 The [[Image:CAM_Engrave.svg|24px]] [[CAM_Engrave|CAM Engrave]] command is primarily for engraving a [[Image:Draft_ShapeString.svg|16px]] [[Draft_ShapeString|Draft ShapeString]] onto a part. It can also be used with other flat 2D geometry, for example imported SVG-based shapes.
 
 <!--T:29-->
-Since FreeCAD 1.2 the operation can reverse milling direction and choose between directional and bidirectional cutting patterns.
+Since FreeCAD 1.2 the operation can reverse the milling direction and use directional or bidirectional cutting patterns.
 
 ==Usage== <!--T:8-->
 
@@ -37,7 +37,7 @@ Since FreeCAD 1.2 the operation can reverse milling direction and choose between
 #* Other flat 2D geometry, such as imported SVG-based shapes, can also be used.
 #* When possible, select the whole flat shape instead of selecting many individual edges in the [[3D_View|3D View]].
 # In the {{MenuCommand|Depths}} section, check and adjust the depth settings as required.
-# In the {{MenuCommand|Data}} tab, adjust {{PropertyData|Cut Pattern}}, {{PropertyData|Reverse}}, and {{PropertyData|Start Vertex}} if the path should start or travel differently.
+# In the {{MenuCommand|Data}} tab, adjust {{PropertyData|Cut Pattern}}, {{PropertyData|Reverse}}, and {{PropertyData|Start Vertex}} if required.
 # Confirm the operation.
 
 ==Options== <!--T:9-->
@@ -49,9 +49,9 @@ Since FreeCAD 1.2 the operation can reverse milling direction and choose between
 ==Notes== <!--T:30-->
 
 <!--T:31-->
-* The {{PropertyData|Final Depth}} default for new operations is based on the stock and the selected engraving shape.
+* The {{PropertyData|Final Depth}} default for new operations is based on the stock and selected engraving shape.
 * Complex curves are segmented using the parent Job's {{PropertyData|Geometry Tolerance}}.
-* {{Value|Bidirectional}} cut pattern alternates direction after each step-down on open wires, reducing retraction moves.
+* The {{Value|Bidirectional}} cut pattern alternates direction after each step-down on open wires.
 
 ==Properties== <!--T:10-->
 
@@ -69,7 +69,7 @@ Since FreeCAD 1.2 the operation can reverse milling direction and choose between
 
 <!--T:11-->
 * {{PropertyData|Clearance Height}}: The height needed to clear clamps and obstructions
-* {{PropertyData|Final Depth}}: Final Depth of Tool - lowest value in Z. The default is based on the stock and engraving shape.
+* {{PropertyData|Final Depth}}: Final Depth of Tool - lowest value in Z
 * {{PropertyData|Safe Height}}: The above which Rapid motions are allowed.
 * {{PropertyData|Start Depth}}: Starting Depth of Tool- first cut depth in Z
 * {{PropertyData|Step Down}}: Incremental Step Down of Tool
@@ -83,8 +83,8 @@ Since FreeCAD 1.2 the operation can reverse milling direction and choose between
 * {{PropertyData|Comment}}: An optional comment for this operation
 * {{PropertyData|Coolant Mode}}: Coolant mode for this operation
 * {{PropertyData|Cycle Time}}: Estimated cycle time for this operation
-* {{PropertyData|Cut Pattern}}: The cut pattern for the operation. The options are {{Value|Directional}} and {{Value|Bidirectional}}.
-* {{PropertyData|Reverse}}: Reverse the milling direction.
+* {{PropertyData|Cut Pattern}}: Cut pattern for the operation: {{Value|Directional}} or {{Value|Bidirectional}}
+* {{PropertyData|Reverse}}: Reverse the milling direction
 * {{PropertyData|Start Vertex}}: The vertex index to start the path from
 * {{PropertyData|Tool Controller}}: The tool controller that will be used to calculate the path
 * {{PropertyData|User Label}}: User assigned label

--- a/wiki/CAM_Engrave.wikitext
+++ b/wiki/CAM_Engrave.wikitext
@@ -23,6 +23,9 @@
 <!--T:20-->
 The [[Image:CAM_Engrave.svg|24px]] [[CAM_Engrave|CAM Engrave]] command is primarily for engraving a [[Image:Draft_ShapeString.svg|16px]] [[Draft_ShapeString|Draft ShapeString]] onto a part. It can also be used with other flat 2D geometry, for example imported SVG-based shapes.
 
+<!--T:29-->
+Since FreeCAD 1.2 the operation can reverse milling direction and choose between directional and bidirectional cutting patterns.
+
 ==Usage== <!--T:8-->
 
 <!--T:21-->
@@ -34,6 +37,7 @@ The [[Image:CAM_Engrave.svg|24px]] [[CAM_Engrave|CAM Engrave]] command is primar
 #* Other flat 2D geometry, such as imported SVG-based shapes, can also be used.
 #* When possible, select the whole flat shape instead of selecting many individual edges in the [[3D_View|3D View]].
 # In the {{MenuCommand|Depths}} section, check and adjust the depth settings as required.
+# In the {{MenuCommand|Data}} tab, adjust {{PropertyData|Cut Pattern}}, {{PropertyData|Reverse}}, and {{PropertyData|Start Vertex}} if the path should start or travel differently.
 # Confirm the operation.
 
 ==Options== <!--T:9-->
@@ -41,6 +45,13 @@ The [[Image:CAM_Engrave.svg|24px]] [[CAM_Engrave|CAM Engrave]] command is primar
 <!--T:22-->
 * '''Base''': The geometry to engrave.
 * '''Clear''': Clears the current geometry selection.
+
+==Notes== <!--T:30-->
+
+<!--T:31-->
+* The {{PropertyData|Final Depth}} default for new operations is based on the stock and the selected engraving shape.
+* Complex curves are segmented using the parent Job's {{PropertyData|Geometry Tolerance}}.
+* {{Value|Bidirectional}} cut pattern alternates direction after each step-down on open wires, reducing retraction moves.
 
 ==Properties== <!--T:10-->
 
@@ -58,7 +69,7 @@ The [[Image:CAM_Engrave.svg|24px]] [[CAM_Engrave|CAM Engrave]] command is primar
 
 <!--T:11-->
 * {{PropertyData|Clearance Height}}: The height needed to clear clamps and obstructions
-* {{PropertyData|Final Depth}}: Final Depth of Tool- lowest value in Z
+* {{PropertyData|Final Depth}}: Final Depth of Tool - lowest value in Z. The default is based on the stock and engraving shape.
 * {{PropertyData|Safe Height}}: The above which Rapid motions are allowed.
 * {{PropertyData|Start Depth}}: Starting Depth of Tool- first cut depth in Z
 * {{PropertyData|Step Down}}: Incremental Step Down of Tool
@@ -72,6 +83,8 @@ The [[Image:CAM_Engrave.svg|24px]] [[CAM_Engrave|CAM Engrave]] command is primar
 * {{PropertyData|Comment}}: An optional comment for this operation
 * {{PropertyData|Coolant Mode}}: Coolant mode for this operation
 * {{PropertyData|Cycle Time}}: Estimated cycle time for this operation
+* {{PropertyData|Cut Pattern}}: The cut pattern for the operation. The options are {{Value|Directional}} and {{Value|Bidirectional}}.
+* {{PropertyData|Reverse}}: Reverse the milling direction.
 * {{PropertyData|Start Vertex}}: The vertex index to start the path from
 * {{PropertyData|Tool Controller}}: The tool controller that will be used to calculate the path
 * {{PropertyData|User Label}}: User assigned label

--- a/wiki/CAM_Engrave.wikitext
+++ b/wiki/CAM_Engrave.wikitext
@@ -24,7 +24,7 @@
 The [[Image:CAM_Engrave.svg|24px]] [[CAM_Engrave|CAM Engrave]] command is primarily for engraving a [[Image:Draft_ShapeString.svg|16px]] [[Draft_ShapeString|Draft ShapeString]] onto a part. It can also be used with other flat 2D geometry, for example imported SVG-based shapes.
 
 <!--T:29-->
-Since FreeCAD 1.2 the operation can reverse the milling direction and use directional or bidirectional cutting patterns.
+{{Version|1.2}}: The operation can reverse the milling direction and use directional or bidirectional cut patterns.
 
 ==Usage== <!--T:8-->
 
@@ -37,7 +37,7 @@ Since FreeCAD 1.2 the operation can reverse the milling direction and use direct
 #* Other flat 2D geometry, such as imported SVG-based shapes, can also be used.
 #* When possible, select the whole flat shape instead of selecting many individual edges in the [[3D_View|3D View]].
 # In the {{MenuCommand|Depths}} section, check and adjust the depth settings as required.
-# In the {{MenuCommand|Data}} tab, adjust {{PropertyData|Cut Pattern}}, {{PropertyData|Reverse}}, and {{PropertyData|Start Vertex}} if required.
+# Adjust {{PropertyData|Cut Pattern}}, {{PropertyData|Reverse}}, and {{PropertyData|Start Vertex}} if required.
 # Confirm the operation.
 
 ==Options== <!--T:9-->
@@ -49,9 +49,9 @@ Since FreeCAD 1.2 the operation can reverse the milling direction and use direct
 ==Notes== <!--T:30-->
 
 <!--T:31-->
-* The {{PropertyData|Final Depth}} default for new operations is based on the stock and selected engraving shape.
-* Complex curves are segmented using the parent Job's {{PropertyData|Geometry Tolerance}}.
-* The {{Value|Bidirectional}} cut pattern alternates direction after each step-down on open wires.
+* {{Version|1.2}}: The {{PropertyData|Final Depth}} default is based on the stock and selected engraving shape.
+* {{Version|1.2}}: Complex curves use the parent Job's {{PropertyData|Geometry Tolerance}} for segmentation.
+* {{Version|1.2}}: {{Value|Bidirectional}} alternates direction after each step-down on open wires.
 
 ==Properties== <!--T:10-->
 


### PR DESCRIPTION
Summary:
- document the FreeCAD 1.2 Engrave Cut Pattern and Reverse properties
- note that Final Depth defaults now depend on stock and the selected engraving shape
- note that complex curve segmentation uses the parent Job Geometry Tolerance

Source changes reflected:
- FreeCAD/FreeCAD#22226 added Engrave Cut Pattern and Reverse behavior
- FreeCAD/FreeCAD#26543 improved Engrave final-depth defaults
- FreeCAD/FreeCAD#26128 made Engrave use Job Geometry Tolerance for complex-shape segmentation

Part of #25.