### PR TITLE
[codex] Document CAM 1.2 machine library preferences

### DIFF
--- a/wiki/CAM_Preferences.wikitext
+++ b/wiki/CAM_Preferences.wikitext
@@ -53,7 +53,7 @@ There are four sections: General, Post processor, Setup and Tools.
 <translate>
 
 <!--T:21-->
-Since FreeCAD 1.2, machine assets can be managed from the CAM preferences. The Machine Library and Machine Editor create and edit {{FileName|*.fcm}} machine configuration files used by machine-based postprocessing.
+{{Version|1.2}}: machine assets can be managed from the CAM preferences. The Machine Library and Machine Editor create and edit {{FileName|*.fcm}} machine configuration files used by machine-based postprocessing.
 
 ==Dressups== <!--T:5-->
 

--- a/wiki/CAM_Preferences.wikitext
+++ b/wiki/CAM_Preferences.wikitext
@@ -51,8 +51,6 @@ There are four sections: General, Post processor, Setup and Tools.
 </translate>
 [[File:Preference_Path_Tab_01_04_V020.png]]
 <translate>
-
-<!--T:21-->
 {{Version|1.2}}: machine assets can be managed from the CAM preferences. The Machine Library and Machine Editor create and edit {{FileName|*.fcm}} machine configuration files used by machine-based postprocessing.
 
 ==Dressups== <!--T:5-->

--- a/wiki/CAM_Preferences.wikitext
+++ b/wiki/CAM_Preferences.wikitext
@@ -52,6 +52,9 @@ There are four sections: General, Post processor, Setup and Tools.
 [[File:Preference_Path_Tab_01_04_V020.png]]
 <translate>
 
+<!--T:21-->
+Since FreeCAD 1.2, machine assets can be managed from the CAM preferences. The Machine Library and Machine Editor allow creating and editing {{FileName|*.fcm}} machine configuration files. Machine definitions can store machine type, units, axis and spindle information, and postprocessor defaults used by machine-based postprocessing.
+
 ==Dressups== <!--T:5-->
 
 </translate>

--- a/wiki/CAM_Preferences.wikitext
+++ b/wiki/CAM_Preferences.wikitext
@@ -53,7 +53,7 @@ There are four sections: General, Post processor, Setup and Tools.
 <translate>
 
 <!--T:21-->
-Since FreeCAD 1.2, machine assets can be managed from the CAM preferences. The Machine Library and Machine Editor allow creating and editing {{FileName|*.fcm}} machine configuration files. Machine definitions can store machine type, units, axis and spindle information, and postprocessor defaults used by machine-based postprocessing.
+Since FreeCAD 1.2, machine assets can be managed from the CAM preferences. The Machine Library and Machine Editor create and edit {{FileName|*.fcm}} machine configuration files used by machine-based postprocessing.
 
 ==Dressups== <!--T:5-->
 


### PR DESCRIPTION
## Summary
- document the FreeCAD 1.2 Machine Library and Machine Editor in CAM preferences
- note .fcm machine configuration files and machine-based postprocessing defaults

## Source
- FreeCAD/FreeCAD#26533
- FreeCAD/FreeCAD#27507

## Validation
- git diff --check
- checked duplicate translation markers in wiki/CAM_Preferences.wikitext
- checked translate tag balance: 9 open / 9 close

Part of #25.