### PR TITLE
[codex] Clarify Basic Part Design tutorial starting guidance

### DIFF
--- a/wiki/Basic_Part_Design_Tutorial.wikitext
+++ b/wiki/Basic_Part_Design_Tutorial.wikitext
@@ -27,6 +27,8 @@ https://youtu.be/geIrH1cOCzc
 
 == Before You Begin == <!--T:3-->
 
+<!--T:69-->
+If you are using FreeCAD 0.19 or later and want a workflow that avoids the [[Topological_naming_problem|topological naming problem]], see the updated [[Basic_Part_Design_Tutorial_019|Basic Part Design Tutorial 019]] before starting.
 == The Task == <!--T:60-->
 
 <!--T:4-->


### PR DESCRIPTION
Refs #29.

This is a small focused tutorial update: the 0.17 Basic Part Design tutorial already links to the 0.19+ rewrite in its metadata, but the empty "Before You Begin" section does not tell readers when to choose it.

Change:
- Adds a short pre-start note that points FreeCAD 0.19+ users to Basic Part Design Tutorial 019 when they want the workflow that avoids the topological naming problem.

Validation:
- Content-only wikitext change.
- Checked that the target page exists in the tutorial index and that the new link target is already referenced from this tutorial.