### PR TITLE
Release notes 1.2: convert BIM and Draft TODO PR lists into entries

### DIFF
--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -91,22 +91,21 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 
 == BIM Workbench ==
 
-ToDo (last check: 20260430, #27222):
-* https://github.com/FreeCAD/FreeCAD/pull/24078
-* https://github.com/FreeCAD/FreeCAD/pull/24190
-* https://github.com/FreeCAD/FreeCAD/pull/24550
-* https://github.com/FreeCAD/FreeCAD/pull/24595
-* https://github.com/FreeCAD/FreeCAD/pull/25086
-* https://github.com/FreeCAD/FreeCAD/pull/25147
-* https://github.com/FreeCAD/FreeCAD/pull/26758
-* https://github.com/FreeCAD/FreeCAD/pull/27222
-* https://github.com/FreeCAD/FreeCAD/pull/27375
-* https://github.com/FreeCAD/FreeCAD/pull/27381
-* https://github.com/FreeCAD/FreeCAD/pull/27420
-* https://github.com/FreeCAD/FreeCAD/pull/27746
-* https://github.com/FreeCAD/FreeCAD/pull/28036
-* https://github.com/FreeCAD/FreeCAD/pull/28104
-* https://github.com/FreeCAD/FreeCAD/pull/28504
+* The BIM Report command MVP was added. [https://github.com/FreeCAD/FreeCAD/pull/24078 Pull request #24078]
+* Hybrid IFC files now support relative paths. [https://github.com/FreeCAD/FreeCAD/pull/24190 Pull request #24190]
+* Wall base removal was improved with smarter behavior. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
+* Baseless wall creation was implemented. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]
+* The BIM Project command was removed from the toolbar. [https://github.com/FreeCAD/FreeCAD/pull/25086 Pull request #25086]
+* First-pass BIM UX improvements were added. [https://github.com/FreeCAD/FreeCAD/pull/25147 Pull request #25147]
+* A task panel box for wall options was added. [https://github.com/FreeCAD/FreeCAD/pull/26758 Pull request #26758]
+* The ArchCovering object and command MVP were added. [https://github.com/FreeCAD/FreeCAD/pull/27222 Pull request #27222]
+* Initial implementation of the Sliding Door preset was added. [https://github.com/FreeCAD/FreeCAD/pull/27375 Pull request #27375]
+* A window options task box was added. [https://github.com/FreeCAD/FreeCAD/pull/27381 Pull request #27381]
+* Window type handling was fixed. [https://github.com/FreeCAD/FreeCAD/pull/27420 Pull request #27420]
+* Quick-access options task boxes were added to relevant objects. [https://github.com/FreeCAD/FreeCAD/pull/27746 Pull request #27746]
+* Conflict-free Nudge shortcuts were added. [https://github.com/FreeCAD/FreeCAD/pull/28036 Pull request #28036]
+* Link processing was refactored and a BIM_Link wrapper command was added. [https://github.com/FreeCAD/FreeCAD/pull/28104 Pull request #28104]
+* Site task panel and UX improvements were added. [https://github.com/FreeCAD/FreeCAD/pull/28504 Pull request #28504]
 
 === Further BIM improvements ===
 
@@ -164,14 +163,13 @@ ToDo (last check: 20260430, #27222):
 
 == Draft Workbench ==
 
-ToDo (last check: 20260430, #29258):
-* https://github.com/FreeCAD/FreeCAD/pull/26571
-* https://github.com/FreeCAD/FreeCAD/pull/26950
-* https://github.com/FreeCAD/FreeCAD/pull/27979
-* https://github.com/FreeCAD/FreeCAD/pull/27987
-* https://github.com/FreeCAD/FreeCAD/pull/28324
-* https://github.com/FreeCAD/FreeCAD/pull/29142
-* https://github.com/FreeCAD/FreeCAD/pull/29298
+* Snapping now supports knots. [https://github.com/FreeCAD/FreeCAD/pull/26571 Pull request #26571]
+* In-command shortcuts can now use more than one character. [https://github.com/FreeCAD/FreeCAD/pull/26950 Pull request #26950]
+* The working plane can now move to a pre-selected vertex. [https://github.com/FreeCAD/FreeCAD/pull/27979 Pull request #27979]
+* Angular mode extension line creation was fixed. [https://github.com/FreeCAD/FreeCAD/pull/27987 Pull request #27987]
+* Polar and circular arrays now consider the active working plane. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
+* importSVG now supports approximation to arcs and lines. [https://github.com/FreeCAD/FreeCAD/pull/29142 Pull request #29142]
+* Angular dimensions now honor overshoot settings. [https://github.com/FreeCAD/FreeCAD/pull/29298 Pull request #29298]
 
 === Further Draft improvements ===
 


### PR DESCRIPTION
## Scope
- Replaced raw ToDo PR URL lists in wiki/en/Release_notes_1.2.wikitext for BIM and Draft.
- Added reader-facing release-note bullets for each referenced merged PR.
- Preserved existing section structure including Further BIM improvements and Further Draft improvements.

## Validation
- Verified each referenced PR exists in FreeCAD/FreeCAD and is merged.
- Confirmed both TODO blocks were removed while both section headings remain.

## Bounty mapping
- Directly addresses #30 and contributes to #26/#27 by documenting missing BIM/Draft release-note items.
