### PR TITLE
[codex] Document Kinetic postprocessor coolant support

### DIFF
--- a/wiki/CAM_Post.wikitext
+++ b/wiki/CAM_Post.wikitext
@@ -127,7 +127,7 @@ Included Postprocessors are saved in '''FreeCAD/Mod/CAM/CAM/Post/scripts''' by d
 *dynapath
 *grbl, including support for bCNC header blocks using Job output argument --bcnc
 *jtech (laser)
-*KineticNCBeamicon2, including operation coolant mode support in FreeCAD 1.2
+*KineticNCBeamicon2
 *[http://linuxcnc.org/docs/html/gcode/g-code.html#gcode:g17-g19.1 linuxcnc] 
 *mach3_mach4
 *nccad

--- a/wiki/CAM_Post.wikitext
+++ b/wiki/CAM_Post.wikitext
@@ -127,6 +127,7 @@ Included Postprocessors are saved in '''FreeCAD/Mod/CAM/CAM/Post/scripts''' by d
 *dynapath
 *grbl, including support for bCNC header blocks using Job output argument --bcnc
 *jtech (laser)
+*KineticNCBeamicon2, including operation coolant mode support in FreeCAD 1.2
 *[http://linuxcnc.org/docs/html/gcode/g-code.html#gcode:g17-g19.1 linuxcnc] 
 *mach3_mach4
 *nccad

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -173,7 +173,7 @@ ToDo (last check: 20260430, #27222):
 * [[CAM_Vcarve|Vcarve]] routing is now improved using "virtual edge backtracking". [https://github.com/FreeCAD/FreeCAD/pull/25049 Pull request #25049]
 * It is now possible to postprocess only selected Operations from the Job and select operations inside Dressup. [https://github.com/FreeCAD/FreeCAD/pull/22764 Pull request #22764]
 * The [[CAM_SelectLoop|loop selection]] tool was improved and now returns the wire if edge(s) selected and other methods failed. [https://github.com/FreeCAD/FreeCAD/pull/24185 Pull request #24185]
-* A cooling feature was added to the Kinetic [[CAM_Post|postprocessor]]. [https://github.com/FreeCAD/FreeCAD/pull/25022 Pull request #25022]
+* A cooling feature was added to the KineticNCBeamicon2 [[CAM_Post|postprocessor]]. [https://github.com/FreeCAD/FreeCAD/pull/25022 Pull request #25022]
 * The ''Units'' (Metric/Imperial) property was added to ToolBits. [https://github.com/FreeCAD/FreeCAD/pull/25783 Pull request #25783]
 * The [[CAM_SimulatorGL|new CAM simulator]] now uses the same ortho/perspective view mode and navigation style as the [[3D_View|3D View]]. [https://github.com/FreeCAD/FreeCAD/pull/23073 Pull request #23073]
 * The [[CAM_Pocket_Shape|Pocket]] operation can now handle horizontal edges in addition to faces. [https://github.com/FreeCAD/FreeCAD/pull/27750 Pull request #27750]

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -173,7 +173,7 @@ ToDo (last check: 20260430, #27222):
 * [[CAM_Vcarve|Vcarve]] routing is now improved using "virtual edge backtracking". [https://github.com/FreeCAD/FreeCAD/pull/25049 Pull request #25049]
 * It is now possible to postprocess only selected Operations from the Job and select operations inside Dressup. [https://github.com/FreeCAD/FreeCAD/pull/22764 Pull request #22764]
 * The [[CAM_SelectLoop|loop selection]] tool was improved and now returns the wire if edge(s) selected and other methods failed. [https://github.com/FreeCAD/FreeCAD/pull/24185 Pull request #24185]
-* A cooling feature was added to the Kinetic postprocessor. [https://github.com/FreeCAD/FreeCAD/pull/25022 Pull request #25022]
+* A cooling feature was added to the Kinetic [[CAM_Post|postprocessor]]. [https://github.com/FreeCAD/FreeCAD/pull/25022 Pull request #25022]
 * The ''Units'' (Metric/Imperial) property was added to ToolBits. [https://github.com/FreeCAD/FreeCAD/pull/25783 Pull request #25783]
 * The [[CAM_SimulatorGL|new CAM simulator]] now uses the same ortho/perspective view mode and navigation style as the [[3D_View|3D View]]. [https://github.com/FreeCAD/FreeCAD/pull/23073 Pull request #23073]
 * The [[CAM_Pocket_Shape|Pocket]] operation can now handle horizontal edges in addition to faces. [https://github.com/FreeCAD/FreeCAD/pull/27750 Pull request #27750]


### PR DESCRIPTION
## Summary
- add KineticNCBeamicon2 to the CAM_Post included postprocessor list
- note FreeCAD 1.2 operation coolant mode support for the Kinetic postprocessor from FreeCAD/FreeCAD#25022
- link the corresponding 1.2 release-note item to CAM_Post

## Validation
- git diff --cached --check
- duplicate translation marker check for CAM_Post and Release_notes_1.2
- translate tag balance check for CAM_Post and Release_notes_1.2

Context: addresses part of CAM Workbench bounty issue #25.