### PR TITLE
[codex] Document CAM Job 1.2 dialog updates

### DIFF
--- a/wiki/CAM_Job.wikitext
+++ b/wiki/CAM_Job.wikitext
@@ -40,7 +40,7 @@ The [[Image:CAM_Job.svg|24px]] [[CAM_Job|CAM Job]] command creates a new Job obj
 #* Use the keyboard shortcut: {{KEY|P}} then {{KEY|J}}.
 
 <!--T:6-->
-The Job GUI dialog box has horizontally aligned tabs such as {{MenuCommand|General}}, {{MenuCommand|Output}}, {{MenuCommand|Setup}}, {{MenuCommand|Tools}}, {{MenuCommand|Workplan}} and, in FreeCAD 1.2 and later, {{MenuCommand|Advanced}}. The user can at any time utilize the {{Button|OK}} or {{Button|Cancel}} options within the dialog.
+The Job GUI dialog box has horizontally aligned tabs such as {{MenuCommand|General}}, {{MenuCommand|Output}}, {{MenuCommand|Setup}}, {{MenuCommand|Tools}}, {{MenuCommand|Workplan}} and {{MenuCommand|Advanced}}. The user can at any time utilize the {{Button|OK}} or {{Button|Cancel}} options within the dialog.
 
 ==General== <!--T:7-->
 
@@ -52,8 +52,8 @@ The Job GUI dialog box has horizontally aligned tabs such as {{MenuCommand|Gener
 * '''Label''': The label of the Job as displayed in the Tree View.
 * '''Model''': The Base Object which defines by its shape the paths of the job. If it is a Part Design object, it is usually the Body you select here. If you have an element selected in the tree ''before'' you click the "Add Job" icon that element is already entered here. You can change it by selecting a different element from the dropdown menu.
 * '''Description''': You can add some notes to the job here. Notes are only for your information and have no effect on the path.
-* '''Document Units''': In FreeCAD 1.2 and later, the New Job dialog includes a unit schema selector. The selected schema is applied to the document when the dialog is accepted.
-* '''Machine''': In FreeCAD 1.2 and later, a machine configuration can be selected on the General tab. A new machine can also be created from this tab without opening the CAM asset preferences first.
+* '''Document Units''': Since FreeCAD 1.2, selects the unit schema applied to the document when the dialog is accepted.
+* '''Machine''': Since FreeCAD 1.2, selects a machine configuration. A new machine can also be created from this tab.
 
 == Output == <!--T:10-->
 
@@ -84,7 +84,7 @@ The Job GUI dialog box has horizontally aligned tabs such as {{MenuCommand|Gener
 * '''Alignment''': select a Vertex to set origin or move Base or Stock
 
 <!--T:27-->
-In FreeCAD 1.2 and later, the stock numeric inputs are unit-aware and follow the document unit schema. The former {{MenuCommand|Set}} group is named {{MenuCommand|Origin & Orientation}}, and a picking toggle can switch vertex selection between the Stock and the underlying Model when they overlap.
+Since FreeCAD 1.2, stock numeric inputs follow the document unit schema. The former {{MenuCommand|Set}} group is named {{MenuCommand|Origin & Orientation}}. A picking toggle can switch vertex selection between overlapping Stock and Model geometry.
 
 ==Tools== <!--T:16-->
 
@@ -113,7 +113,7 @@ If you have a job that contains more than one path operation, you can determine 
 ==Advanced== <!--T:28-->
 
 <!--T:29-->
-In FreeCAD 1.2 and later, the former {{MenuCommand|Op Defaults}} tab is named {{MenuCommand|Advanced}}. Operation defaults are available as a sub-tab there.
+Since FreeCAD 1.2, the former {{MenuCommand|Op Defaults}} tab is named {{MenuCommand|Advanced}}. Operation defaults are available as a sub-tab there.
 
 
 <!--T:26-->

--- a/wiki/CAM_Job.wikitext
+++ b/wiki/CAM_Job.wikitext
@@ -40,7 +40,7 @@ The [[Image:CAM_Job.svg|24px]] [[CAM_Job|CAM Job]] command creates a new Job obj
 #* Use the keyboard shortcut: {{KEY|P}} then {{KEY|J}}.
 
 <!--T:6-->
-The Job GUI dialog box has five horizontally aligned tabs: {{MenuCommand|General}}, {{MenuCommand|Output}}, {{MenuCommand|Setup}}, {{MenuCommand|Tools}}, and {{MenuCommand|Workplan}}. The user can at any time utilize the {{Button|OK}} or {{Button|Cancel}} options within the dialog.
+The Job GUI dialog box has horizontally aligned tabs such as {{MenuCommand|General}}, {{MenuCommand|Output}}, {{MenuCommand|Setup}}, {{MenuCommand|Tools}}, {{MenuCommand|Workplan}} and, in FreeCAD 1.2 and later, {{MenuCommand|Advanced}}. The user can at any time utilize the {{Button|OK}} or {{Button|Cancel}} options within the dialog.
 
 ==General== <!--T:7-->
 
@@ -52,6 +52,8 @@ The Job GUI dialog box has five horizontally aligned tabs: {{MenuCommand|General
 * '''Label''': The label of the Job as displayed in the Tree View.
 * '''Model''': The Base Object which defines by its shape the paths of the job. If it is a Part Design object, it is usually the Body you select here. If you have an element selected in the tree ''before'' you click the "Add Job" icon that element is already entered here. You can change it by selecting a different element from the dropdown menu.
 * '''Description''': You can add some notes to the job here. Notes are only for your information and have no effect on the path.
+* '''Document Units''': In FreeCAD 1.2 and later, the New Job dialog includes a unit schema selector. The selected schema is applied to the document when the dialog is accepted.
+* '''Machine''': In FreeCAD 1.2 and later, a machine configuration can be selected on the General tab. A new machine can also be created from this tab without opening the CAM asset preferences first.
 
 == Output == <!--T:10-->
 
@@ -69,7 +71,6 @@ The Job GUI dialog box has five horizontally aligned tabs: {{MenuCommand|General
 <!--T:24-->
 * '''Processor''': Select the [[CAM_Post|postprocessor]] for your machine.
 * '''Arguments''': Add arguments for the [[CAM_Post|postprocessor]] as needed.
-* '''Machine''': Optionally select a machine configuration. When a machine is selected, it defines the postprocessor and related output settings for the job.
 
 ==Setup== <!--T:13-->
 
@@ -81,6 +82,9 @@ The Job GUI dialog box has five horizontally aligned tabs: {{MenuCommand|General
 * '''Stock''': set the size and shape of the raw material. 
 * '''Orientation''': Selected Edge or Face is used to orient Base or Stock accordingly.
 * '''Alignment''': select a Vertex to set origin or move Base or Stock
+
+<!--T:27-->
+In FreeCAD 1.2 and later, the stock numeric inputs are unit-aware and follow the document unit schema. The former {{MenuCommand|Set}} group is named {{MenuCommand|Origin & Orientation}}, and a picking toggle can switch vertex selection between the Stock and the underlying Model when they overlap.
 
 ==Tools== <!--T:16-->
 
@@ -105,6 +109,11 @@ You can delete the default tool if you have your own tool added.
 
 <!--T:23-->
 If you have a job that contains more than one path operation, you can determine in which order the operations should be done. To reorder, select an operation and push the up or down button.
+
+==Advanced== <!--T:28-->
+
+<!--T:29-->
+In FreeCAD 1.2 and later, the former {{MenuCommand|Op Defaults}} tab is named {{MenuCommand|Advanced}}. Operation defaults are available as a sub-tab there.
 
 
 <!--T:26-->

--- a/wiki/CAM_Job.wikitext
+++ b/wiki/CAM_Job.wikitext
@@ -52,8 +52,8 @@ The Job GUI dialog box has horizontally aligned tabs such as {{MenuCommand|Gener
 * '''Label''': The label of the Job as displayed in the Tree View.
 * '''Model''': The Base Object which defines by its shape the paths of the job. If it is a Part Design object, it is usually the Body you select here. If you have an element selected in the tree ''before'' you click the "Add Job" icon that element is already entered here. You can change it by selecting a different element from the dropdown menu.
 * '''Description''': You can add some notes to the job here. Notes are only for your information and have no effect on the path.
-* '''Document Units''': Since FreeCAD 1.2, selects the unit schema applied to the document when the dialog is accepted.
-* '''Machine''': Since FreeCAD 1.2, selects a machine configuration. A new machine can also be created from this tab.
+* '''Document Units''': {{Version|1.2}}: selects the unit schema applied to the document when the dialog is accepted.
+* '''Machine''': {{Version|1.2}}: selects a machine configuration. A new machine can also be created from this tab.
 
 == Output == <!--T:10-->
 
@@ -84,7 +84,7 @@ The Job GUI dialog box has horizontally aligned tabs such as {{MenuCommand|Gener
 * '''Alignment''': select a Vertex to set origin or move Base or Stock
 
 <!--T:27-->
-Since FreeCAD 1.2, stock numeric inputs follow the document unit schema. The former {{MenuCommand|Set}} group is named {{MenuCommand|Origin & Orientation}}. A picking toggle can switch vertex selection between overlapping Stock and Model geometry.
+{{Version|1.2}}: stock numeric inputs follow the document unit schema. The former {{MenuCommand|Set}} group is named {{MenuCommand|Origin & Orientation}}. A picking toggle can switch vertex selection between overlapping Stock and Model geometry.
 
 ==Tools== <!--T:16-->
 
@@ -113,7 +113,7 @@ If you have a job that contains more than one path operation, you can determine 
 ==Advanced== <!--T:28-->
 
 <!--T:29-->
-Since FreeCAD 1.2, the former {{MenuCommand|Op Defaults}} tab is named {{MenuCommand|Advanced}}. Operation defaults are available as a sub-tab there.
+{{Version|1.2}}: the former {{MenuCommand|Op Defaults}} tab is named {{MenuCommand|Advanced}}. Operation defaults are available as a sub-tab there.
 
 
 <!--T:26-->


### PR DESCRIPTION
## Summary
- document FreeCAD 1.2 CAM Job dialog updates
- add Document Units and General-tab Machine notes
- note unit-aware stock inputs, Origin & Orientation, picking toggle, and Advanced tab rename

## Source
- FreeCAD/FreeCAD#29861

## Validation
- git diff --check
- checked duplicate translation markers in wiki/CAM_Job.wikitext
- checked translate tag balance: 6 open / 6 close

Part of #25.