### PR TITLE
[codex] Document CAM circular hole base 1.2 details

### DIFF
--- a/wiki/CAM_Drilling.wikitext
+++ b/wiki/CAM_Drilling.wikitext
@@ -50,7 +50,7 @@ The [[Image:CAM_Drilling.svg|16px]] [[CAM_Drilling|Drilling]] tool generates a d
 # Press the {{Button|OK}} button to generate the drilling path(s).
 
 <!--T:46-->
-In FreeCAD 1.2 and later, the circular-hole Base Geometry list shows each hole's position and, for cylindrical faces, whether the hole is blind. Other shapes show {{Value|---}} for the blind state.
+{{Version|1.2}}: The circular-hole Base Geometry list shows each hole's position. For cylindrical faces it also shows whether the hole is blind; other shapes show {{Value|---}}.
 
 ==Notes== <!--T:13-->
 

--- a/wiki/CAM_Drilling.wikitext
+++ b/wiki/CAM_Drilling.wikitext
@@ -49,6 +49,9 @@ The [[Image:CAM_Drilling.svg|16px]] [[CAM_Drilling|Drilling]] tool generates a d
 # In the {{MenuCommand|Heights}} section check, and if required adjust, the {{MenuCommand|Safe Height}} and the {{MenuCommand|Clearance Height}}.
 # Press the {{Button|OK}} button to generate the drilling path(s).
 
+<!--T:46-->
+In FreeCAD 1.2 and later, the circular-hole Base Geometry list shows each hole's position and, for cylindrical faces, whether the hole is blind. Other shapes show {{Value|---}} for the blind state.
+
 ==Notes== <!--T:13-->
 
 <!--T:14-->

--- a/wiki/CAM_Helix.wikitext
+++ b/wiki/CAM_Helix.wikitext
@@ -32,6 +32,10 @@ The [[Image:CAM_Helix.svg|24px]] [[CAM_Helix|CAM Helix]] command appends a helic
 * You will be prompted with a "Choose a Tool Controller" pop-up window to select a Tool Controller. In older versions, in the {{KEY|[[Image:CAM_Helix.svg|24px]]}} Operation tab, choose a Tool controller and confirm by pressing {{Button|Apply}}.
 * Open the Base Geometry tab. All available holes compatible with the Helix tool in the Job Model will be selectable for processing. In the [[3D_View|3D View]] select the holes by their edge or wall face and add them with the {{Button|Add}} button. Check that they appear in the list. Confirm that the list matches the holes that are intended for processing.
 * To remove holes select them in the list and press the {{Button|Remove}} button.
+
+<!--T:29-->
+{{Version|1.2}}: The circular-hole Base Geometry list shows each hole's position. For cylindrical faces it also shows whether the hole is blind; other shapes show {{Value|---}}.
+
 * Ensure Start Depth, Final Depth and the helix pitch and ramp limits are correct, and adjust if not.
 * Ensure Safe and Clearance Heights are correct.
 * In the Operation tab, specify the helix Starting surface (outside/inside), cutting Direction (climb/conventional), and Step Over percentage.


### PR DESCRIPTION
## Summary
- document FreeCAD 1.2 circular-hole Base Geometry list details for Drilling and Helix
- note position display and blind-state display for cylindrical faces

## Source
- FreeCAD/FreeCAD#27869

## Validation
- git diff --check
- checked duplicate translation markers in wiki/CAM_Drilling.wikitext and wiki/CAM_Helix.wikitext
- checked translate tag balance: 5 open / 5 close across both files

Part of #25.