### PR TITLE
[codex] Document CAM Pocket Shape 1.2 horizontal edges

### DIFF
--- a/wiki/CAM_Pocket_Shape.wikitext
+++ b/wiki/CAM_Pocket_Shape.wikitext
@@ -34,7 +34,7 @@ The CAM Pocket Shape object is made to be part of a [[Image:CAM_Job.svg|16px]] [
 
 <!--T:6-->
 # Select the bottom or the wall(s) of a pocket. While it is usually easier to select the bottom, the walls have to be selected when a pocket goes through all.
-# Since FreeCAD 1.2, horizontal edges can also be selected. Edges are combined into wires, and a closed horizontal wire is converted into a pocket face.
+# {{Version|1.2}}: horizontal edges can also be selected. Edges are combined into wires, and a closed horizontal wire is converted into a pocket face.
 # There are several ways to invoke the command:
 #* Press the {{Button|[[Image:CAM_Pocket_Shape.svg|16px]] [[CAM_Pocket_Shape|Pocket Shape]]}} button.
 #* Select the {{MenuCommand|CAM → [[Image:CAM_Pocket_Shape.svg|16px]] Pocket Shape}} option from the menu.

--- a/wiki/CAM_Pocket_Shape.wikitext
+++ b/wiki/CAM_Pocket_Shape.wikitext
@@ -34,6 +34,7 @@ The CAM Pocket Shape object is made to be part of a [[Image:CAM_Job.svg|16px]] [
 
 <!--T:6-->
 # Select the bottom or the wall(s) of a pocket. While it is usually easier to select the bottom, the walls have to be selected when a pocket goes through all.
+# In FreeCAD 1.2 and later, horizontal edges can also be selected. Edges are combined into wires, and a closed horizontal wire is converted into a face that can be used for the pocket.
 # There are several ways to invoke the command:
 #* Press the {{Button|[[Image:CAM_Pocket_Shape.svg|16px]] [[CAM_Pocket_Shape|Pocket Shape]]}} button.
 #* Select the {{MenuCommand|CAM → [[Image:CAM_Pocket_Shape.svg|16px]] Pocket Shape}} option from the menu.

--- a/wiki/CAM_Pocket_Shape.wikitext
+++ b/wiki/CAM_Pocket_Shape.wikitext
@@ -34,7 +34,7 @@ The CAM Pocket Shape object is made to be part of a [[Image:CAM_Job.svg|16px]] [
 
 <!--T:6-->
 # Select the bottom or the wall(s) of a pocket. While it is usually easier to select the bottom, the walls have to be selected when a pocket goes through all.
-# In FreeCAD 1.2 and later, horizontal edges can also be selected. Edges are combined into wires, and a closed horizontal wire is converted into a face that can be used for the pocket.
+# Since FreeCAD 1.2, horizontal edges can also be selected. Edges are combined into wires, and a closed horizontal wire is converted into a pocket face.
 # There are several ways to invoke the command:
 #* Press the {{Button|[[Image:CAM_Pocket_Shape.svg|16px]] [[CAM_Pocket_Shape|Pocket Shape]]}} button.
 #* Select the {{MenuCommand|CAM → [[Image:CAM_Pocket_Shape.svg|16px]] Pocket Shape}} option from the menu.


### PR DESCRIPTION
## Summary
- document FreeCAD 1.2 horizontal edge selection support for CAM Pocket Shape
- explain that selected edges are combined into wires and closed horizontal wires become pocket faces

## Source
- FreeCAD/FreeCAD#27750

## Validation
- git diff --check
- checked duplicate translation markers in wiki/CAM_Pocket_Shape.wikitext
- checked translate tag balance: 4 open / 4 close

Part of #25.