### PR TITLE
[codex] Document CAM LeadInOut 1.2 LineZFollow style

### DIFF
--- a/wiki/CAM_DressupLeadInOut.wikitext
+++ b/wiki/CAM_DressupLeadInOut.wikitext
@@ -40,8 +40,6 @@ The [[Image:CAM_DressupLeadInOut.svg|24px]] [[CAM_DressupLeadInOut|CAM DressupLe
 * '''Lead in''': Controls the entry move added before the main cutting path.
 * '''Lead out''': Controls the exit move added after the main cutting path.
 * '''Feed rate''': {{Version|1.2}} The corresponding lead-in and lead-out moves use the feed rates defined for these moves in the tool controller. By default these follow the horizontal feed rate.
-
-<!--T:20-->
 * '''LineZFollow''': {{Version|1.2}} A straight-segment Z-following style. It requires less computation than {{Value|ArcZFollow}} and can be useful when a closed path is taken multiple times.
 
 ==Limitations== <!--T:8-->

--- a/wiki/CAM_DressupLeadInOut.wikitext
+++ b/wiki/CAM_DressupLeadInOut.wikitext
@@ -41,6 +41,9 @@ The [[Image:CAM_DressupLeadInOut.svg|24px]] [[CAM_DressupLeadInOut|CAM DressupLe
 * '''Lead out''': Controls the exit move added after the main cutting path.
 * '''Feed rate''': {{Version|1.2}} The corresponding lead-in and lead-out moves use the feed rates defined for these moves in the tool controller. By default these follow the horizontal feed rate.
 
+<!--T:20-->
+* '''LineZFollow''': {{Version|1.2}} A lead-in/out style that can replace {{Value|ArcZFollow}}. It follows the Z change with straight segments, requires less computation, and can be useful when a closed path is taken multiple times.
+
 ==Limitations== <!--T:8-->
 
 <!--T:19-->

--- a/wiki/CAM_DressupLeadInOut.wikitext
+++ b/wiki/CAM_DressupLeadInOut.wikitext
@@ -42,7 +42,7 @@ The [[Image:CAM_DressupLeadInOut.svg|24px]] [[CAM_DressupLeadInOut|CAM DressupLe
 * '''Feed rate''': {{Version|1.2}} The corresponding lead-in and lead-out moves use the feed rates defined for these moves in the tool controller. By default these follow the horizontal feed rate.
 
 <!--T:20-->
-* '''LineZFollow''': {{Version|1.2}} A lead-in/out style that can replace {{Value|ArcZFollow}}. It follows the Z change with straight segments, requires less computation, and can be useful when a closed path is taken multiple times.
+* '''LineZFollow''': {{Version|1.2}} A straight-segment Z-following style. It requires less computation than {{Value|ArcZFollow}} and can be useful when a closed path is taken multiple times.
 
 ==Limitations== <!--T:8-->
 


### PR DESCRIPTION
## Summary
- document the FreeCAD 1.2 LineZFollow lead-in/out style
- note its relationship to ArcZFollow and straight-segment Z following behavior

## Source
- FreeCAD/FreeCAD#27986

## Validation
- git diff --check
- checked duplicate translation markers in wiki/CAM_DressupLeadInOut.wikitext
- checked translate tag balance: 2 open / 2 close

Part of #25.