### PR TITLE
[codex] Document CAM SimulatorGL 1.2 integration

### DIFF
--- a/wiki/CAM_SimulatorGL.wikitext
+++ b/wiki/CAM_SimulatorGL.wikitext
@@ -49,7 +49,7 @@ The [[Image:CAM_SimulatorGL.svg|24px]] [[CAM_SimulatorGL|CAM SimulatorGL]] comma
 ==Notes== <!--T:11-->
 
 <!--T:12-->
-* Since FreeCAD 1.2, the simulator view is integrated into the main window instead of being shown as a separate external window.
+* {{Version|1.2}}: the simulator view is integrated into the main window instead of being shown as a separate external window.
 * The simulator follows the active orthographic or perspective view mode used by the [[3D_View|3D View]].
 
 ==Properties== <!--T:8-->

--- a/wiki/CAM_SimulatorGL.wikitext
+++ b/wiki/CAM_SimulatorGL.wikitext
@@ -24,7 +24,7 @@
 ==Description== <!--T:3-->
 
 <!--T:4-->
-The [[Image:CAM_SimulatorGL.svg|24px]] [[CAM_SimulatorGL|CAM SimulatorGL]] command is a new alternative to [[CAM_Simulator|Legacy CAM Simulator]]. It's based on low-level OpenGL functions and is meant to be faster and more precise than the old simulator. {{Version|1.2}} The simulator opens as a view in the FreeCAD main window and uses the same navigation style and orthographic or perspective view mode as the [[3D_View|3D View]].
+The [[Image:CAM_SimulatorGL.svg|24px]] [[CAM_SimulatorGL|CAM SimulatorGL]] command is a new alternative to [[CAM_Simulator|Legacy CAM Simulator]]. It's based on low-level OpenGL functions and is meant to be faster and more precise than the old simulator.
 
 </translate>
 [[Image:CAM_new_simulator.PNG|600px]]
@@ -44,13 +44,13 @@ The [[Image:CAM_SimulatorGL.svg|24px]] [[CAM_SimulatorGL|CAM SimulatorGL]] comma
 #* A simulator view will open in the main window.
 #* Use the left-side buttons: Play, Single-Step, Decrease/Increase simulation speed and the slider to control the animation.
 #* Use the right-side buttons to: Reset camera, Show/hide overlay of base model, Orbit the model, Display the path and Enable/disable Ambient Occlusion.
-#* {{Version|1.2}} Navigate the simulator view with the same mouse navigation style used by the [[3D_View|3D View]].
+#* Navigate the simulator view with the same mouse navigation style used by the [[3D_View|3D View]].
 
 ==Notes== <!--T:11-->
 
 <!--T:12-->
-* {{Version|1.2}} The simulator view is integrated into the main window instead of being shown as a separate external window.
-* {{Version|1.2}} The simulator follows the active orthographic or perspective view mode used by the [[3D_View|3D View]].
+* Since FreeCAD 1.2, the simulator view is integrated into the main window instead of being shown as a separate external window.
+* The simulator follows the active orthographic or perspective view mode used by the [[3D_View|3D View]].
 
 ==Properties== <!--T:8-->
 

--- a/wiki/CAM_SimulatorGL.wikitext
+++ b/wiki/CAM_SimulatorGL.wikitext
@@ -24,7 +24,7 @@
 ==Description== <!--T:3-->
 
 <!--T:4-->
-The [[Image:CAM_SimulatorGL.svg|24px]] [[CAM_SimulatorGL|CAM SimulatorGL]] command is a new alternative to [[CAM_Simulator|Legacy CAM Simulator]]. It's based on low-level OpenGL functions. To eliminate interference with the 3D View of FreeCAD, it works in a separate window with a separate OpenGL context. It's meant to be faster and more precise than the old simulator.
+The [[Image:CAM_SimulatorGL.svg|24px]] [[CAM_SimulatorGL|CAM SimulatorGL]] command is a new alternative to [[CAM_Simulator|Legacy CAM Simulator]]. It's based on low-level OpenGL functions and is meant to be faster and more precise than the old simulator. {{Version|1.2}} The simulator opens as a view in the FreeCAD main window and uses the same navigation style and orthographic or perspective view mode as the [[3D_View|3D View]].
 
 </translate>
 [[Image:CAM_new_simulator.PNG|600px]]
@@ -41,13 +41,16 @@ The [[Image:CAM_SimulatorGL.svg|24px]] [[CAM_SimulatorGL|CAM SimulatorGL]] comma
 # Tune the {{MenuCommand|Accuracy}} setting.
 # Select the {{MenuCommand|Job}} for simulation from the drop menu.
 # Press the [[Image:CAM_BPlay.svg|24px]] (Activate / resume simulation) button
-#* A separate window with the simulator will open.
+#* A simulator view will open in the main window.
 #* Use the left-side buttons: Play, Single-Step, Decrease/Increase simulation speed and the slider to control the animation.
 #* Use the right-side buttons to: Reset camera, Show/hide overlay of base model, Orbit the model, Display the path and Enable/disable Ambient Occlusion.
-#* Control the 3D View with the following mouse controls:
-#** Zoom: use the mouse wheel or hold {{KEY|Ctrl}} and {{KEY|Shift}} and move the cursor to zoom in and out
-#** Pan: hold the middle mouse button or {{KEY|Shift}} and move the cursor
-#** Rotate: hold the middle mouse button, then press and hold the left mouse button and move the cursor or hold {{KEY|Alt}} and move the cursor
+#* {{Version|1.2}} Navigate the simulator view with the same mouse navigation style used by the [[3D_View|3D View]].
+
+==Notes== <!--T:11-->
+
+<!--T:12-->
+* {{Version|1.2}} The simulator view is integrated into the main window instead of being shown as a separate external window.
+* {{Version|1.2}} The simulator follows the active orthographic or perspective view mode used by the [[3D_View|3D View]].
 
 ==Properties== <!--T:8-->
 


### PR DESCRIPTION
## Summary
- update CAM_SimulatorGL for the FreeCAD 1.2 main-window/MDI simulator integration from FreeCAD/FreeCAD#22204
- document that the simulator follows the 3D View navigation style and orthographic/perspective mode from FreeCAD/FreeCAD#23073
- replace stale separate-window mouse-control wording with current simulator-view notes

## Validation
- git diff --cached --check
- duplicate translation marker check for CAM_SimulatorGL
- translate tag balance check for CAM_SimulatorGL

Context: addresses part of CAM Workbench bounty issue #25.