### PR TITLE
[codex] Document CAM Deburr 1.2 tolerance behavior

### DIFF
--- a/wiki/CAM_Deburr.wikitext
+++ b/wiki/CAM_Deburr.wikitext
@@ -25,7 +25,7 @@
 The [[Image:CAM_Deburr.svg|24px]] [[CAM_Deburr|CAM Deburr]] command is primarily for deburring an edge.
 
 <!--T:25-->
-Since FreeCAD 1.2, complex-curve segmentation for this operation uses the parent Job's {{PropertyData|Geometry Tolerance}}.
+Since FreeCAD 1.2, complex curves use the parent Job's {{PropertyData|Geometry Tolerance}} for segmentation.
 
 == Usage == <!--T:5-->
 
@@ -56,11 +56,6 @@ The Final step is to activate the {{MenuCommand|Operation}} section where you ca
 
 <!--T:24-->
 :[[File:Path Deburr Operations-tab.png|300px|Deburring interface with the options]]
-
-== Notes == <!--T:26-->
-
-<!--T:27-->
-* For complex shapes, the segmentation precision is controlled by the parent Job's {{PropertyData|Geometry Tolerance}}.
 
 == Properties == <!--T:11-->
 

--- a/wiki/CAM_Deburr.wikitext
+++ b/wiki/CAM_Deburr.wikitext
@@ -24,6 +24,9 @@
 <!--T:4-->
 The [[Image:CAM_Deburr.svg|24px]] [[CAM_Deburr|CAM Deburr]] command is primarily for deburring an edge.
 
+<!--T:25-->
+Since FreeCAD 1.2, complex-curve segmentation for this operation uses the parent Job's {{PropertyData|Geometry Tolerance}}.
+
 == Usage == <!--T:5-->
 
 <!--T:6-->
@@ -53,6 +56,11 @@ The Final step is to activate the {{MenuCommand|Operation}} section where you ca
 
 <!--T:24-->
 :[[File:Path Deburr Operations-tab.png|300px|Deburring interface with the options]]
+
+== Notes == <!--T:26-->
+
+<!--T:27-->
+* For complex shapes, the segmentation precision is controlled by the parent Job's {{PropertyData|Geometry Tolerance}}.
 
 == Properties == <!--T:11-->
 

--- a/wiki/CAM_Deburr.wikitext
+++ b/wiki/CAM_Deburr.wikitext
@@ -25,7 +25,7 @@
 The [[Image:CAM_Deburr.svg|24px]] [[CAM_Deburr|CAM Deburr]] command is primarily for deburring an edge.
 
 <!--T:25-->
-Since FreeCAD 1.2, complex curves use the parent Job's {{PropertyData|Geometry Tolerance}} for segmentation.
+{{Version|1.2}}: complex curves use the parent Job's {{PropertyData|Geometry Tolerance}} for segmentation.
 
 == Usage == <!--T:5-->
 


### PR DESCRIPTION
Summary:
- document that CAM Deburr uses the parent Job Geometry Tolerance for complex-curve segmentation in FreeCAD 1.2
- add a short note near the Deburr operation description and notes section

Source change reflected:
- FreeCAD/FreeCAD#26128 made Engrave and Deburr use Job Geometry Tolerance for complex-shape segmentation

Part of #25.