### PR TITLE
[codex] Document CAM SimpleCopy 1.2 multiple selection

### DIFF
--- a/wiki/CAM_SimpleCopy.wikitext
+++ b/wiki/CAM_SimpleCopy.wikitext
@@ -24,7 +24,6 @@
 <!--T:3-->
 The [[Image:CAM_SimpleCopy.svg|24px]] [[CAM_SimpleCopy|CAM SimpleCopy]] command creates a non-parametric copy of a given path.
 
-<!--T:10-->
 {{Version|1.2}}: the command can combine multiple selected operations into one simple copy.
 
 ==Usage== <!--T:4-->

--- a/wiki/CAM_SimpleCopy.wikitext
+++ b/wiki/CAM_SimpleCopy.wikitext
@@ -25,7 +25,7 @@
 The [[Image:CAM_SimpleCopy.svg|24px]] [[CAM_SimpleCopy|CAM SimpleCopy]] command creates a non-parametric copy of a given path.
 
 <!--T:10-->
-Since FreeCAD 1.2 the command can also create one simple copy from multiple selected operations by combining their commands.
+Since FreeCAD 1.2, the command can combine multiple selected operations into one simple copy.
 
 ==Usage== <!--T:4-->
 
@@ -37,8 +37,8 @@ Since FreeCAD 1.2 the command can also create one simple copy from multiple sele
 
 <!--T:7-->
 * The simple copy is not bound anymore to the path that was used to make the copy, and is not parametric. Therefore, when edited with the [[CAM_Inspect|CAM Inspect]] tool, any change made to its G-code will be retained.
-* When multiple operations are selected, all selected operations must use the same {{PropertyData|Coolant Mode}} and {{PropertyData|Tool Controller}}. Their commands are combined into one simple copy.
-* Since FreeCAD 1.2, SimpleCopy can be used with operations that contain commands, even if they are not based on the standard CAM operation base class.
+* Multiple selected operations must use the same {{PropertyData|Coolant Mode}} and {{PropertyData|Tool Controller}}.
+* Since FreeCAD 1.2, SimpleCopy can also copy operations that contain commands without using the standard CAM operation base class.
 
 
 <!--T:9-->

--- a/wiki/CAM_SimpleCopy.wikitext
+++ b/wiki/CAM_SimpleCopy.wikitext
@@ -24,16 +24,21 @@
 <!--T:3-->
 The [[Image:CAM_SimpleCopy.svg|24px]] [[CAM_SimpleCopy|CAM SimpleCopy]] command creates a non-parametric copy of a given path.
 
+<!--T:10-->
+Since FreeCAD 1.2 the command can also create one simple copy from multiple selected operations by combining their commands.
+
 ==Usage== <!--T:4-->
 
 <!--T:5-->
-# Select one [[CAM_Workbench|CAM]] object
+# Select one or more [[CAM_Workbench|CAM]] objects.
 # Press the {{Button|[[Image:CAM_SimpleCopy.svg|16px]] [[CAM_SimpleCopy|Simple Copy]]}} button
 
 ==Options== <!--T:6--> 
 
 <!--T:7-->
 * The simple copy is not bound anymore to the path that was used to make the copy, and is not parametric. Therefore, when edited with the [[CAM_Inspect|CAM Inspect]] tool, any change made to its G-code will be retained.
+* When multiple operations are selected, all selected operations must use the same {{PropertyData|Coolant Mode}} and {{PropertyData|Tool Controller}}. Their commands are combined into one simple copy.
+* Since FreeCAD 1.2, SimpleCopy can be used with operations that contain commands, even if they are not based on the standard CAM operation base class.
 
 
 <!--T:9-->

--- a/wiki/CAM_SimpleCopy.wikitext
+++ b/wiki/CAM_SimpleCopy.wikitext
@@ -25,7 +25,7 @@
 The [[Image:CAM_SimpleCopy.svg|24px]] [[CAM_SimpleCopy|CAM SimpleCopy]] command creates a non-parametric copy of a given path.
 
 <!--T:10-->
-Since FreeCAD 1.2, the command can combine multiple selected operations into one simple copy.
+{{Version|1.2}}: the command can combine multiple selected operations into one simple copy.
 
 ==Usage== <!--T:4-->
 
@@ -38,7 +38,7 @@ Since FreeCAD 1.2, the command can combine multiple selected operations into one
 <!--T:7-->
 * The simple copy is not bound anymore to the path that was used to make the copy, and is not parametric. Therefore, when edited with the [[CAM_Inspect|CAM Inspect]] tool, any change made to its G-code will be retained.
 * Multiple selected operations must use the same {{PropertyData|Coolant Mode}} and {{PropertyData|Tool Controller}}.
-* Since FreeCAD 1.2, SimpleCopy can also copy operations that contain commands without using the standard CAM operation base class.
+* {{Version|1.2}}: SimpleCopy can also copy operations that contain commands without using the standard CAM operation base class.
 
 
 <!--T:9-->


### PR DESCRIPTION
Summary:
- document that SimpleCopy can create one simple copy from multiple selected operations in FreeCAD 1.2
- note the shared Coolant Mode and Tool Controller requirement for multiple selections
- mention support for operations that contain commands even if they do not derive from the standard CAM operation base class

Source change reflected:
- FreeCAD/FreeCAD#24297 allowed SimpleCopy multiple selection and command-combining behavior

Part of #25.