### PR TITLE
[codex] Document CAM SelectLoop 1.2 wire fallback

### DIFF
--- a/wiki/CAM_SelectLoop.wikitext
+++ b/wiki/CAM_SelectLoop.wikitext
@@ -25,6 +25,9 @@
 <!--T:2-->
 The [[Image:CAM_SelectLoop.svg|24px]] [[CAM_SelectLoop|CAM SelectLoop]] command completes a selection of edges that form a loop.
 
+<!--T:16-->
+Since FreeCAD 1.2 the command can also return the wire from the selected edge or edges when the other loop-detection methods do not find a result.
+
 ==Usage== <!--T:3-->
 
 <!--T:4-->
@@ -39,6 +42,7 @@ The [[Image:CAM_SelectLoop.svg|24px]] [[CAM_SelectLoop|CAM SelectLoop]] command 
 
 <!--T:15-->
 * This command can also be very useful in other workbenches.
+* The wire fallback can help with selections from objects such as a [[PartDesign_SubShapeBinder|SubShapeBinder]] or a [[Sketcher_Workbench|Sketch]] that is not on a horizontal plane.
 
 
 <!--T:7-->

--- a/wiki/CAM_SelectLoop.wikitext
+++ b/wiki/CAM_SelectLoop.wikitext
@@ -26,7 +26,7 @@
 The [[Image:CAM_SelectLoop.svg|24px]] [[CAM_SelectLoop|CAM SelectLoop]] command completes a selection of edges that form a loop.
 
 <!--T:16-->
-Since FreeCAD 1.2 the command can also return the wire from the selected edge or edges when the other loop-detection methods do not find a result.
+Since FreeCAD 1.2, if the normal loop detection fails, the command can return the wire from the selected edges.
 
 ==Usage== <!--T:3-->
 
@@ -42,7 +42,7 @@ Since FreeCAD 1.2 the command can also return the wire from the selected edge or
 
 <!--T:15-->
 * This command can also be very useful in other workbenches.
-* The wire fallback can help with selections from objects such as a [[PartDesign_SubShapeBinder|SubShapeBinder]] or a [[Sketcher_Workbench|Sketch]] that is not on a horizontal plane.
+* The wire fallback can help with selections from a [[PartDesign_SubShapeBinder|SubShapeBinder]] or a non-horizontal [[Sketcher_Workbench|Sketch]].
 
 
 <!--T:7-->

--- a/wiki/CAM_SelectLoop.wikitext
+++ b/wiki/CAM_SelectLoop.wikitext
@@ -26,7 +26,7 @@
 The [[Image:CAM_SelectLoop.svg|24px]] [[CAM_SelectLoop|CAM SelectLoop]] command completes a selection of edges that form a loop.
 
 <!--T:16-->
-Since FreeCAD 1.2, if the normal loop detection fails, the command can return the wire from the selected edges.
+{{Version|1.2}}: If the normal loop detection fails, the command can return the wire from the selected edges.
 
 ==Usage== <!--T:3-->
 


### PR DESCRIPTION
Summary:
- document the FreeCAD 1.2 SelectLoop fallback that returns a wire from selected edge(s) when other loop-detection methods do not find a result
- note that this helps selections from SubShapeBinder or non-horizontal Sketch objects

Source change reflected:
- FreeCAD/FreeCAD#24185 improved SelectLoop to return a wire when edge selections are available and other methods fail

Part of #25.