### PR TITLE
[codex] Document CAM Profile 1.2 multiple-feature handling

### DIFF
--- a/wiki/CAM_Profile.wikitext
+++ b/wiki/CAM_Profile.wikitext
@@ -142,7 +142,7 @@ Note: It is suggested that you do not edit the Placement property of path operat
 * {{PropertyData|Direction}}: The direction that the tool path should go around the part: Clockwise[CW] or Counterclockwise[CCW]
 * {{PropertyData|Expand Profile}}: Extend the profile clearing beyond the Extra Offset.
 * {{PropertyData|Expand Profile Step Over}}: Set the stepover percentage, based on the tool's diameter.
-* {{PropertyData|Handle Multiple Features}}: Choose how to process multiple Base Geometry features. {{Value|Individually}} processes each feature separately. {{Value|Collectively}} combines compatible features before generating the profile path. Since FreeCAD 1.2, collective handling also supports Profile Edges selections and whole-model perimeter profiles generated from the Job model.
+* {{PropertyData|Handle Multiple Features}}: Choose how to process multiple Base Geometry features. {{Value|Individually}} processes each feature separately. {{Value|Collectively}} combines compatible features before generating the profile path. Since FreeCAD 1.2, {{Value|Collectively}} also supports Profile Edges selections and whole-model perimeter profiles.
 * {{PropertyData|OffsetExtra}}: Extra value to stay away from final profile- good for roughing toolpath
 * {{PropertyData|Process Circles}}: Check if you want this Profile Operation to also be applied to cylindrical holes, ''which normally get drilled''.
 * {{PropertyData|Process Holes}}: Check if this Profile Operation should also process holes in the base geometry. '''Note''' that this does not include cylindrical holes.

--- a/wiki/CAM_Profile.wikitext
+++ b/wiki/CAM_Profile.wikitext
@@ -142,7 +142,7 @@ Note: It is suggested that you do not edit the Placement property of path operat
 * {{PropertyData|Direction}}: The direction that the tool path should go around the part: Clockwise[CW] or Counterclockwise[CCW]
 * {{PropertyData|Expand Profile}}: Extend the profile clearing beyond the Extra Offset.
 * {{PropertyData|Expand Profile Step Over}}: Set the stepover percentage, based on the tool's diameter.
-* {{PropertyData|Handle Multiple Features}}: Choose how to process multiple Base Geometry features.
+* {{PropertyData|Handle Multiple Features}}: Choose how to process multiple Base Geometry features. {{Value|Individually}} processes each feature separately. {{Value|Collectively}} combines compatible features before generating the profile path. Since FreeCAD 1.2, collective handling also supports Profile Edges selections and whole-model perimeter profiles generated from the Job model.
 * {{PropertyData|OffsetExtra}}: Extra value to stay away from final profile- good for roughing toolpath
 * {{PropertyData|Process Circles}}: Check if you want this Profile Operation to also be applied to cylindrical holes, ''which normally get drilled''.
 * {{PropertyData|Process Holes}}: Check if this Profile Operation should also process holes in the base geometry. '''Note''' that this does not include cylindrical holes.

--- a/wiki/CAM_Profile.wikitext
+++ b/wiki/CAM_Profile.wikitext
@@ -142,7 +142,7 @@ Note: It is suggested that you do not edit the Placement property of path operat
 * {{PropertyData|Direction}}: The direction that the tool path should go around the part: Clockwise[CW] or Counterclockwise[CCW]
 * {{PropertyData|Expand Profile}}: Extend the profile clearing beyond the Extra Offset.
 * {{PropertyData|Expand Profile Step Over}}: Set the stepover percentage, based on the tool's diameter.
-* {{PropertyData|Handle Multiple Features}}: Choose how to process multiple Base Geometry features. {{Value|Individually}} processes each feature separately. {{Value|Collectively}} combines compatible features before generating the profile path. Since FreeCAD 1.2, {{Value|Collectively}} also supports Profile Edges selections and whole-model perimeter profiles.
+* {{PropertyData|Handle Multiple Features}}: Choose how to process multiple Base Geometry features. {{Value|Individually}} processes each feature separately. {{Value|Collectively}} combines compatible features before generating the profile path. {{Version|1.2}}: {{Value|Collectively}} also supports Profile Edges selections and whole-model perimeter profiles.
 * {{PropertyData|OffsetExtra}}: Extra value to stay away from final profile- good for roughing toolpath
 * {{PropertyData|Process Circles}}: Check if you want this Profile Operation to also be applied to cylindrical holes, ''which normally get drilled''.
 * {{PropertyData|Process Holes}}: Check if this Profile Operation should also process holes in the base geometry. '''Note''' that this does not include cylindrical holes.


### PR DESCRIPTION
## Summary
- document FreeCAD 1.2 collective multiple-feature handling for CAM Profile
- clarify Individually vs Collectively behavior
- note collective handling for Profile Edges and whole-model perimeter profiles from the Job model

## Source
- FreeCAD/FreeCAD#26867

## Validation
- git diff --check
- checked duplicate translation markers in wiki/CAM_Profile.wikitext
- checked translate tag balance: 4 open / 4 close

Part of #25.