### PR TITLE
[codex] Document CAM Drilling and Helix linking modes

### DIFF
--- a/wiki/CAM_Drilling.wikitext
+++ b/wiki/CAM_Drilling.wikitext
@@ -112,6 +112,16 @@ Note: It is suggested that you do not edit the Placement property of path operat
 * {{PropertyData|User Label}}: User assigned label
 * {{PropertyData|Tool Controller}}: Defines the Tool controller used in the Operation
 
+<!--T:46-->
+{{TitleProperty|Linking}}
+
+<!--T:47-->
+* {{PropertyData|LinkingMode}}: {{Version|1.2}} Controls collision detection for linking moves between drilling locations.
+** {{Value|Fastest}}: Uses a simple path check that does not account for tool size.
+** {{Value|Compromise}}: Uses the tool diameter for collision detection.
+** {{Value|Safest}}: Uses the cross section of the tool shape for collision detection. This is the slowest mode.
+* {{PropertyData|LinkingSafetyMargin}}: {{Version|1.2}} Distance used for linking-move collision detection.
+
 <!--T:25-->
 {{TitleProperty|Rotation}} (''when available'')
 

--- a/wiki/CAM_Drilling.wikitext
+++ b/wiki/CAM_Drilling.wikitext
@@ -116,11 +116,11 @@ Note: It is suggested that you do not edit the Placement property of path operat
 {{TitleProperty|Linking}}
 
 <!--T:47-->
-* {{PropertyData|LinkingMode}}: {{Version|1.2}} Controls collision detection for linking moves between drilling locations.
+* {{PropertyData|LinkingMode}}: Controls collision detection for linking moves between drilling locations. {{Version|1.2}}
 ** {{Value|Fastest}}: Uses a simple path check that does not account for tool size.
 ** {{Value|Compromise}}: Uses the tool diameter for collision detection.
-** {{Value|Safest}}: Uses the cross section of the tool shape for collision detection. This is the slowest mode.
-* {{PropertyData|LinkingSafetyMargin}}: {{Version|1.2}} Distance used for linking-move collision detection.
+** {{Value|Safest}}: Uses the tool shape cross section for collision detection. This is the slowest mode.
+* {{PropertyData|LinkingSafetyMargin}}: Distance used for linking-move collision detection. {{Version|1.2}}
 
 <!--T:25-->
 {{TitleProperty|Rotation}} (''when available'')

--- a/wiki/CAM_Helix.wikitext
+++ b/wiki/CAM_Helix.wikitext
@@ -71,11 +71,11 @@ Also the current implementation only uses the horizontal tool speed for helix pa
 {{TitleProperty|Linking}}
 
 <!--T:28-->
-* {{PropertyData|LinkingMode}}: {{Version|1.2}} Controls collision detection for linking moves between helix locations.
+* {{PropertyData|LinkingMode}}: Controls collision detection for linking moves between helix locations. {{Version|1.2}}
 ** {{Value|Fastest}}: Uses a simple path check that does not account for tool size.
 ** {{Value|Compromise}}: Uses the tool diameter for collision detection.
-** {{Value|Safest}}: Uses the cross section of the tool shape for collision detection. This is the slowest mode.
-* {{PropertyData|LinkingSafetyMargin}}: {{Version|1.2}} Distance used for linking-move collision detection.
+** {{Value|Safest}}: Uses the tool shape cross section for collision detection. This is the slowest mode.
+* {{PropertyData|LinkingSafetyMargin}}: Distance used for linking-move collision detection. {{Version|1.2}}
 
 ===View=== <!--T:13-->
 

--- a/wiki/CAM_Helix.wikitext
+++ b/wiki/CAM_Helix.wikitext
@@ -67,8 +67,15 @@ Also the current implementation only uses the horizontal tool speed for helix pa
 
 ===Data=== <!--T:12-->
 
-<!--T:17-->
-Empty
+<!--T:27-->
+{{TitleProperty|Linking}}
+
+<!--T:28-->
+* {{PropertyData|LinkingMode}}: {{Version|1.2}} Controls collision detection for linking moves between helix locations.
+** {{Value|Fastest}}: Uses a simple path check that does not account for tool size.
+** {{Value|Compromise}}: Uses the tool diameter for collision detection.
+** {{Value|Safest}}: Uses the cross section of the tool shape for collision detection. This is the slowest mode.
+* {{PropertyData|LinkingSafetyMargin}}: {{Version|1.2}} Distance used for linking-move collision detection.
 
 ===View=== <!--T:13-->
 


### PR DESCRIPTION
## Summary
- document FreeCAD 1.2 LinkingMode and LinkingSafetyMargin for Drilling and Helix from FreeCAD/FreeCAD#28180
- explain Fastest, Compromise, and Safest collision-detection modes for linking moves
- keep the change scoped to operation property docs

## Validation
- git diff --cached --check
- duplicate translation marker check for CAM_Drilling and CAM_Helix
- translate tag balance check for CAM_Drilling and CAM_Helix

Context: addresses part of CAM Workbench bounty issue #25.