### PR TITLE
[codex] Document CAM ToolBit 1.2 units property

### DIFF
--- a/wiki/CAM_ToolBit.wikitext
+++ b/wiki/CAM_ToolBit.wikitext
@@ -43,7 +43,7 @@ Within the FreeCAD GUI the CAM toolbit library manager provides a mechanism to c
 == JSON Structure == <!--T:10-->
 
 <!--T:15-->
-Since FreeCAD 1.2 a ToolBit can define a {{incode|Units}} parameter with a value of {{value|Metric}} or {{value|Imperial}}. The ToolBit editor uses this value to display the tool dimensions in the ToolBit's native unit schema, while CAM calculations still use metric units internally. Switching between unit schemas can introduce small rounding differences.
+Since FreeCAD 1.2, a ToolBit can define a {{incode|Units}} parameter: {{value|Metric}} or {{value|Imperial}}. The ToolBit editor uses it for native-unit display; CAM calculations still use metric units internally. Changing the unit schema may cause small rounding differences.
 
 </translate>
 {{Code|

--- a/wiki/CAM_ToolBit.wikitext
+++ b/wiki/CAM_ToolBit.wikitext
@@ -43,7 +43,7 @@ Within the FreeCAD GUI the CAM toolbit library manager provides a mechanism to c
 == JSON Structure == <!--T:10-->
 
 <!--T:15-->
-Since FreeCAD 1.2, a ToolBit can define a {{incode|Units}} parameter: {{value|Metric}} or {{value|Imperial}}. The ToolBit editor uses it for native-unit display; CAM calculations still use metric units internally. Changing the unit schema may cause small rounding differences.
+{{Version|1.2}}: a ToolBit can define a {{incode|Units}} parameter: {{value|Metric}} or {{value|Imperial}}. The ToolBit editor uses it for native-unit display; CAM calculations still use metric units internally. Changing the unit schema may cause small rounding differences.
 
 </translate>
 {{Code|

--- a/wiki/CAM_ToolBit.wikitext
+++ b/wiki/CAM_ToolBit.wikitext
@@ -42,7 +42,6 @@ Within the FreeCAD GUI the CAM toolbit library manager provides a mechanism to c
 
 == JSON Structure == <!--T:10-->
 
-<!--T:15-->
 {{Version|1.2}}: a ToolBit can define a {{incode|Units}} parameter: {{value|Metric}} or {{value|Imperial}}. The ToolBit editor uses it for native-unit display; CAM calculations still use metric units internally. Changing the unit schema may cause small rounding differences.
 
 </translate>

--- a/wiki/CAM_ToolBit.wikitext
+++ b/wiki/CAM_ToolBit.wikitext
@@ -42,6 +42,9 @@ Within the FreeCAD GUI the CAM toolbit library manager provides a mechanism to c
 
 == JSON Structure == <!--T:10-->
 
+<!--T:15-->
+Since FreeCAD 1.2 a ToolBit can define a {{incode|Units}} parameter with a value of {{value|Metric}} or {{value|Imperial}}. The ToolBit editor uses this value to display the tool dimensions in the ToolBit's native unit schema, while CAM calculations still use metric units internally. Switching between unit schemas can introduce small rounding differences.
+
 </translate>
 {{Code|
 {
@@ -50,6 +53,7 @@ Within the FreeCAD GUI the CAM toolbit library manager provides a mechanism to c
   "shape": "endmill.fcstd",
   "attribute": {},
   "parameter": {
+    "Units": "Metric",
     "CuttingEdgeHeight": "30.000 mm",
     "Diameter": "1.000 mm",
     "Length": "50.000 mm",


### PR DESCRIPTION
## Summary
- document the FreeCAD 1.2 ToolBit Units parameter on CAM_ToolBit
- add Units to the ToolBit JSON example
- note Metric/Imperial display behavior and internal metric calculations

## Source
- FreeCAD/FreeCAD#25783

## Validation
- git diff --check
- checked duplicate translation markers in wiki/CAM_ToolBit.wikitext
- checked translate tag balance: 3 open / 3 close

Part of #25.