### PR TITLE
Docs: add missing CAM/BIM/Draft FreeCAD 1.2 updates (EN)

### DIFF
--- a/wiki/en/BIM_Workbench.wikitext
+++ b/wiki/en/BIM_Workbench.wikitext
@@ -48,6 +48,17 @@ If you are used to another BIM application, check our [[BIM_application_compatib
 
 The [[BIM_ingame_tutorial|in-game tutorial]] is an easy way to quickly get on track with the BIM workbench.
 
+== Recent improvements in FreeCAD 1.2 ==
+
+The following BIM changes were added in FreeCAD 1.2 and impact day-to-day usage:
+
+* The BIM Report command MVP was introduced. [https://github.com/FreeCAD/FreeCAD/pull/24078 Pull request #24078]
+* Hybrid IFC projects now support relative paths. [https://github.com/FreeCAD/FreeCAD/pull/24190 Pull request #24190]
+* Baseless wall creation was implemented, and wall base handling was improved. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595] [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
+* Window tooling received a dedicated options task box and fixes for window type handling. [https://github.com/FreeCAD/FreeCAD/pull/27381 Pull request #27381] [https://github.com/FreeCAD/FreeCAD/pull/27420 Pull request #27420]
+* The ArchCovering object and command MVP were added. [https://github.com/FreeCAD/FreeCAD/pull/27222 Pull request #27222]
+* BIM link workflow was refactored with the BIM_Link wrapper command. [https://github.com/FreeCAD/FreeCAD/pull/28104 Pull request #28104]
+
 == Tools ==
 
 The BIM workbench gathers tools from several other FreeCAD workbenches, mainly [[Draft_Workbench|Draft]] and [[Part_Workbench|Part]], roughly reorganized in logical categories.

--- a/wiki/en/CAM_Workbench.wikitext
+++ b/wiki/en/CAM_Workbench.wikitext
@@ -24,6 +24,16 @@ The FreeCAD CAM Workbench workflow creates these machine instructions as follows
 * Milling paths are created using e.g. [[CAM_Profile|Contour]] and [[CAM_Pocket3D|Pocket]] Operations. These CAM objects use internal FreeCAD G-code dialect, independent of the CNC machine.
 * Export the job with a G-code, matching to your machine. This step is called ''post processing''; there are different post processors available.
 
+== Recent improvements in FreeCAD 1.2 ==
+
+The following CAM improvements were introduced in FreeCAD 1.2 and are useful to know when working with current files:
+
+* [[CAM_Drilling|Drilling]] now includes tapping as a strategy, replacing the previous experimental standalone approach. [https://github.com/FreeCAD/FreeCAD/pull/27506 Pull request #27506]
+* [[CAM_Pocket_Shape|Pocket Shape]] supports using horizontal edges in addition to faces. [https://github.com/FreeCAD/FreeCAD/pull/27750 Pull request #27750]
+* [[CAM_Drilling|Drilling]] supports manual face and edge selection for drilling and helix-drilling workflows. [https://github.com/FreeCAD/FreeCAD/pull/27494 Pull request #27494]
+* [[CAM_SimulatorGL|CAM Simulator]] behavior was improved to follow standard 3D view navigation and projection mode. [https://github.com/FreeCAD/FreeCAD/pull/23073 Pull request #23073]
+* [[CAM_Copy|Copy Operation]] can now copy all operations recursively. [https://github.com/FreeCAD/FreeCAD/pull/24819 Pull request #24819]
+
 == General concepts ==
 
 The CAM Workbench generates G-code defining the paths required to mill the Project represented by the 3D model on the target mill in [[CAM_scripting#The_FreeCAD_Internal_GCode_Format|the CAM Job Operations FreeCAD G-code dialect]], which is later translated to the appropriate dialect for the target CNC controller by selecting the appropriate postprocessor.

--- a/wiki/en/Draft_Workbench.wikitext
+++ b/wiki/en/Draft_Workbench.wikitext
@@ -26,6 +26,17 @@ If your primary goal is the production of complex 2D drawings and [[DXF|DXF]] fi
 On the left, in white, several planar objects.<br>
 On the right a non-planar [[Draft_Wire|Draft Wire]] used as the Path Object of a [[Draft_PathArray|Draft PathArray]].}}
 
+== Recent improvements in FreeCAD 1.2 ==
+
+The following Draft updates were added in FreeCAD 1.2:
+
+* Draft snapping now supports knots for curve workflows. [https://github.com/FreeCAD/FreeCAD/pull/26571 Pull request #26571]
+* In-command shortcuts now support multiple characters. [https://github.com/FreeCAD/FreeCAD/pull/26950 Pull request #26950]
+* The working plane can be moved to a pre-selected vertex. [https://github.com/FreeCAD/FreeCAD/pull/27979 Pull request #27979]
+* Angular dimension overshoot settings are now correctly honored. [https://github.com/FreeCAD/FreeCAD/pull/29298 Pull request #29298]
+* SVG import supports approximation to arcs and lines. [https://github.com/FreeCAD/FreeCAD/pull/29142 Pull request #29142]
+* Polar and circular arrays now respect the active working plane. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
+
 == Drafting ==
 
 * [[Image:Draft_Line.svg|32px]] [[Draft_Line|Line]]: creates a straight line.


### PR DESCRIPTION
## Scope
- Added "Recent improvements in FreeCAD 1.2" sections to:
  - `wiki/en/CAM_Workbench.wikitext`
  - `wiki/en/BIM_Workbench.wikitext`
  - `wiki/en/Draft_Workbench.wikitext`
- Documented concrete user-facing updates with merged upstream FreeCAD PR links.

## Notes
- This PR intentionally focuses on English docs for a fast, reviewable bounty slice.
- Content targets missing workbench information requested in the bounty issues.

## Validation
- Wikitext links inserted using existing page style.
- Changes are limited to the three EN workbench pages.
