### PR TITLE
[codex] Document CAM Slot 1.2 safe-height move

### DIFF
--- a/wiki/CAM_Slot.wikitext
+++ b/wiki/CAM_Slot.wikitext
@@ -50,7 +50,7 @@ The CAM Slot object is made to be part of a [[Image:CAM_Job.svg|24px]] [[CAM_Job
 
 <!--T:7-->
 * All slots:
-** Since FreeCAD 1.2, slot output first rapids from {{PropertyData|Clearance Height}} to {{PropertyData|Safe Height}}.
+** {{Version|1.2}}: slot output first rapids from {{PropertyData|Clearance Height}} to {{PropertyData|Safe Height}}.
 ** Both the beginning and end of a slot path can be extended or shortened. Use the `Extend Path Start` and `Extend Path End` properties.
 ** Use the `Layer Mode` property to cut the slot in `Single-pass` mode at final depth, or in `Multi-pass` mode using the available `Step Down` property.
 ** Toggle the `Reverse Direction` property to reverse the direction of the cut path.

--- a/wiki/CAM_Slot.wikitext
+++ b/wiki/CAM_Slot.wikitext
@@ -50,6 +50,7 @@ The CAM Slot object is made to be part of a [[Image:CAM_Job.svg|24px]] [[CAM_Job
 
 <!--T:7-->
 * All slots:
+** Since FreeCAD 1.2, generated G-code starts with a rapid move from {{PropertyData|Clearance Height}} to {{PropertyData|Safe Height}} before slot cutting begins.
 ** Both the beginning and end of a slot path can be extended or shortened. Use the `Extend Path Start` and `Extend Path End` properties.
 ** Use the `Layer Mode` property to cut the slot in `Single-pass` mode at final depth, or in `Multi-pass` mode using the available `Step Down` property.
 ** Toggle the `Reverse Direction` property to reverse the direction of the cut path.
@@ -103,7 +104,7 @@ Note: It is suggested that you do not edit the Placement property of path operat
 * {{PropertyData|Clearance Height}}: The height needed to clear clamps and obstructions
 * {{PropertyData|Final Depth}}: Final Depth of Tool- lowest value in Z
 * {{PropertyData|Finish Depth}}: Maximum material removed on final pass. The height (thickness) of the last cutting level - ''set for a better finish''.
-* {{PropertyData|Safe Height}}: The height above which Rapid motions are allowed. (Rapid safety height between locations)
+* {{PropertyData|Safe Height}}: The height above which Rapid motions are allowed. (Rapid safety height between locations). Since FreeCAD 1.2 the Slot path starts with a rapid move from Clearance Height to Safe Height.
 * {{PropertyData|Start Depth}}: Starting depth of Tool - ''first cut depth in Z''
 * {{PropertyData|Step Down}}: Incremental step down of Tool during operation
 

--- a/wiki/CAM_Slot.wikitext
+++ b/wiki/CAM_Slot.wikitext
@@ -50,7 +50,7 @@ The CAM Slot object is made to be part of a [[Image:CAM_Job.svg|24px]] [[CAM_Job
 
 <!--T:7-->
 * All slots:
-** Since FreeCAD 1.2, generated G-code starts with a rapid move from {{PropertyData|Clearance Height}} to {{PropertyData|Safe Height}} before slot cutting begins.
+** Since FreeCAD 1.2, slot output first rapids from {{PropertyData|Clearance Height}} to {{PropertyData|Safe Height}}.
 ** Both the beginning and end of a slot path can be extended or shortened. Use the `Extend Path Start` and `Extend Path End` properties.
 ** Use the `Layer Mode` property to cut the slot in `Single-pass` mode at final depth, or in `Multi-pass` mode using the available `Step Down` property.
 ** Toggle the `Reverse Direction` property to reverse the direction of the cut path.
@@ -104,7 +104,7 @@ Note: It is suggested that you do not edit the Placement property of path operat
 * {{PropertyData|Clearance Height}}: The height needed to clear clamps and obstructions
 * {{PropertyData|Final Depth}}: Final Depth of Tool- lowest value in Z
 * {{PropertyData|Finish Depth}}: Maximum material removed on final pass. The height (thickness) of the last cutting level - ''set for a better finish''.
-* {{PropertyData|Safe Height}}: The height above which Rapid motions are allowed. (Rapid safety height between locations). Since FreeCAD 1.2 the Slot path starts with a rapid move from Clearance Height to Safe Height.
+* {{PropertyData|Safe Height}}: The height above which Rapid motions are allowed. (Rapid safety height between locations)
 * {{PropertyData|Start Depth}}: Starting depth of Tool - ''first cut depth in Z''
 * {{PropertyData|Step Down}}: Incremental step down of Tool during operation
 


### PR DESCRIPTION
Summary:
- document the FreeCAD 1.2 Slot startup rapid move from Clearance Height to Safe Height
- add the behavior to the usage notes and Safe Height property description

Source change reflected:
- FreeCAD/FreeCAD#25845 added a rapid move from ClearanceHeight to SafeHeight at the beginning of Slot G-code

Part of #25.