### PR TITLE
[codex] Document CAM toggle operation 1.2 group support

### DIFF
--- a/wiki/CAM_OpActiveToggle.wikitext
+++ b/wiki/CAM_OpActiveToggle.wikitext
@@ -25,6 +25,9 @@
 <!--T:4-->
 The [[Image:CAM_OpActiveToggle.svg|24px]] [[CAM_OpActiveToggle|CAM OpActiveToggle]] command toggles the {{PropertyData|Active}} property of a selected CAM operation.
 
+<!--T:26-->
+Since FreeCAD 1.2 the command can also toggle all operations in a selected Job or {{MenuCommand|Operations}} group.
+
 <!--T:25-->
 If this property is set to {{FALSE}}, the operation is treated as inactive. Its path is not shown in the [[3D_View|3D View]], and it is ignored by commands such as [[Image:CAM_Inspect.svg|16px]] [[CAM_Inspect|CAM Inspect]] and [[Image:CAM_Post.svg|16px]] [[CAM_Post|CAM Post]].
 
@@ -32,6 +35,7 @@ If this property is set to {{FALSE}}, the operation is treated as inactive. Its 
 
 <!--T:7-->
 # Select an operation in the {{MenuCommand|Operations}} group belonging to a Job. A deactivated operation can be recognized by its grayed out label and icon.
+#* Since FreeCAD 1.2, you can also select a Job or its {{MenuCommand|Operations}} group to toggle all contained operations.
 # There are several ways to invoke the command:
 #* Press the {{Button|[[Image:CAM_OpActiveToggle.svg|16px]] [[CAM_OpActiveToggle|Toggle Operation]]}} button.
 #* Select the {{MenuCommand|CAM → [[Image:CAM_OpActiveToggle.svg|16px]] Toggle Operation}} option from the menu.
@@ -48,6 +52,10 @@ If this property is set to {{FALSE}}, the operation is treated as inactive. Its 
 #** The operation icon and label are no longer grayed out.
 #** The paths generated from the operation are recomputed and displayed in the [[3D_View|3D View]].
 #** When using the [[Image:CAM_Inspect.svg|16px]] [[CAM_Inspect|CAM Inspect]] command or the [[Image:CAM_Post.svg|16px]] [[CAM_Post|CAM Post]] command, the operation's G-code is provided again.
+#* If you have selected a Job or {{MenuCommand|Operations}} group:
+#** If all contained operations are active, the command deactivates all of them.
+#** If all contained operations are inactive, the command activates all of them.
+#** If at least one contained operation is inactive, the command activates all contained operations.
 
 ==Scripting== <!--T:17-->
 

--- a/wiki/CAM_OpActiveToggle.wikitext
+++ b/wiki/CAM_OpActiveToggle.wikitext
@@ -26,7 +26,7 @@
 The [[Image:CAM_OpActiveToggle.svg|24px]] [[CAM_OpActiveToggle|CAM OpActiveToggle]] command toggles the {{PropertyData|Active}} property of a selected CAM operation.
 
 <!--T:26-->
-Since FreeCAD 1.2, the command can also toggle all operations in a selected Job or {{MenuCommand|Operations}} group.
+{{Version|1.2}}: the command can also toggle all operations in a selected Job or {{MenuCommand|Operations}} group.
 
 <!--T:25-->
 If this property is set to {{FALSE}}, the operation is treated as inactive. Its path is not shown in the [[3D_View|3D View]], and it is ignored by commands such as [[Image:CAM_Inspect.svg|16px]] [[CAM_Inspect|CAM Inspect]] and [[Image:CAM_Post.svg|16px]] [[CAM_Post|CAM Post]].

--- a/wiki/CAM_OpActiveToggle.wikitext
+++ b/wiki/CAM_OpActiveToggle.wikitext
@@ -26,7 +26,7 @@
 The [[Image:CAM_OpActiveToggle.svg|24px]] [[CAM_OpActiveToggle|CAM OpActiveToggle]] command toggles the {{PropertyData|Active}} property of a selected CAM operation.
 
 <!--T:26-->
-Since FreeCAD 1.2 the command can also toggle all operations in a selected Job or {{MenuCommand|Operations}} group.
+Since FreeCAD 1.2, the command can also toggle all operations in a selected Job or {{MenuCommand|Operations}} group.
 
 <!--T:25-->
 If this property is set to {{FALSE}}, the operation is treated as inactive. Its path is not shown in the [[3D_View|3D View]], and it is ignored by commands such as [[Image:CAM_Inspect.svg|16px]] [[CAM_Inspect|CAM Inspect]] and [[Image:CAM_Post.svg|16px]] [[CAM_Post|CAM Post]].
@@ -34,8 +34,7 @@ If this property is set to {{FALSE}}, the operation is treated as inactive. Its 
 ==Usage== <!--T:5-->
 
 <!--T:7-->
-# Select an operation in the {{MenuCommand|Operations}} group belonging to a Job. A deactivated operation can be recognized by its grayed out label and icon.
-#* Since FreeCAD 1.2, you can also select a Job or its {{MenuCommand|Operations}} group to toggle all contained operations.
+# Select an operation, a Job, or an {{MenuCommand|Operations}} group. A deactivated operation can be recognized by its grayed out label and icon.
 # There are several ways to invoke the command:
 #* Press the {{Button|[[Image:CAM_OpActiveToggle.svg|16px]] [[CAM_OpActiveToggle|Toggle Operation]]}} button.
 #* Select the {{MenuCommand|CAM → [[Image:CAM_OpActiveToggle.svg|16px]] Toggle Operation}} option from the menu.
@@ -52,10 +51,7 @@ If this property is set to {{FALSE}}, the operation is treated as inactive. Its 
 #** The operation icon and label are no longer grayed out.
 #** The paths generated from the operation are recomputed and displayed in the [[3D_View|3D View]].
 #** When using the [[Image:CAM_Inspect.svg|16px]] [[CAM_Inspect|CAM Inspect]] command or the [[Image:CAM_Post.svg|16px]] [[CAM_Post|CAM Post]] command, the operation's G-code is provided again.
-#* If you have selected a Job or {{MenuCommand|Operations}} group:
-#** If all contained operations are active, the command deactivates all of them.
-#** If all contained operations are inactive, the command activates all of them.
-#** If at least one contained operation is inactive, the command activates all contained operations.
+#* If you have selected a Job or {{MenuCommand|Operations}} group, all contained operations are toggled together. If at least one contained operation is inactive, all are activated; otherwise all are deactivated.
 
 ==Scripting== <!--T:17-->
 


### PR DESCRIPTION
Summary:
- document that Toggle Operation can operate on a selected Job or Operations group in FreeCAD 1.2
- add the group-toggle behavior for all-active, all-inactive, and mixed operation states

Source change reflected:
- FreeCAD/FreeCAD#24872 allowed ToggleOperation for Job and Operations group selections

Part of #25.