### PR TITLE
[codex] Document CAM 1.2 retract threshold controls

### DIFF
--- a/wiki/CAM_Pocket_Shape.wikitext
+++ b/wiki/CAM_Pocket_Shape.wikitext
@@ -108,8 +108,8 @@ Note: It is suggested that you do not edit the Placement property of path operat
 <!--T:40-->
 * {{PropertyData|Cut Mode}}: Specifies a CW or CCW move for the cut
 * {{PropertyData|Extra Offset}}: Extra offset to apply to the operation. Direction is operation dependent. (Extra value to stay away from final profile ''good for roughing toolpath'')
-* {{PropertyData|Keep Tool Down}}: Attempts to avoid unnecessary retractions.
 * {{PropertyData|Min Travel}}: Use 3D Sorting of Path (when multiple base geometries used).
+* {{PropertyData|Retract Threshold}}: Distance used to avoid unnecessary retractions. In FreeCAD 1.2 and later this replaces {{PropertyData|Keep Tool Down}}. A value of {{Value|0}} disables keep-tool-down behavior; a positive value allows the operation to stay down for repositioning moves within that distance.
 * {{PropertyData|Start At}}: Start pocketing at center or boundary.
 * {{PropertyData|Step Over}}: Select the horizontal step over ('''Percent''' of tool diameter: 100% = tool diameter).
 * {{PropertyData|Use Outline}}: Uses the outline of the base geometry.

--- a/wiki/CAM_Pocket_Shape.wikitext
+++ b/wiki/CAM_Pocket_Shape.wikitext
@@ -109,7 +109,7 @@ Note: It is suggested that you do not edit the Placement property of path operat
 * {{PropertyData|Cut Mode}}: Specifies a CW or CCW move for the cut
 * {{PropertyData|Extra Offset}}: Extra offset to apply to the operation. Direction is operation dependent. (Extra value to stay away from final profile ''good for roughing toolpath'')
 * {{PropertyData|Min Travel}}: Use 3D Sorting of Path (when multiple base geometries used).
-* {{PropertyData|Retract Threshold}}: Distance below which the operation can stay down for repositioning moves. A value of {{Value|0}} disables this behavior. Since FreeCAD 1.2, this replaces {{PropertyData|Keep Tool Down}}.
+* {{PropertyData|Retract Threshold}}: Distance below which the operation can stay down for repositioning moves. A value of {{Value|0}} disables this behavior. {{Version|1.2}}: This replaces {{PropertyData|Keep Tool Down}}.
 * {{PropertyData|Start At}}: Start pocketing at center or boundary.
 * {{PropertyData|Step Over}}: Select the horizontal step over ('''Percent''' of tool diameter: 100% = tool diameter).
 * {{PropertyData|Use Outline}}: Uses the outline of the base geometry.

--- a/wiki/CAM_Pocket_Shape.wikitext
+++ b/wiki/CAM_Pocket_Shape.wikitext
@@ -109,7 +109,7 @@ Note: It is suggested that you do not edit the Placement property of path operat
 * {{PropertyData|Cut Mode}}: Specifies a CW or CCW move for the cut
 * {{PropertyData|Extra Offset}}: Extra offset to apply to the operation. Direction is operation dependent. (Extra value to stay away from final profile ''good for roughing toolpath'')
 * {{PropertyData|Min Travel}}: Use 3D Sorting of Path (when multiple base geometries used).
-* {{PropertyData|Retract Threshold}}: Distance used to avoid unnecessary retractions. In FreeCAD 1.2 and later this replaces {{PropertyData|Keep Tool Down}}. A value of {{Value|0}} disables keep-tool-down behavior; a positive value allows the operation to stay down for repositioning moves within that distance.
+* {{PropertyData|Retract Threshold}}: Distance below which the operation can stay down for repositioning moves. A value of {{Value|0}} disables this behavior. Since FreeCAD 1.2, this replaces {{PropertyData|Keep Tool Down}}.
 * {{PropertyData|Start At}}: Start pocketing at center or boundary.
 * {{PropertyData|Step Over}}: Select the horizontal step over ('''Percent''' of tool diameter: 100% = tool diameter).
 * {{PropertyData|Use Outline}}: Uses the outline of the base geometry.

--- a/wiki/CAM_Profile.wikitext
+++ b/wiki/CAM_Profile.wikitext
@@ -147,6 +147,7 @@ Note: It is suggested that you do not edit the Placement property of path operat
 * {{PropertyData|Process Circles}}: Check if you want this Profile Operation to also be applied to cylindrical holes, ''which normally get drilled''.
 * {{PropertyData|Process Holes}}: Check if this Profile Operation should also process holes in the base geometry. '''Note''' that this does not include cylindrical holes.
 * {{PropertyData|Process Perimeter}}: Check if this Profile Operation should also process the outside perimeter of the base geometry shapes
+* {{PropertyData|Retract Threshold}}: Distance used to avoid unnecessary retractions. A value of {{Value|0}} disables keep-tool-down behavior; a positive value allows the operation to stay down for repositioning moves within that distance.
 * {{PropertyData|Side}}: (Cut Side) Side of edge that tool should cut. This only matters if ''Use Compensation'' is True (checked).
 * {{PropertyData|Use Compensation}}: If checked, the Profile Operation is offset by the tool radius. The offset direction is determined by the Cut Side.
 * {{PropertyData|SortingMode}}: Controls how multiple selected features are ordered. {{Value|Automatic}} uses the default path sorting. {{Value|Manual}} follows the order in which the features were selected.

--- a/wiki/CAM_Profile.wikitext
+++ b/wiki/CAM_Profile.wikitext
@@ -147,7 +147,7 @@ Note: It is suggested that you do not edit the Placement property of path operat
 * {{PropertyData|Process Circles}}: Check if you want this Profile Operation to also be applied to cylindrical holes, ''which normally get drilled''.
 * {{PropertyData|Process Holes}}: Check if this Profile Operation should also process holes in the base geometry. '''Note''' that this does not include cylindrical holes.
 * {{PropertyData|Process Perimeter}}: Check if this Profile Operation should also process the outside perimeter of the base geometry shapes
-* {{PropertyData|Retract Threshold}}: Distance used to avoid unnecessary retractions. A value of {{Value|0}} disables keep-tool-down behavior; a positive value allows the operation to stay down for repositioning moves within that distance.
+* {{PropertyData|Retract Threshold}}: Distance below which the operation can stay down for repositioning moves. A value of {{Value|0}} disables this behavior.
 * {{PropertyData|Side}}: (Cut Side) Side of edge that tool should cut. This only matters if ''Use Compensation'' is True (checked).
 * {{PropertyData|Use Compensation}}: If checked, the Profile Operation is offset by the tool radius. The offset direction is determined by the Cut Side.
 * {{PropertyData|SortingMode}}: Controls how multiple selected features are ordered. {{Value|Automatic}} uses the default path sorting. {{Value|Manual}} follows the order in which the features were selected.


### PR DESCRIPTION
## Summary
- document FreeCAD 1.2 Retract Threshold for CAM Profile and Pocket Shape
- replace the stale Pocket Shape Keep Tool Down property entry
- explain 0 vs positive threshold behavior for avoiding retractions

## Source
- FreeCAD/FreeCAD#21738

## Validation
- git diff --check
- checked duplicate translation markers in wiki/CAM_Profile.wikitext and wiki/CAM_Pocket_Shape.wikitext
- checked translate tag balance: 8 open / 8 close across both files

Part of #25.