### PR TITLE
[codex] Add CAM Mirror dressup page

### DIFF
--- a/wiki/CAM_DressupLeadInOut.wikitext
+++ b/wiki/CAM_DressupLeadInOut.wikitext
@@ -4,10 +4,10 @@
 <!--T:9-->
 {{Docnav
 |[[CAM_DressupDragKnife|DressupDragKnife]]
-|[[CAM_DressupRampEntry|DressupRampEntry]]
+|[[CAM_DressupMirror|DressupMirror]]
 |[[CAM_Workbench|CAM]]
 |IconL=CAM_DressupDragKnife.svg
-|IconR=CAM_DressupRampEntry.svg
+|IconR=CAM_Dressup.svg
 |IconC=Workbench_CAM.svg
 }}
 
@@ -60,10 +60,10 @@ Add python code here
 <!--T:10-->
 {{Docnav
 |[[CAM_DressupDragKnife|DressupDragKnife]]
-|[[CAM_DressupRampEntry|DressupRampEntry]]
+|[[CAM_DressupMirror|DressupMirror]]
 |[[CAM_Workbench|CAM]]
 |IconL=CAM_DressupDragKnife.svg
-|IconR=CAM_DressupRampEntry.svg
+|IconR=CAM_Dressup.svg
 |IconC=Workbench_CAM.svg
 }}
 

--- a/wiki/CAM_DressupMirror.wikitext
+++ b/wiki/CAM_DressupMirror.wikitext
@@ -1,0 +1,82 @@
+<languages/>
+<translate>
+
+<!--T:1-->
+{{Docnav
+|[[CAM_DressupLeadInOut|DressupLeadInOut]]
+|[[CAM_DressupRampEntry|DressupRampEntry]]
+|[[CAM_Workbench|CAM]]
+|IconL=CAM_DressupLeadInOut.svg
+|IconR=CAM_DressupRampEntry.svg
+|IconC=Workbench_CAM.svg
+}}
+
+<!--T:2-->
+{{GuiCommand
+|Name=CAM DressupMirror
+|MenuLocation=CAM → Path Dressup → Mirror
+|Workbenches=[[CAM_Workbench|CAM]]
+|Version=1.2
+|SeeAlso=[[CAM_DressupLeadInOut|CAM DressupLeadInOut]], [[CAM_DressupRampEntry|CAM DressupRampEntry]], [[CAM_DressupTag|CAM DressupTag]]
+}}
+
+==Description== <!--T:3-->
+
+<!--T:4-->
+The [[Image:CAM_Dressup.svg|24px]] [[CAM_DressupMirror|CAM DressupMirror]] command dresses up an existing path by creating a mirrored copy of its movements. The dressup can replace the original path with the mirrored path or append the mirrored path after the original path.
+
+==Usage== <!--T:5-->
+
+<!--T:6-->
+# Select an existing path operation.
+# There are several ways to invoke the command:
+#* Press the {{Button|[[Image:CAM_Dressup.svg|16px]] [[CAM_DressupMirror|Mirror]]}} button if it is visible in the CAM toolbar.
+#* Select the {{MenuCommand|CAM → Path Dressup → [[Image:CAM_Dressup.svg|16px]] Mirror}} option from the menu.
+# Adjust the mirror properties in the Data tab of the Property View.
+# Recompute the dressup if required.
+
+==Properties== <!--T:7-->
+
+<!--T:8-->
+{{TitleProperty|Path}}
+
+<!--T:9-->
+* {{PropertyData|Base}}: The base path operation to mirror.
+* {{PropertyData|MirrorAxis}}: The mirror mode. The options are {{Value|X}}, {{Value|Y}}, {{Value|XY}}, {{Value|Reference}}, and {{Value|None}}.
+** {{Value|X}} mirrors Y coordinates about an X-axis line.
+** {{Value|Y}} mirrors X coordinates about a Y-axis line.
+** {{Value|XY}} mirrors both X and Y coordinates.
+** {{Value|Reference}} uses the selected reference edge or plane to define the mirror axis.
+** {{Value|None}} leaves the base path unchanged.
+* {{PropertyData|Offset}}: Vector offset applied to the mirror axis. The Z component shifts Z moves in the resulting path.
+* {{PropertyData|CenterModel}}: Mirrors around the center of the base model when an axis mirror mode is used.
+* {{PropertyData|KeepBasePath}}: If {{TRUE}}, keeps the base path and adds the mirrored path. If {{FALSE}}, only the mirrored path is output.
+* {{PropertyData|Reference}}: Reference edge or plane used when {{PropertyData|MirrorAxis}} is {{Value|Reference}}.
+
+==Notes== <!--T:10-->
+
+<!--T:11-->
+* The command is active when a suitable path operation is selected.
+* The base operation is hidden after the dressup is created and remains available as the dressup's base object.
+* The dressup mirrors motion commands. Non-motion commands are copied without coordinate changes.
+* Arc directions are adjusted when the mirror mode changes handedness.
+
+==Limitations== <!--T:12-->
+
+<!--T:13-->
+* Reference mode requires reference geometry that can define an X- or Y-aligned mirror axis.
+* The result depends on the selected operation and machine setup. Inspect the generated path before cutting material.
+
+<!--T:14-->
+{{Docnav
+|[[CAM_DressupLeadInOut|DressupLeadInOut]]
+|[[CAM_DressupRampEntry|DressupRampEntry]]
+|[[CAM_Workbench|CAM]]
+|IconL=CAM_DressupLeadInOut.svg
+|IconR=CAM_DressupRampEntry.svg
+|IconC=Workbench_CAM.svg
+}}
+
+</translate>
+{{CAM_Tools_navi{{#translation:}}}}
+{{Userdocnavi{{#translation:}}}}

--- a/wiki/CAM_DressupMirror.wikitext
+++ b/wiki/CAM_DressupMirror.wikitext
@@ -23,7 +23,7 @@
 ==Description== <!--T:3-->
 
 <!--T:4-->
-The [[Image:CAM_Dressup.svg|24px]] [[CAM_DressupMirror|CAM DressupMirror]] command dresses up an existing path by creating a mirrored copy of its movements. The dressup can replace the original path with the mirrored path or append the mirrored path after the original path.
+The [[Image:CAM_Dressup.svg|24px]] [[CAM_DressupMirror|CAM DressupMirror]] command creates a mirrored copy of an existing path. The dressup can replace the original path or append the mirrored path after it.
 
 ==Usage== <!--T:5-->
 
@@ -48,9 +48,9 @@ The [[Image:CAM_Dressup.svg|24px]] [[CAM_DressupMirror|CAM DressupMirror]] comma
 ** {{Value|XY}} mirrors both X and Y coordinates.
 ** {{Value|Reference}} uses the selected reference edge or plane to define the mirror axis.
 ** {{Value|None}} leaves the base path unchanged.
-* {{PropertyData|Offset}}: Vector offset applied to the mirror axis. The Z component shifts Z moves in the resulting path.
+* {{PropertyData|Offset}}: Vector offset applied to the mirror axis. The Z component shifts Z moves.
 * {{PropertyData|CenterModel}}: Mirrors around the center of the base model when an axis mirror mode is used.
-* {{PropertyData|KeepBasePath}}: If {{TRUE}}, keeps the base path and adds the mirrored path. If {{FALSE}}, only the mirrored path is output.
+* {{PropertyData|KeepBasePath}}: If {{TRUE}}, keeps the base path and adds the mirrored path. If {{FALSE}}, outputs only the mirrored path.
 * {{PropertyData|Reference}}: Reference edge or plane used when {{PropertyData|MirrorAxis}} is {{Value|Reference}}.
 
 ==Notes== <!--T:10-->

--- a/wiki/CAM_DressupRampEntry.wikitext
+++ b/wiki/CAM_DressupRampEntry.wikitext
@@ -3,10 +3,10 @@
 
 <!--T:8-->
 {{Docnav
-|[[CAM_DressupLeadInOut|DressupLeadInOut]]
+|[[CAM_DressupMirror|DressupMirror]]
 |[[CAM_DressupTag|DressupTag]]
 |[[CAM_Workbench|CAM]]
-|IconL=CAM_DressupLeadInOut.svg
+|IconL=CAM_Dressup.svg
 |IconR=CAM_DressupTag.svg
 |IconC=Workbench_CAM.svg
 }}
@@ -58,10 +58,10 @@ The [[Image:CAM_DressupRampEntry.svg|24px]] [[CAM_DressupRampEntry|CAM DressupRa
 
 <!--T:9-->
 {{Docnav
-|[[CAM_DressupLeadInOut|DressupLeadInOut]]
+|[[CAM_DressupMirror|DressupMirror]]
 |[[CAM_DressupTag|DressupTag]]
 |[[CAM_Workbench|CAM]]
-|IconL=CAM_DressupLeadInOut.svg
+|IconL=CAM_Dressup.svg
 |IconR=CAM_DressupTag.svg
 |IconC=Workbench_CAM.svg
 }}

--- a/wiki/CAM_Workbench.wikitext
+++ b/wiki/CAM_Workbench.wikitext
@@ -203,6 +203,9 @@ Some commands are experimental and not available by default. To enable them see 
 <!--T:58-->
 * [[Image:CAM_DressupLeadInOut.svg|32px]] [[CAM_DressupLeadInOut|Lead In/Out]]: Adds a lead-in and/or lead-out point to a selected path.
 
+<!--T:142-->
+* [[Image:CAM_Dressup.svg|32px]] [[CAM_DressupMirror|Mirror]]: Creates a mirrored copy of a selected path.
+
 <!--T:59-->
 * [[Image:CAM_DressupRampEntry.svg|32px]] [[CAM_DressupRampEntry|Ramp Entry]]: Adds ramp entry dressup modification to a selected path.
 

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -182,7 +182,7 @@ ToDo (last check: 20260430, #27222):
 * The Circular Hole Base feature used to select Base Geometry for some operations now shows position and blind state (for cylinder faces) in addition to face name and diameter. [https://github.com/FreeCAD/FreeCAD/pull/27869 Pull request #27869]
 * The [[CAM_Helix|Helix]] operation now has the ''Helix Max Ramp Angle'' property while ''Helix Pitch'' was renamed to ''Helix Max Pitch''. [https://github.com/FreeCAD/FreeCAD/pull/29286 Pull request #29286]
 * The ''Zig Zag Angle'' property of the [[CAM_Pocket_Shape|Pocket]] operation was renamed to ''Angle''. It is now hidden if the selected pattern is ''Offset''. [https://github.com/FreeCAD/FreeCAD/pull/26842 Pull request #26842]
-* A new tool was added to allow mirroring dressups. [https://github.com/FreeCAD/FreeCAD/pull/21820 Pull request #21820]
+* A new [[CAM_DressupMirror|Mirror]] tool was added to allow mirroring dressups. [https://github.com/FreeCAD/FreeCAD/pull/21820 Pull request #21820]
 * A rapid move from ''Clearance Height'' to ''Safe Height'' was added at the beginning of the [[CAM_Slot|Slot]] operation's G-code. [https://github.com/FreeCAD/FreeCAD/pull/25845 Pull request #25845]
 * The CAM context menu was improved. [https://github.com/FreeCAD/FreeCAD/pull/26492 Pull request #26492]
 * [[CAM_Engrave|Engraving]] has two new properties: ''Pattern'' (allows swapping the direction after step down to exclude retraction) and ''Reverse'' (forces direction change). [https://github.com/FreeCAD/FreeCAD/pull/22226 Pull request #22226]

--- a/wiki/Template;CAM_Tools_navi.wikitext
+++ b/wiki/Template;CAM_Tools_navi.wikitext
@@ -18,7 +18,7 @@
 
 ----
 
-* '''CAM Dressup:''' [[CAM_DressupArray{{#translation:}}|Array]], [[CAM_DressupAxisMap{{#translation:}}|Axis Map]], [[CAM_DressupPathBoundary{{#translation:}}|Boundary]], [[CAM_DressupDogbone{{#translation:}}|Dogbone]], [[CAM_DressupDragKnife{{#translation:}}|Drag Knife]], [[CAM_DressupLeadInOut{{#translation:}}|Lead In/Out]], [[CAM_DressupRampEntry{{#translation:}}|Ramp Entry]], [[CAM_DressupTag{{#translation:}}|Tag]], [[CAM_DressupZCorrect{{#translation:}}|Z Depth Correction]]
+* '''CAM Dressup:''' [[CAM_DressupArray{{#translation:}}|Array]], [[CAM_DressupAxisMap{{#translation:}}|Axis Map]], [[CAM_DressupPathBoundary{{#translation:}}|Boundary]], [[CAM_DressupDogbone{{#translation:}}|Dogbone]], [[CAM_DressupDragKnife{{#translation:}}|Drag Knife]], [[CAM_DressupLeadInOut{{#translation:}}|Lead In/Out]], [[CAM_DressupMirror{{#translation:}}|Mirror]], [[CAM_DressupRampEntry{{#translation:}}|Ramp Entry]], [[CAM_DressupTag{{#translation:}}|Tag]], [[CAM_DressupZCorrect{{#translation:}}|Z Depth Correction]]
 
 ----
 


### PR DESCRIPTION
## Summary
- add a new CAM_DressupMirror command page for the FreeCAD 1.2 Mirror Dressup from FreeCAD/FreeCAD#21820
- link the page from CAM Workbench, CAM tools navigation, neighboring dressup Docnav entries, and the 1.2 release notes
- document mirror modes, offset/center/reference behavior, KeepBasePath, and path-safety notes

## Validation
- git diff --cached --check
- duplicate translation marker check for CAM_DressupMirror, CAM_DressupLeadInOut, CAM_DressupRampEntry, CAM_Workbench, and Release_notes_1.2
- translate tag balance check for CAM_DressupMirror, CAM_DressupLeadInOut, CAM_DressupRampEntry, CAM_Workbench, and Release_notes_1.2
- confirmed referenced generic icons CAM_Dressup.svg and Workbench_CAM.svg exist

Context: addresses part of CAM Workbench bounty issue #25.