### PR TITLE
[codex] Document CAM Array 1.2 jitter controls

### DIFF
--- a/wiki/CAM_Array.wikitext
+++ b/wiki/CAM_Array.wikitext
@@ -34,18 +34,18 @@ The [[Image:CAM_Array.svg|24px]] [[CAM_Array|CAM Array]] command creates a new p
 ==Properties== <!--T:6-->
 
 <!--T:7-->
-*{{PropertyData|Type}}: The array type: {{value|Linear1D}}, {{value|Linear2D}} or {{value|Polar}}.
+*{{PropertyData|Type}}: The array type: {{value|Linear1D}}, {{value|Linear2D}} or {{value|Polar}}
 *{{PropertyData|Offset}}: The spacing between the array copies for each direction
 *{{PropertyData|Copies}}: The number of copies (not counting the original) for each direction
 
 <!--T:18-->
-Since FreeCAD 1.2 the previous percentage-based jitter control is replaced by {{PropertyData|UseJitter}}. Jitter can be applied to polar arrays, and random rotation jitter is available for all array types.
+Since FreeCAD 1.2, the previous percentage-based jitter control is replaced by {{PropertyData|UseJitter}}. Jitter can be applied to polar arrays, and random rotation jitter is available for all array types.
 
 <!--T:19-->
-*{{PropertyData|UseJitter}}: Enables random offsets and rotations for generated array copies.
-*{{PropertyData|JitterMagnitude}}: The maximum random translation in each direction.
-*{{PropertyData|JitterAngle}}: The maximum random rotation angle.
-*{{PropertyData|JitterSeed}}: The seed value for repeatable jitter randomness.
+*{{PropertyData|UseJitter}}: Enables random offsets and rotations for generated array copies
+*{{PropertyData|JitterMagnitude}}: The maximum random translation in each direction
+*{{PropertyData|JitterAngle}}: The maximum random rotation angle
+*{{PropertyData|JitterSeed}}: The seed value for repeatable jitter
 
 ==Scripting== <!--T:12-->
 

--- a/wiki/CAM_Array.wikitext
+++ b/wiki/CAM_Array.wikitext
@@ -38,10 +38,8 @@ The [[Image:CAM_Array.svg|24px]] [[CAM_Array|CAM Array]] command creates a new p
 *{{PropertyData|Offset}}: The spacing between the array copies for each direction
 *{{PropertyData|Copies}}: The number of copies (not counting the original) for each direction
 
-<!--T:18-->
 {{Version|1.2}}: the previous percentage-based jitter control is replaced by {{PropertyData|UseJitter}}. Jitter can be applied to polar arrays, and random rotation jitter is available for all array types.
 
-<!--T:19-->
 *{{PropertyData|UseJitter}}: Enables random offsets and rotations for generated array copies
 *{{PropertyData|JitterMagnitude}}: The maximum random translation in each direction
 *{{PropertyData|JitterAngle}}: The maximum random rotation angle

--- a/wiki/CAM_Array.wikitext
+++ b/wiki/CAM_Array.wikitext
@@ -39,7 +39,7 @@ The [[Image:CAM_Array.svg|24px]] [[CAM_Array|CAM Array]] command creates a new p
 *{{PropertyData|Copies}}: The number of copies (not counting the original) for each direction
 
 <!--T:18-->
-Since FreeCAD 1.2, the previous percentage-based jitter control is replaced by {{PropertyData|UseJitter}}. Jitter can be applied to polar arrays, and random rotation jitter is available for all array types.
+{{Version|1.2}}: the previous percentage-based jitter control is replaced by {{PropertyData|UseJitter}}. Jitter can be applied to polar arrays, and random rotation jitter is available for all array types.
 
 <!--T:19-->
 *{{PropertyData|UseJitter}}: Enables random offsets and rotations for generated array copies

--- a/wiki/CAM_Array.wikitext
+++ b/wiki/CAM_Array.wikitext
@@ -34,9 +34,18 @@ The [[Image:CAM_Array.svg|24px]] [[CAM_Array|CAM Array]] command creates a new p
 ==Properties== <!--T:6-->
 
 <!--T:7-->
-*{{PropertyData|Type}}: The type array (polar, linear one ore two directions)
+*{{PropertyData|Type}}: The array type: {{value|Linear1D}}, {{value|Linear2D}} or {{value|Polar}}.
 *{{PropertyData|Offset}}: The spacing between the array copies for each direction
 *{{PropertyData|Copies}}: The number of copies (not counting the original) for each direction
+
+<!--T:18-->
+Since FreeCAD 1.2 the previous percentage-based jitter control is replaced by {{PropertyData|UseJitter}}. Jitter can be applied to polar arrays, and random rotation jitter is available for all array types.
+
+<!--T:19-->
+*{{PropertyData|UseJitter}}: Enables random offsets and rotations for generated array copies.
+*{{PropertyData|JitterMagnitude}}: The maximum random translation in each direction.
+*{{PropertyData|JitterAngle}}: The maximum random rotation angle.
+*{{PropertyData|JitterSeed}}: The seed value for repeatable jitter randomness.
 
 ==Scripting== <!--T:12-->
 


### PR DESCRIPTION
## Summary
- document the FreeCAD 1.2 CAM Array jitter control changes
- add UseJitter, JitterMagnitude, JitterAngle, and JitterSeed properties
- note polar-array jitter and rotation jitter support across array types

## Source
- FreeCAD/FreeCAD#26326

## Validation
- git diff --check
- checked duplicate translation markers in wiki/CAM_Array.wikitext
- checked translate tag balance: 2 open / 2 close

Part of #25.