### PR TITLE
[codex] Document CAM selected-operation postprocessing

### DIFF
--- a/wiki/CAM_Post.wikitext
+++ b/wiki/CAM_Post.wikitext
@@ -85,7 +85,7 @@ If only one CNC machine is used, or if all CNC machines share a common Postproce
 # Confirm the {{MenuCommand|Output File}} name and directory
 
 <!--T:31-->
-In FreeCAD 1.2 and later, one or more Operations inside a Job can be selected and exported with {{MenuCommand|Post Process Selected}}. This postprocesses only the selected Operations, and can also use Operations selected inside a Dressup.
+Since FreeCAD 1.2, {{MenuCommand|Post Process Selected}} exports only the selected Operations in a Job. Operations selected inside a Dressup can also be used.
 
 ==Options== <!--T:6-->
 

--- a/wiki/CAM_Post.wikitext
+++ b/wiki/CAM_Post.wikitext
@@ -84,6 +84,9 @@ If only one CNC machine is used, or if all CNC machines share a common Postproce
 #* Use the keyboard shortcut: {{KEY|P}} then {{KEY|P}}.
 # Confirm the {{MenuCommand|Output File}} name and directory
 
+<!--T:31-->
+In FreeCAD 1.2 and later, one or more Operations inside a Job can be selected and exported with {{MenuCommand|Post Process Selected}}. This postprocesses only the selected Operations, and can also use Operations selected inside a Dressup.
+
 ==Options== <!--T:6-->
 
 <!--T:7-->

--- a/wiki/CAM_Post.wikitext
+++ b/wiki/CAM_Post.wikitext
@@ -85,7 +85,7 @@ If only one CNC machine is used, or if all CNC machines share a common Postproce
 # Confirm the {{MenuCommand|Output File}} name and directory
 
 <!--T:31-->
-Since FreeCAD 1.2, {{MenuCommand|Post Process Selected}} exports only the selected Operations in a Job. Operations selected inside a Dressup can also be used.
+{{Version|1.2}}: {{MenuCommand|Post Process Selected}} exports only the selected Operations in a Job. Operations selected inside a Dressup can also be used.
 
 ==Options== <!--T:6-->
 


### PR DESCRIPTION
## Summary
- document FreeCAD 1.2 Post Process Selected usage
- explain exporting only selected Operations from a Job
- note support for Operations selected inside a Dressup

## Source
- FreeCAD/FreeCAD#22764

## Validation
- git diff --check
- checked duplicate translation markers in wiki/CAM_Post.wikitext
- checked translate tag balance: 1 open / 1 close

Part of #25.