### PR TITLE
[codex] Document CAM Vcarve 1.2 virtual backtracking

### DIFF
--- a/wiki/CAM_Vcarve.wikitext
+++ b/wiki/CAM_Vcarve.wikitext
@@ -38,7 +38,7 @@ Unlike engraving which follows the lines in the shapestring, V-carving uses a V-
 The V-carve algorithm calculates a path down the center-line of a region using a Voronoi diagram. This center-line is the path the tool will follow in the XY-plane. It next calculates a 'maximum inscribed circle' along the path. This is the largest circle that can be drawn at that point and remain entirely inside the clearing area. Using the circle radius and the tip angle of the cutter, the depth of cut is calculated.  
 
 <!--T:36-->
-Since FreeCAD 1.2 the routing can use virtual edge backtracking. When the next cutting start point can be reached through a path that has already been carved, or through an edge that will be carved next, the operation can travel along that edge instead of using a slower retract, rapid move, and plunge sequence.
+Since FreeCAD 1.2, routing can use virtual edge backtracking. If the next cutting start point is reachable through an already-carved path, or through an edge that will be carved next, the operation can follow that edge instead of a retract, rapid move and plunge.
 
 ==Usage== <!--T:8-->
 

--- a/wiki/CAM_Vcarve.wikitext
+++ b/wiki/CAM_Vcarve.wikitext
@@ -37,6 +37,9 @@ Unlike engraving which follows the lines in the shapestring, V-carving uses a V-
 <!--T:24-->
 The V-carve algorithm calculates a path down the center-line of a region using a Voronoi diagram. This center-line is the path the tool will follow in the XY-plane. It next calculates a 'maximum inscribed circle' along the path. This is the largest circle that can be drawn at that point and remain entirely inside the clearing area. Using the circle radius and the tip angle of the cutter, the depth of cut is calculated.  
 
+<!--T:36-->
+Since FreeCAD 1.2 the routing can use virtual edge backtracking. When the next cutting start point can be reached through a path that has already been carved, or through an edge that will be carved next, the operation can travel along that edge instead of using a slower retract, rapid move, and plunge sequence.
+
 ==Usage== <!--T:8-->
 
 === Prepare the shapes to engrave === <!--T:25-->

--- a/wiki/CAM_Vcarve.wikitext
+++ b/wiki/CAM_Vcarve.wikitext
@@ -37,7 +37,6 @@ Unlike engraving which follows the lines in the shapestring, V-carving uses a V-
 <!--T:24-->
 The V-carve algorithm calculates a path down the center-line of a region using a Voronoi diagram. This center-line is the path the tool will follow in the XY-plane. It next calculates a 'maximum inscribed circle' along the path. This is the largest circle that can be drawn at that point and remain entirely inside the clearing area. Using the circle radius and the tip angle of the cutter, the depth of cut is calculated.  
 
-<!--T:36-->
 {{Version|1.2}}: routing can use virtual edge backtracking. If the next cutting start point is reachable through an already-carved path, or through an edge that will be carved next, the operation can follow that edge instead of a retract, rapid move and plunge.
 
 ==Usage== <!--T:8-->

--- a/wiki/CAM_Vcarve.wikitext
+++ b/wiki/CAM_Vcarve.wikitext
@@ -38,7 +38,7 @@ Unlike engraving which follows the lines in the shapestring, V-carving uses a V-
 The V-carve algorithm calculates a path down the center-line of a region using a Voronoi diagram. This center-line is the path the tool will follow in the XY-plane. It next calculates a 'maximum inscribed circle' along the path. This is the largest circle that can be drawn at that point and remain entirely inside the clearing area. Using the circle radius and the tip angle of the cutter, the depth of cut is calculated.  
 
 <!--T:36-->
-Since FreeCAD 1.2, routing can use virtual edge backtracking. If the next cutting start point is reachable through an already-carved path, or through an edge that will be carved next, the operation can follow that edge instead of a retract, rapid move and plunge.
+{{Version|1.2}}: routing can use virtual edge backtracking. If the next cutting start point is reachable through an already-carved path, or through an edge that will be carved next, the operation can follow that edge instead of a retract, rapid move and plunge.
 
 ==Usage== <!--T:8-->
 


### PR DESCRIPTION
## Summary
- document the FreeCAD 1.2 CAM Vcarve virtual edge backtracking behavior
- explain when already-carved or soon-to-be-carved edges can replace retract/rapid/plunge repositioning

## Source
- FreeCAD/FreeCAD#25049

## Validation
- git diff --check
- checked duplicate translation markers in wiki/CAM_Vcarve.wikitext
- checked translate tag balance: 3 open / 3 close

Part of #25.