### PR TITLE
[codex] Document CAM Waterline 1.2 OCL Adaptive updates

### DIFF
--- a/wiki/CAM_Waterline.wikitext
+++ b/wiki/CAM_Waterline.wikitext
@@ -34,7 +34,7 @@ The [[Image:CAM_Waterline.svg|24px]] [[CAM_Waterline|CAM Waterline]] command cre
 <!--T:6-->
 The Waterline operation has three algorithms: OCL Dropcutter, OCL Adaptive, and Experimental.
 * The OCL Dropcutter and OCL Adaptive algorithms interface to OCL.pyd, a 3rd party Open Source module titled [[OpenCamLib|OpenCamLib]], that generates tool paths from a 3D Model. OpenCamLib is not integrated directly into FreeCAD.
-* The OCL Adaptive algorithm is available since FreeCAD 1.2. It can generate smoother paths more quickly for suitable models. It is not restricted by Waterline boundaries; use a [[CAM_DressupPathBoundary|Boundary Dressup]] if required.
+* {{Version|1.2}}: The OCL Adaptive algorithm is available. It can generate smoother paths more quickly for suitable models. It is not restricted by Waterline boundaries; use a [[CAM_DressupPathBoundary|Boundary Dressup]] if required.
 * The Experimental algorithm makes use of the built-in Path.Area() class.
 
 <!--T:7-->

--- a/wiki/CAM_Waterline.wikitext
+++ b/wiki/CAM_Waterline.wikitext
@@ -34,7 +34,7 @@ The [[Image:CAM_Waterline.svg|24px]] [[CAM_Waterline|CAM Waterline]] command cre
 <!--T:6-->
 The Waterline operation has three algorithms: OCL Dropcutter, OCL Adaptive, and Experimental.
 * The OCL Dropcutter and OCL Adaptive algorithms interface to OCL.pyd, a 3rd party Open Source module titled [[OpenCamLib|OpenCamLib]], that generates tool paths from a 3D Model. OpenCamLib is not integrated directly into FreeCAD.
-* The OCL Adaptive algorithm is available since FreeCAD 1.2. It can generate smoother paths more quickly for suitable models, but it cannot be restricted by Waterline boundaries; if the path exceeds the stock limits a warning is shown and a [[CAM_DressupPathBoundary|Boundary Dressup]] can be used.
+* The OCL Adaptive algorithm is available since FreeCAD 1.2. It can generate smoother paths more quickly for suitable models. It is not restricted by Waterline boundaries; use a [[CAM_DressupPathBoundary|Boundary Dressup]] if required.
 * The Experimental algorithm makes use of the built-in Path.Area() class.
 
 <!--T:7-->
@@ -62,8 +62,8 @@ Usage instructions for multiple variations of the [[CAM_Waterline|Waterline]] op
 ### Set the Sample Interval used for the OCL scan.
 ## OCL Adaptive
 ### Set the Layer Mode: Single-pass or Multi-pass.
-### Set the Sample Interval and Min Sample Interval used for the adaptive OCL scan.
-### Optionally enable Optimize Linear Paths to remove unnecessary co-linear points from G-code output.
+### Set the Sample Interval and Min Sample Interval for the adaptive OCL scan.
+### Optionally enable Optimize Linear Paths.
 ## Experimental
 ### Choose the BoundBox: Stock or BaseBoundBox.
 ### Set the Layer Mode: Single-pass or Multi-pass.
@@ -137,8 +137,8 @@ Note: It is suggested that you do not edit the Placement property of path operat
 * {{PropertyData|Depth Offset}}: 
 * {{PropertyData|Ignore Outer Above}}: 
 * {{PropertyData|Layer Mode}}: The completion mode for the operation: single or multi-pass
-* {{PropertyData|Min Sample Interval}}: The minimum sampling resolution for the OCL Adaptive algorithm. Smaller values quickly increase processing time.
-* {{PropertyData|Optimize Linear Paths}}: For the OCL Adaptive algorithm, remove unnecessary co-linear points from G-code output.
+* {{PropertyData|Min Sample Interval}}: Minimum sampling resolution for the OCL Adaptive algorithm
+* {{PropertyData|Optimize Linear Paths}}: Remove unnecessary co-linear points from G-code output
 * {{PropertyData|Step Over}}: 
 
 <!--T:27-->

--- a/wiki/CAM_Waterline.wikitext
+++ b/wiki/CAM_Waterline.wikitext
@@ -32,8 +32,9 @@
 The [[Image:CAM_Waterline.svg|24px]] [[CAM_Waterline|CAM Waterline]] command creates a new Waterline operation. As of 0.19_pre, the operation works on the entire model to generate G-code for the Job. Currently, within the operation's settings there is no functionality to select specific areas, faces, or regions of the model.
 
 <!--T:6-->
-The Waterline operation has two algorithms: OCL Drop Cutter and Experimental.
-* The OCL Drop Cutter algorithm interfaces to OCL.pyd, a 3rd party Open Source module titled [[OpenCamLib|OpenCamLib]], that generates tool paths from a 3D Model. OpenCamLib is not integrated directly into FreeCAD.
+The Waterline operation has three algorithms: OCL Dropcutter, OCL Adaptive, and Experimental.
+* The OCL Dropcutter and OCL Adaptive algorithms interface to OCL.pyd, a 3rd party Open Source module titled [[OpenCamLib|OpenCamLib]], that generates tool paths from a 3D Model. OpenCamLib is not integrated directly into FreeCAD.
+* The OCL Adaptive algorithm is available since FreeCAD 1.2. It can generate smoother paths more quickly for suitable models, but it cannot be restricted by Waterline boundaries; if the path exceeds the stock limits a warning is shown and a [[CAM_DressupPathBoundary|Boundary Dressup]] can be used.
 * The Experimental algorithm makes use of the built-in Path.Area() class.
 
 <!--T:7-->
@@ -59,6 +60,10 @@ Usage instructions for multiple variations of the [[CAM_Waterline|Waterline]] op
 ### Choose the BoundBox: Stock or BaseBoundBox.
 ### Set the Layer Mode: Single-pass or Multi-pass.
 ### Set the Sample Interval used for the OCL scan.
+## OCL Adaptive
+### Set the Layer Mode: Single-pass or Multi-pass.
+### Set the Sample Interval and Min Sample Interval used for the adaptive OCL scan.
+### Optionally enable Optimize Linear Paths to remove unnecessary co-linear points from G-code output.
 ## Experimental
 ### Choose the BoundBox: Stock or BaseBoundBox.
 ### Set the Layer Mode: Single-pass or Multi-pass.
@@ -132,6 +137,8 @@ Note: It is suggested that you do not edit the Placement property of path operat
 * {{PropertyData|Depth Offset}}: 
 * {{PropertyData|Ignore Outer Above}}: 
 * {{PropertyData|Layer Mode}}: The completion mode for the operation: single or multi-pass
+* {{PropertyData|Min Sample Interval}}: The minimum sampling resolution for the OCL Adaptive algorithm. Smaller values quickly increase processing time.
+* {{PropertyData|Optimize Linear Paths}}: For the OCL Adaptive algorithm, remove unnecessary co-linear points from G-code output.
 * {{PropertyData|Step Over}}: 
 
 <!--T:27-->
@@ -205,6 +212,8 @@ This section is simply a layout map of the settings in the window editor for the
 * {{PropertyData|Cut Pattern}}~
 * {{PropertyData|Boundary Adjustment}}~
 * {{PropertyData|Sample Interval}}~
+* {{PropertyData|Min Sample Interval}}~
+* {{PropertyData|Optimize Linear Paths}}~
 ~Visibility changes with other settings. 
 
 ==Resources== <!--T:43--> 


### PR DESCRIPTION
Summary:
- update CAM Waterline to list OCL Adaptive alongside OCL Dropcutter and Experimental
- document OCL Adaptive behavior, including stock-limit warning and Boundary Dressup workaround
- add Min Sample Interval and Optimize Linear Paths to the properties/task-panel layout

Source changes reflected:
- FreeCAD/FreeCAD#23149 added the OCL Adaptive algorithm to Waterline
- FreeCAD/FreeCAD#27040 added Optimize Linear Paths for Waterline OCL Adaptive

Part of #25.