### PR TITLE
[codex] Document CAM MillFace linking modes

### DIFF
--- a/wiki/CAM_MillFace.wikitext
+++ b/wiki/CAM_MillFace.wikitext
@@ -122,11 +122,11 @@ Note: It is suggested that you do not edit the Placement property of path operat
 {{TitleProperty|Linking}}
 
 <!--T:44-->
-* {{PropertyData|LinkingMode}}: {{Version|1.2}} Controls collision detection for linking moves between face-milling areas.
+* {{PropertyData|LinkingMode}}: Controls collision detection for linking moves between face-milling areas. {{Version|1.2}}
 ** {{Value|Fastest}}: Uses a simple path check that does not account for tool size.
 ** {{Value|Compromise}}: Uses the tool diameter for collision detection.
-** {{Value|Safest}}: Uses the cross section of the tool shape for collision detection. This is the slowest mode.
-* {{PropertyData|LinkingSafetyMargin}}: {{Version|1.2}} Distance used for linking-move collision detection.
+** {{Value|Safest}}: Uses the tool shape cross section for collision detection. This is the slowest mode.
+* {{PropertyData|LinkingSafetyMargin}}: Distance used for linking-move collision detection. {{Version|1.2}}
 
 <!--T:29-->
 {{TitleProperty|Pocket}}

--- a/wiki/CAM_MillFace.wikitext
+++ b/wiki/CAM_MillFace.wikitext
@@ -118,6 +118,16 @@ Note: It is suggested that you do not edit the Placement property of path operat
 * {{PropertyData|Tool Controller}}: Defines the Tool controller used in the Operation
 * {{PropertyData|User Label}}: User assigned label
 
+<!--T:43-->
+{{TitleProperty|Linking}}
+
+<!--T:44-->
+* {{PropertyData|LinkingMode}}: {{Version|1.2}} Controls collision detection for linking moves between face-milling areas.
+** {{Value|Fastest}}: Uses a simple path check that does not account for tool size.
+** {{Value|Compromise}}: Uses the tool diameter for collision detection.
+** {{Value|Safest}}: Uses the cross section of the tool shape for collision detection. This is the slowest mode.
+* {{PropertyData|LinkingSafetyMargin}}: {{Version|1.2}} Distance used for linking-move collision detection.
+
 <!--T:29-->
 {{TitleProperty|Pocket}}
 

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -186,7 +186,7 @@ ToDo (last check: 20260430, #27222):
 * A rapid move from ''Clearance Height'' to ''Safe Height'' was added at the beginning of the [[CAM_Slot|Slot]] operation's G-code. [https://github.com/FreeCAD/FreeCAD/pull/25845 Pull request #25845]
 * The CAM context menu was improved. [https://github.com/FreeCAD/FreeCAD/pull/26492 Pull request #26492]
 * [[CAM_Engrave|Engraving]] has two new properties: ''Pattern'' (allows swapping the direction after step down to exclude retraction) and ''Reverse'' (forces direction change). [https://github.com/FreeCAD/FreeCAD/pull/22226 Pull request #22226]
-* Linking now considers the tool shape. [https://github.com/FreeCAD/FreeCAD/pull/28180 Pull request #28180]
+* Linking moves for operations such as [[CAM_MillFace|Face]], [[CAM_Drilling|Drilling]], and [[CAM_Helix|Helix]] can now consider the tool shape. [https://github.com/FreeCAD/FreeCAD/pull/28180 Pull request #28180]
 * The Array tool's Jitter feature was improved. [https://github.com/FreeCAD/FreeCAD/pull/26326 Pull request #26326]
 * The HandleMultipleFeatures feature can now process more cases for the [[CAM_Area|Area]] operation. [https://github.com/FreeCAD/FreeCAD/pull/26867 Pull request #26867]
 * The [[CAM_DressupTag|DressupTag]] tool can now automatically place tags for several closed paths. [https://github.com/FreeCAD/FreeCAD/pull/22468 Pull request #22468]


### PR DESCRIPTION
## Summary
- document FreeCAD 1.2 MillFace LinkingMode and LinkingSafetyMargin properties from FreeCAD/FreeCAD#28180
- explain Fastest, Compromise, and Safest collision-detection modes for linking moves
- update the 1.2 release-note item to link the affected Face, Drilling, and Helix operation pages

## Validation
- git diff --cached --check
- duplicate translation marker check for CAM_MillFace and Release_notes_1.2
- translate tag balance check for CAM_MillFace and Release_notes_1.2

Context: addresses part of CAM Workbench bounty issue #25.