### PR TITLE
[codex] Document CAM Copy 1.2 dressup copying

### DIFF
--- a/wiki/CAM_Copy.wikitext
+++ b/wiki/CAM_Copy.wikitext
@@ -24,7 +24,7 @@
 The [[Image:CAM_Copy.svg|24px]] [[CAM_Copy|CAM Copy]] command creates a copy of a selected path.
 
 <!--T:12-->
-Since FreeCAD 1.2 the command can copy any CAM operation that contains path commands and recursively copies dressups attached to the selected operation.
+Since FreeCAD 1.2, the command can also copy CAM operations that contain path commands.
 
 ==Usage== <!--T:4-->
 
@@ -46,7 +46,7 @@ Since FreeCAD 1.2 the command can copy any CAM operation that contains path comm
 The copy stays linked with the original path. If the original changes, so does the copy.
 
 <!--T:13-->
-When the selected operation has dressups, the copied operation receives copies of those dressups as well.
+Attached dressups are copied recursively.
 
 
 <!--T:11-->

--- a/wiki/CAM_Copy.wikitext
+++ b/wiki/CAM_Copy.wikitext
@@ -23,6 +23,9 @@
 <!--T:3-->
 The [[Image:CAM_Copy.svg|24px]] [[CAM_Copy|CAM Copy]] command creates a copy of a selected path.
 
+<!--T:12-->
+Since FreeCAD 1.2 the command can copy any CAM operation that contains path commands and recursively copies dressups attached to the selected operation.
+
 ==Usage== <!--T:4-->
 
 <!--T:5-->
@@ -41,6 +44,9 @@ The [[Image:CAM_Copy.svg|24px]] [[CAM_Copy|CAM Copy]] command creates a copy of 
 
 <!--T:9-->
 The copy stays linked with the original path. If the original changes, so does the copy.
+
+<!--T:13-->
+When the selected operation has dressups, the copied operation receives copies of those dressups as well.
 
 
 <!--T:11-->

--- a/wiki/CAM_Copy.wikitext
+++ b/wiki/CAM_Copy.wikitext
@@ -24,7 +24,7 @@
 The [[Image:CAM_Copy.svg|24px]] [[CAM_Copy|CAM Copy]] command creates a copy of a selected path.
 
 <!--T:12-->
-Since FreeCAD 1.2, the command can also copy CAM operations that contain path commands.
+{{Version|1.2}}: the command can also copy CAM operations that contain path commands.
 
 ==Usage== <!--T:4-->
 


### PR DESCRIPTION
Summary:
- document that CAM Copy can copy any operation that contains path commands in FreeCAD 1.2
- note that dressups attached to the selected operation are recursively copied

Source change reflected:
- FreeCAD/FreeCAD#24819 allowed Operation Copy for all command-containing operations and recursive Dressup copy

Part of #25.