### PR TITLE
[codex] Add CAM Rotary Surface operation page

### DIFF
--- a/wiki/CAM_RotarySurface.wikitext
+++ b/wiki/CAM_RotarySurface.wikitext
@@ -1,0 +1,117 @@
+<languages/>
+<translate>
+
+<!--T:1-->
+{{VeryImportantMessage|This is an unfinished experimental feature. See [[CAM_experimental|Enable Experimental Features]].}}
+
+</translate>
+{{UnfinishedDocu{{#translation:}}}}
+<translate>
+
+<!--T:2-->
+{{Docnav
+|[[CAM_Surface|3D Surface]]
+|[[CAM_Waterline|Waterline]]
+|[[CAM_Workbench|CAM]]
+|IconL=CAM_Surface.svg
+|IconR=CAM_Waterline.svg
+|IconC=Workbench_CAM.svg
+}}
+
+<!--T:3-->
+{{GuiCommand
+|Name=CAM RotarySurface
+|MenuLocation=CAM → Rotary Surface
+|Workbenches=[[CAM_Workbench|CAM]]
+|Version=1.2
+}}
+
+==Description== <!--T:4-->
+
+<!--T:5-->
+The [[Image:CAM_RotarySurface.svg|24px]] [[CAM_RotarySurface|CAM RotarySurface]] command creates a continuous 4-axis rotary surfacing operation for a part mounted on a single rotary axis. The operation supports Spiral, Parallel, and Rings cut patterns and emits continuous XYZA toolpaths.
+
+<!--T:6-->
+The command uses [[OpenCamLib|OpenCamLib]] and is available when OCL-dependent advanced features and experimental CAM features are enabled.
+
+<!--T:7-->
+'''Note:''' In order to use the Rotary Surface operation you must:
+# Properly install [[OpenCamLib|OpenCamLib]].
+# Enable [[CAM_experimental|Experimental Features]] for the CAM Workbench.
+# Check {{MenuCommand|Edit → Preferences → CAM → Advanced → Enable OCL dependent features}}.
+# Create a [[CAM_Job|CAM Job]] that has Cylinder stock and a machine configuration with at least one rotary axis.
+
+==Usage== <!--T:8-->
+
+<!--T:9-->
+# Create or activate a [[CAM_Job|CAM Job]].
+# Configure the Job with Cylinder stock aligned to the rotary axis.
+# Configure the Job machine with at least one rotary axis.
+# Optionally select faces on the Job model if the operation should be limited to the selected region.
+# There are several ways to invoke the command:
+#* Press the {{Button|[[Image:CAM_RotarySurface.svg|16px]] [[CAM_RotarySurface|Rotary Surface]]}} button if it is visible in the CAM toolbar.
+#* Select the {{MenuCommand|CAM → Rotary Surface}} option from the menu.
+# Select the tool controller for the operation.
+# Adjust the rotary settings in the task panel.
+# Optionally press the {{Button|Apply}} button to preview the operation with the current settings.
+# Click the {{Button|OK}} button or the {{Button|Cancel}} button to create or cancel the operation.
+
+==Notes== <!--T:10-->
+
+<!--T:11-->
+* {{Version|1.2}} The rotary axis must be aligned with world X or world Y. A rotary axis along world Z is not supported.
+* {{Version|1.2}} The operation requires Cylinder stock, and the cylinder axis must be aligned with the Job machine rotary axis.
+* {{Version|1.2}} The Job must contain at least one model object.
+* {{Version|1.2}} The operation warns if the part center is noticeably off the rotary axis.
+* Ball-end or bull-nose cutters are better suited for rotary surfacing than flat cutters.
+* {{PropertyData|BoundaryFromFaces}} can restrict the toolpath to the projected axial and angular extents of selected faces.
+
+==Properties== <!--T:12-->
+
+<!--T:13-->
+''' ''Note'' ''': Not all of these Properties are available in the Task Window Editor. Some are only accessible in the Data tab of the Properties View panel for this Operation.
+
+<!--T:14-->
+{{TitleProperty|Rotary}}
+
+<!--T:15-->
+* {{PropertyData|StartX}}: Axial start position along the rotary axis.
+* {{PropertyData|StopX}}: Axial stop position along the rotary axis. The value must be greater than {{PropertyData|StartX}}.
+* {{PropertyData|StartAngle}}: Angular start position in degrees.
+* {{PropertyData|StopAngle}}: Angular stop position in degrees.
+* {{PropertyData|StepOver}}: Axial advance per full revolution. For Spiral this is the pitch, for Rings this is the distance between rings, and for Parallel it also drives the angular stepover.
+* {{PropertyData|AngularResolution}}: Angular spacing between sampled toolpath points. Smaller values create smoother paths and more G-code.
+* {{PropertyData|RadialStockToLeave}}: Radial finish allowance left on the surface.
+* {{PropertyData|CutMode}}: The cutting direction. The options are {{Value|Climb}} and {{Value|Conventional}}.
+* {{PropertyData|CutPattern}}: The toolpath pattern. The options are {{Value|Spiral}}, {{Value|Parallel}}, and {{Value|Rings}}.
+* {{PropertyData|FeedMode}}: The feed-rate strategy. {{Value|AxialOnly}} emits a constant feed from the tool controller. {{Value|SurfaceSpeed}} scales the feed to maintain the requested surface speed where possible.
+* {{PropertyData|MaxFeed}}: Upper cap on the effective rotary feed rate. A value of {{Value|0}} uses the fallback maximum from the operation.
+* {{PropertyData|BoundaryFromFaces}}: If {{TRUE}} and base geometry is selected, restricts the toolpath to the projected axial and angular extents of the selected faces.
+
+<!--T:16-->
+{{TitleProperty|Mesh}}
+
+<!--T:17-->
+* {{PropertyData|LinearDeflection}}: Tessellation linear deflection. Smaller values create a finer mesh.
+* {{PropertyData|AngularDeflection}}: Tessellation angular deflection. Smaller values create a finer mesh.
+
+==Limitations== <!--T:18-->
+
+<!--T:19-->
+* {{Version|1.2}} Only the first rotary axis declared by the Job machine is used.
+* {{Version|1.2}} Selected-face boundary restriction is not wrap-aware when the selected region crosses the 0/360 degree boundary.
+* The built-in path simulator may not fully represent machine-specific 4-axis rotary motion. Inspect generated G-code with suitable machine-aware tools before cutting material.
+
+<!--T:20-->
+{{Docnav
+|[[CAM_Surface|3D Surface]]
+|[[CAM_Waterline|Waterline]]
+|[[CAM_Workbench|CAM]]
+|IconL=CAM_Surface.svg
+|IconR=CAM_Waterline.svg
+|IconC=Workbench_CAM.svg
+}}
+
+</translate>
+{{CAM_Tools_navi{{#translation:}}}}
+{{Userdocnavi{{#translation:}}}}

--- a/wiki/CAM_RotarySurface.wikitext
+++ b/wiki/CAM_RotarySurface.wikitext
@@ -29,14 +29,14 @@
 ==Description== <!--T:4-->
 
 <!--T:5-->
-The [[Image:CAM_RotarySurface.svg|24px]] [[CAM_RotarySurface|CAM RotarySurface]] command creates a continuous 4-axis rotary surfacing operation for a part mounted on a single rotary axis. The operation supports Spiral, Parallel, and Rings cut patterns and emits continuous XYZA toolpaths.
+The [[Image:CAM_RotarySurface.svg|24px]] [[CAM_RotarySurface|CAM RotarySurface]] command creates a continuous 4-axis rotary surfacing operation for a part mounted on a single rotary axis. It supports Spiral, Parallel, and Rings cut patterns and emits continuous XYZA toolpaths.
 
 <!--T:6-->
 The command uses [[OpenCamLib|OpenCamLib]] and is available when OCL-dependent advanced features and experimental CAM features are enabled.
 
 <!--T:7-->
-'''Note:''' In order to use the Rotary Surface operation you must:
-# Properly install [[OpenCamLib|OpenCamLib]].
+'''Note:''' To use the Rotary Surface operation:
+# Install [[OpenCamLib|OpenCamLib]].
 # Enable [[CAM_experimental|Experimental Features]] for the CAM Workbench.
 # Check {{MenuCommand|Edit → Preferences → CAM → Advanced → Enable OCL dependent features}}.
 # Create a [[CAM_Job|CAM Job]] that has Cylinder stock and a machine configuration with at least one rotary axis.
@@ -59,10 +59,10 @@ The command uses [[OpenCamLib|OpenCamLib]] and is available when OCL-dependent a
 ==Notes== <!--T:10-->
 
 <!--T:11-->
-* {{Version|1.2}} The rotary axis must be aligned with world X or world Y. A rotary axis along world Z is not supported.
-* {{Version|1.2}} The operation requires Cylinder stock, and the cylinder axis must be aligned with the Job machine rotary axis.
-* {{Version|1.2}} The Job must contain at least one model object.
-* {{Version|1.2}} The operation warns if the part center is noticeably off the rotary axis.
+* The rotary axis must be aligned with world X or world Y. A rotary axis along world Z is not supported.
+* The operation requires Cylinder stock, and the cylinder axis must be aligned with the Job machine rotary axis.
+* The Job must contain at least one model object.
+* The operation warns if the part center is noticeably off the rotary axis.
 * Ball-end or bull-nose cutters are better suited for rotary surfacing than flat cutters.
 * {{PropertyData|BoundaryFromFaces}} can restrict the toolpath to the projected axial and angular extents of selected faces.
 
@@ -79,7 +79,7 @@ The command uses [[OpenCamLib|OpenCamLib]] and is available when OCL-dependent a
 * {{PropertyData|StopX}}: Axial stop position along the rotary axis. The value must be greater than {{PropertyData|StartX}}.
 * {{PropertyData|StartAngle}}: Angular start position in degrees.
 * {{PropertyData|StopAngle}}: Angular stop position in degrees.
-* {{PropertyData|StepOver}}: Axial advance per full revolution. For Spiral this is the pitch, for Rings this is the distance between rings, and for Parallel it also drives the angular stepover.
+* {{PropertyData|StepOver}}: Axial advance per full revolution. This is the pitch for Spiral, the ring spacing for Rings, and also controls angular stepover for Parallel.
 * {{PropertyData|AngularResolution}}: Angular spacing between sampled toolpath points. Smaller values create smoother paths and more G-code.
 * {{PropertyData|RadialStockToLeave}}: Radial finish allowance left on the surface.
 * {{PropertyData|CutMode}}: The cutting direction. The options are {{Value|Climb}} and {{Value|Conventional}}.
@@ -98,8 +98,8 @@ The command uses [[OpenCamLib|OpenCamLib]] and is available when OCL-dependent a
 ==Limitations== <!--T:18-->
 
 <!--T:19-->
-* {{Version|1.2}} Only the first rotary axis declared by the Job machine is used.
-* {{Version|1.2}} Selected-face boundary restriction is not wrap-aware when the selected region crosses the 0/360 degree boundary.
+* Only the first rotary axis declared by the Job machine is used.
+* Selected-face boundary restriction is not wrap-aware when the selected region crosses the 0/360 degree boundary.
 * The built-in path simulator may not fully represent machine-specific 4-axis rotary motion. Inspect generated G-code with suitable machine-aware tools before cutting material.
 
 <!--T:20-->

--- a/wiki/CAM_Workbench.wikitext
+++ b/wiki/CAM_Workbench.wikitext
@@ -180,6 +180,9 @@ Some commands are experimental and not available by default. To enable them see 
 <!--T:74-->
 * [[Image:CAM_Surface.svg|32px]] [[CAM_Surface|3D Surface]]: Creates a path for a 3D surface. [[CAM_experimental|{{Emphasis|Experimental}}]].
 
+<!--T:142-->
+* [[Image:CAM_RotarySurface.svg|32px]] [[CAM_RotarySurface|Rotary Surface]]: Creates a continuous 4-axis rotary surfacing path. [[CAM_experimental|{{Emphasis|Experimental}}]].
+
 <!--T:106-->
 * [[Image:CAM_Waterline.svg|32px]] [[CAM_Waterline|Waterline]]: Creates a waterline path for a 3D surface. [[CAM_experimental|{{Emphasis|Experimental}}]].
 

--- a/wiki/File/CAM_RotarySurface.svg
+++ b/wiki/File/CAM_RotarySurface.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" version="1.1">
+  <title>CAM Rotary Surface</title>
+  <defs>
+    <linearGradient id="cyl" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#9ec5ff"/>
+      <stop offset="0.5" stop-color="#3674d8"/>
+      <stop offset="1" stop-color="#1a3a78"/>
+    </linearGradient>
+  </defs>
+  <!-- Cylindrical part on horizontal rotary axis -->
+  <ellipse cx="14" cy="32" rx="4" ry="14" fill="#1a3a78" stroke="#0a1a3a" stroke-width="1"/>
+  <rect x="14" y="18" width="36" height="28" fill="url(#cyl)" stroke="#0a1a3a" stroke-width="1"/>
+  <ellipse cx="50" cy="32" rx="4" ry="14" fill="#5388d6" stroke="#0a1a3a" stroke-width="1"/>
+  <!-- Spiral toolpath as a polyline of helix segments -->
+  <path d="M16 22 Q22 26 28 22 Q34 18 40 22 Q46 26 50 22"
+        fill="none" stroke="#ff7a00" stroke-width="2" stroke-linecap="round"/>
+  <path d="M16 30 Q22 34 28 30 Q34 26 40 30 Q46 34 50 30"
+        fill="none" stroke="#ff7a00" stroke-width="2" stroke-linecap="round"/>
+  <path d="M16 38 Q22 42 28 38 Q34 34 40 38 Q46 42 50 38"
+        fill="none" stroke="#ff7a00" stroke-width="2" stroke-linecap="round"/>
+  <!-- Tool tip indicator -->
+  <rect x="30" y="6" width="4" height="10" fill="#444"/>
+  <polygon points="28,16 36,16 32,22" fill="#888"/>
+  <!-- Rotation arrow -->
+  <path d="M50 50 A8 8 0 1 0 56 42" fill="none" stroke="#cc2c2c" stroke-width="2"/>
+  <polygon points="56,40 58,44 54,44" fill="#cc2c2c"/>
+</svg>

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -192,7 +192,7 @@ ToDo (last check: 20260430, #27222):
 * The [[CAM_DressupTag|DressupTag]] tool can now automatically place tags for several closed paths. [https://github.com/FreeCAD/FreeCAD/pull/22468 Pull request #22468]
 * The [[CAM_DressupTag|DressupTag]] tool now scales better with many edges. [https://github.com/FreeCAD/FreeCAD/pull/29094 Pull request #29094]
 * The [[CAM_Adaptive|Adaptive]] operation now uses helix generator to create a helix entry. Helix properties were moved to the ''Adaptive Helix Entry'' group. There are also new property names ''Helix Max Ramp Angle'' and ''Helix Max Pitch''. [https://github.com/FreeCAD/FreeCAD/pull/22357 Pull request #22357]
-* A new Rotary Surface operation was added for 4th axis surfacing. [https://github.com/FreeCAD/FreeCAD/pull/29751 Pull request #29751]
+* A new [[CAM_RotarySurface|Rotary Surface]] operation was added for 4th axis surfacing. [https://github.com/FreeCAD/FreeCAD/pull/29751 Pull request #29751]
 * The job creation and editing dialogs were improved. Job creation now includes a unit schema selector, template description was added to the json and there is a machine selector, as well as a button to create new machines on the General tab. Several other widgets within those panels were also enhanced. [https://github.com/FreeCAD/FreeCAD/pull/29861 Pull request #29861]
 * {{Incode|MachineState.G0F}}, and {{Incode|.ReturnMode}} were added for [[CAM_Drilling|Drilling]] commands. [https://github.com/FreeCAD/FreeCAD/pull/29892 Pull request #29892]
 

--- a/wiki/Template;CAM_Tools_navi.wikitext
+++ b/wiki/Template;CAM_Tools_navi.wikitext
@@ -14,7 +14,7 @@
 
 ----
 
-* '''3D Operations:''' [[CAM_Pocket3D{{#translation:}}|3D Pocket]], [[CAM_Surface{{#translation:}}|3D Surface]], [[CAM_Waterline{{#translation:}}|Waterline]]
+* '''3D Operations:''' [[CAM_Pocket3D{{#translation:}}|3D Pocket]], [[CAM_Surface{{#translation:}}|3D Surface]], [[CAM_RotarySurface{{#translation:}}|Rotary Surface]], [[CAM_Waterline{{#translation:}}|Waterline]]
 
 ----
 


### PR DESCRIPTION
## Summary
- add a new CAM_RotarySurface command page for the FreeCAD 1.2 Rotary Surface operation from FreeCAD/FreeCAD#29751
- add the CAM_RotarySurface SVG icon and link the page from CAM Workbench, CAM tools navigation, and the 1.2 release notes
- document the OCL/experimental prerequisites, cylinder stock and rotary-axis requirements, key task-panel properties, and v1 limitations

## Validation
- git diff --cached --check
- duplicate translation marker check for CAM_RotarySurface, CAM_Workbench, and Release_notes_1.2
- translate tag balance check for CAM_RotarySurface, CAM_Workbench, and Release_notes_1.2
- xmllint --noout wiki/File/CAM_RotarySurface.svg

Context: addresses part of CAM Workbench bounty issue #25.