### PR TITLE
[codex] Document CAM post editor updates

### DIFF
--- a/wiki/CAM_Post.wikitext
+++ b/wiki/CAM_Post.wikitext
@@ -90,10 +90,7 @@ If only one CNC machine is used, or if all CNC machines share a common Postproce
 Output file and Postprocessor properties can be set in the  [[CAM_Job|Job]], at any time, prior to invoking the Postprocessor.
 
 <!--T:32-->
-In FreeCAD 1.2 and later, the G-code editor dialog displays line numbers when the postprocessor is configured to show the generated output before saving.
-
-<!--T:33-->
-For refactored postprocessors in FreeCAD 1.2 and later, the G-code editor dialog can also abort postprocessing before the output file is written.
+Since FreeCAD 1.2, the G-code editor dialog displays line numbers when generated output is shown before saving. For refactored postprocessors, the dialog can also abort postprocessing before the output file is written.
 
 <!--T:12-->
 The provided Postprocessors are written with comments indicating areas containing Flags, Configuration Variables, and Sections of G-Codes and M-Codes that are to be used by the Postprocessor to configure the output.

--- a/wiki/CAM_Post.wikitext
+++ b/wiki/CAM_Post.wikitext
@@ -89,6 +89,12 @@ If only one CNC machine is used, or if all CNC machines share a common Postproce
 <!--T:7-->
 Output file and Postprocessor properties can be set in the  [[CAM_Job|Job]], at any time, prior to invoking the Postprocessor.
 
+<!--T:32-->
+In FreeCAD 1.2 and later, the G-code editor dialog displays line numbers when the postprocessor is configured to show the generated output before saving.
+
+<!--T:33-->
+For refactored postprocessors in FreeCAD 1.2 and later, the G-code editor dialog can also abort postprocessing before the output file is written.
+
 <!--T:12-->
 The provided Postprocessors are written with comments indicating areas containing Flags, Configuration Variables, and Sections of G-Codes and M-Codes that are to be used by the Postprocessor to configure the output.
 

--- a/wiki/CAM_Post.wikitext
+++ b/wiki/CAM_Post.wikitext
@@ -90,7 +90,7 @@ If only one CNC machine is used, or if all CNC machines share a common Postproce
 Output file and Postprocessor properties can be set in the  [[CAM_Job|Job]], at any time, prior to invoking the Postprocessor.
 
 <!--T:32-->
-Since FreeCAD 1.2, the G-code editor dialog displays line numbers when generated output is shown before saving. For refactored postprocessors, the dialog can also abort postprocessing before the output file is written.
+{{Version|1.2}}: The G-code editor dialog displays line numbers when generated output is shown before saving. For refactored postprocessors, the dialog can also abort postprocessing before the output file is written.
 
 <!--T:12-->
 The provided Postprocessors are written with comments indicating areas containing Flags, Configuration Variables, and Sections of G-Codes and M-Codes that are to be used by the Postprocessor to configure the output.

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -148,7 +148,7 @@ ToDo (last check: 20260430, #27222):
 === Further CAM improvements === <!--T:26-->
 
 <!--T:72-->
-* The G-code export dialog now shows line numbers. [https://github.com/FreeCAD/FreeCAD/pull/23862 Pull request #23862]
+* The [[CAM_Post|G-code export dialog]] now shows line numbers. [https://github.com/FreeCAD/FreeCAD/pull/23862 Pull request #23862]
 * The MillFace operation was reimplemented with significant improvements as MillFacing. [https://github.com/FreeCAD/FreeCAD/pull/24367 Pull request #24367]
 * [[CAM_SimpleCopy|SimpleCopy]] now allows multiple selection of operations. [https://github.com/FreeCAD/FreeCAD/pull/24297 Pull request #24297]
 * OCL Adaptive Algorithm was added to the [[CAM_Waterline|Waterline]] operation. [https://github.com/FreeCAD/FreeCAD/pull/23149 Pull request #23149]
@@ -166,7 +166,7 @@ ToDo (last check: 20260430, #27222):
 * The [[CAM_SimulatorGL|new CAM simulator]] was integrated as an MDI widget into the main window. [https://github.com/FreeCAD/FreeCAD/pull/22204 Pull request #22204]
 * The [[CAM_Copy|Copy Operation]] tool can now copy all operations and do it recursively. [https://github.com/FreeCAD/FreeCAD/pull/24819 Pull request #24819]
 * The [[CAM_OpActiveToggle|Toggle Operation]] tool now supports Job and Operations groups. [https://github.com/FreeCAD/FreeCAD/pull/24872 Pull request #24872]
-* It is now possible to cancel G-code export. [https://github.com/FreeCAD/FreeCAD/pull/25273 Pull request #25273]
+* It is now possible to cancel [[CAM_Post|G-code export]]. [https://github.com/FreeCAD/FreeCAD/pull/25273 Pull request #25273]
 * Tolerance can now be set for [[CAM_DressupTag|Tag Dressup]], [[CAM_Engrave|Engrave]], and [[CAM_Deburr|Deburr]] operations to change the precision of segmentation of complex shapes while creating a path. [https://github.com/FreeCAD/FreeCAD/pull/26127 Pull request #26127] and [https://github.com/FreeCAD/FreeCAD/pull/26128 Pull request #26128]
 * [[CAM_Adaptive|Adaptive]] operation now automatically picks the diameter of the helix entrance. [https://github.com/FreeCAD/FreeCAD/pull/23980 Pull request #23980]
 * CAM task panels now support selecting shapes from different objects. [https://github.com/FreeCAD/FreeCAD/pull/22304 Pull request #22304]


### PR DESCRIPTION
## Summary
- document FreeCAD 1.2 G-code editor line numbers from FreeCAD/FreeCAD#23862 on CAM_Post
- document that refactored postprocessors can abort postprocessing from the editor dialog from FreeCAD/FreeCAD#25273
- link the related 1.2 release-note entries to CAM_Post

## Validation
- git diff --cached --check
- duplicate translation marker check for CAM_Post and Release_notes_1.2
- translate tag balance check for CAM_Post and Release_notes_1.2

Context: addresses part of CAM Workbench bounty issue #25.