### PR TITLE
docs(en): Release notes 1.2 — BIM & Draft ToDo bullets

### DIFF
--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -91,22 +91,21 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 
 == BIM Workbench ==
 
-ToDo (last check: 20260430, #27222):
-* https://github.com/FreeCAD/FreeCAD/pull/24078
-* https://github.com/FreeCAD/FreeCAD/pull/24190
-* https://github.com/FreeCAD/FreeCAD/pull/24550
-* https://github.com/FreeCAD/FreeCAD/pull/24595
-* https://github.com/FreeCAD/FreeCAD/pull/25086
-* https://github.com/FreeCAD/FreeCAD/pull/25147
-* https://github.com/FreeCAD/FreeCAD/pull/26758
-* https://github.com/FreeCAD/FreeCAD/pull/27222
-* https://github.com/FreeCAD/FreeCAD/pull/27375
-* https://github.com/FreeCAD/FreeCAD/pull/27381
-* https://github.com/FreeCAD/FreeCAD/pull/27420
-* https://github.com/FreeCAD/FreeCAD/pull/27746
-* https://github.com/FreeCAD/FreeCAD/pull/28036
-* https://github.com/FreeCAD/FreeCAD/pull/28104
-* https://github.com/FreeCAD/FreeCAD/pull/28504
+* A BIM Report command (MVP) was added. [https://github.com/FreeCAD/FreeCAD/pull/24078 Pull request #24078]
+* Hybrid IFC files can use relative paths in BIM. [https://github.com/FreeCAD/FreeCAD/pull/24190 Pull request #24190]
+* Wall bases can be removed intelligently for BIM walls. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
+* Baseless walls can be created in BIM. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]
+* The BIM Project command was removed from the toolbar. [https://github.com/FreeCAD/FreeCAD/pull/25086 Pull request #25086]
+* Incremental BIM UX improvements (iteration 1). [https://github.com/FreeCAD/FreeCAD/pull/25147 Pull request #25147]
+* A task panel box for wall options was added. [https://github.com/FreeCAD/FreeCAD/pull/26758 Pull request #26758]
+* An ArchCovering object and command (MVP) were added. [https://github.com/FreeCAD/FreeCAD/pull/27222 Pull request #27222]
+* Initial implementation of a Sliding Door preset. [https://github.com/FreeCAD/FreeCAD/pull/27375 Pull request #27375]
+* A window options task box was added. [https://github.com/FreeCAD/FreeCAD/pull/27381 Pull request #27381]
+* Window type handling was improved. [https://github.com/FreeCAD/FreeCAD/pull/27420 Pull request #27420]
+* Quick-access options task boxes were added to relevant BIM objects. [https://github.com/FreeCAD/FreeCAD/pull/27746 Pull request #27746]
+* Conflict-free Nudge shortcuts were added. [https://github.com/FreeCAD/FreeCAD/pull/28036 Pull request #28036]
+* Link processing was refactored and a BIM_Link wrapper command was added. [https://github.com/FreeCAD/FreeCAD/pull/28104 Pull request #28104]
+* Site task panel and related UX improvements. [https://github.com/FreeCAD/FreeCAD/pull/28504 Pull request #28504]
 
 === Further BIM improvements ===
 
@@ -164,14 +163,13 @@ ToDo (last check: 20260430, #27222):
 
 == Draft Workbench ==
 
-ToDo (last check: 20260430, #29258):
-* https://github.com/FreeCAD/FreeCAD/pull/26571
-* https://github.com/FreeCAD/FreeCAD/pull/26950
-* https://github.com/FreeCAD/FreeCAD/pull/27979
-* https://github.com/FreeCAD/FreeCAD/pull/27987
-* https://github.com/FreeCAD/FreeCAD/pull/28324
-* https://github.com/FreeCAD/FreeCAD/pull/29142
-* https://github.com/FreeCAD/FreeCAD/pull/29298
+* Knots support was added for snapping in the [[Draft_Workbench|Draft Workbench]]. [https://github.com/FreeCAD/FreeCAD/pull/26571 Pull request #26571]
+* In-command shortcuts can use more than a single character. [https://github.com/FreeCAD/FreeCAD/pull/26950 Pull request #26950]
+* The working plane moves to a vertex when that vertex is pre-selected. [https://github.com/FreeCAD/FreeCAD/pull/27979 Pull request #27979]
+* Angular mode extension lines are created more reliably. [https://github.com/FreeCAD/FreeCAD/pull/27987 Pull request #27987]
+* Polar and circular arrays respect the active working plane. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
+* [[Draft_SVG|importSVG]] approximates paths to arcs and lines more effectively. [https://github.com/FreeCAD/FreeCAD/pull/29142 Pull request #29142]
+* Angular dimensions honor overshoot settings. [https://github.com/FreeCAD/FreeCAD/pull/29298 Pull request #29298]
 
 === Further Draft improvements ===
 


### PR DESCRIPTION
## Summary

- Replaces the **BIM Workbench** and **Draft Workbench** `ToDo` raw PR URL lists on `wiki/en/Release_notes_1.2.wikitext` with formatted release-note bullets (same link style as the rest of the page).
- Addresses bounty scope for **#30** (release notes gaps) and the concrete EN relnotes parts of **#26** / **#27**.

## Classification des bounties (toutes encore ouvertes au 2026-05-17)

| Issue | Titre | Complexité | Réalisable en une itération ? |
|------|--------|------------|-------------------------------|
| #25 | CAM — infos manquantes | **Élevée** | Partiel — section EN CAM déjà dense |
| #26 | BIM — infos manquantes | **Élevée** / **Moyenne** (relnotes EN) | **Oui** pour cette PR |
| #27 | Draft — infos manquantes | idem | **Oui** pour cette PR |
| #28 | Infos obsolètes | **Très élevée** | Non — epic |
| #29 | Tutoriels | **Très élevée** | Non — epic |
| #30 | Release_notes_1.2 | **Moyenne** | **Oui** (cette PR) |

## Test plan

- [ ] Proofread EN bullets against merged PR titles on `FreeCAD/FreeCAD`.
- [ ] Sync other locales in a follow-up if desired.

