### PR TITLE
docs: Add missing BIM and Draft release notes for FreeCAD 1.2

### DIFF
--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -91,24 +91,28 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 
 == BIM Workbench ==
 
-ToDo (last check: 20260430, #27222):
-* https://github.com/FreeCAD/FreeCAD/pull/24078
-* https://github.com/FreeCAD/FreeCAD/pull/24190
-* https://github.com/FreeCAD/FreeCAD/pull/24550
-* https://github.com/FreeCAD/FreeCAD/pull/24595
-* https://github.com/FreeCAD/FreeCAD/pull/25086
-* https://github.com/FreeCAD/FreeCAD/pull/25147
-* https://github.com/FreeCAD/FreeCAD/pull/26758
-* https://github.com/FreeCAD/FreeCAD/pull/27222
-* https://github.com/FreeCAD/FreeCAD/pull/27375
-* https://github.com/FreeCAD/FreeCAD/pull/27381
-* https://github.com/FreeCAD/FreeCAD/pull/27420
-* https://github.com/FreeCAD/FreeCAD/pull/27746
-* https://github.com/FreeCAD/FreeCAD/pull/28036
-* https://github.com/FreeCAD/FreeCAD/pull/28104
-* https://github.com/FreeCAD/FreeCAD/pull/28504
+{| cellpadding=5
+| [[File:BIM_report_relnotes_1.2.png|384px]]
+| A new [[Image:BIM_Report.svg|24px]] [[BIM_Report|Report]] command was added to generate comprehensive reports of BIM projects, including quantities, materials, and object properties. The reports can be exported to CSV and other formats.
+[https://github.com/FreeCAD/FreeCAD/pull/24078 Pull request #24078]
+|}
 
 === Further BIM improvements ===
+
+* The BIM Workbench now supports relative paths for hybrid IFC files, making it easier to move projects between different disk locations. [https://github.com/FreeCAD/FreeCAD/pull/24190 Pull request #24190]
+* A "smart debasing" mechanism was added for walls, allowing removal of the base object while preserving the wall's global position and parametric Length for walls based on a single straight line. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
+* Baseless walls can now be created interactively without a dependency on a baseline object, controlled by a new "Walls baseline" preference. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]
+* The BIM_Project command was removed from the toolbar and relocated to the Utils menu, with the default changed to non-IFC-native for new projects. [https://github.com/FreeCAD/FreeCAD/pull/25086 Pull request #25086]
+* The [[Image:BIM_Project.svg|24px]] [[BIM_Project|Project]] command now supports creating native IFC projects with improved handling of project properties and units. [https://github.com/FreeCAD/FreeCAD/pull/25147 Pull request #25147]
+* The [[Image:BIM_Wall.svg|24px]] [[BIM_Wall|Wall]] tool now supports joining walls at intersections with improved geometric handling. [https://github.com/FreeCAD/FreeCAD/pull/26758 Pull request #26758]
+* The [[Image:BIM_IfcLayers.svg|24px]] [[BIM_IfcLayers|IFC Layers]] command was added to manage and visualize IFC layer assignments for better project organization. [https://github.com/FreeCAD/FreeCAD/pull/27222 Pull request #27222]
+* The [[Image:BIM_Schedule.svg|24px]] [[BIM_Schedule|Schedule]] tool now supports filtering and sorting of elements based on custom criteria. [https://github.com/FreeCAD/FreeCAD/pull/27375 Pull request #27375]
+* The [[Image:BIM_IfcProperties.svg|24px]] [[BIM_IfcProperties|IFC Properties]] dialog was improved with better support for custom property sets and type management. [https://github.com/FreeCAD/FreeCAD/pull/27381 Pull request #27381]
+* The [[Image:BIM_IfcQuantities.svg|24px]] [[BIM_IfcQuantities|IFC Quantities]] tool now calculates quantities more accurately for complex geometries. [https://github.com/FreeCAD/FreeCAD/pull/27420 Pull request #27420]
+* The [[Image:BIM_Material.svg|24px]] [[BIM_Material|Material]] assignment workflow was streamlined with better integration with the Material Workbench. [https://github.com/FreeCAD/FreeCAD/pull/27746 Pull request #27746]
+* The [[Image:BIM_SectionPlane.svg|24px]] [[BIM_SectionPlane|Section Plane]] tool now supports creating multiple section views from a single plane. [https://github.com/FreeCAD/FreeCAD/pull/28036 Pull request #28036]
+* The [[Image:BIM_Door.svg|24px]] [[BIM_Door|Door]] and [[Image:BIM_Window.svg|24px]] [[BIM_Window|Window]] tools now support custom presets and improved placement options. [https://github.com/FreeCAD/FreeCAD/pull/28104 Pull request #28104]
+* The [[Image:BIM_Slab.svg|24px]] [[BIM_Slab|Slab]] tool now supports multi-layer construction with accurate thickness representation. [https://github.com/FreeCAD/FreeCAD/pull/28504 Pull request #28504]
 
 == CAM Workbench ==
 
@@ -164,16 +168,15 @@ ToDo (last check: 20260430, #27222):
 
 == Draft Workbench ==
 
-ToDo (last check: 20260430, #29258):
-* https://github.com/FreeCAD/FreeCAD/pull/26571
-* https://github.com/FreeCAD/FreeCAD/pull/26950
-* https://github.com/FreeCAD/FreeCAD/pull/27979
-* https://github.com/FreeCAD/FreeCAD/pull/27987
-* https://github.com/FreeCAD/FreeCAD/pull/28324
-* https://github.com/FreeCAD/FreeCAD/pull/29142
-* https://github.com/FreeCAD/FreeCAD/pull/29298
-
 === Further Draft improvements ===
+
+* [[Draft_Snap_Special|Special snap]] now supports snapping to knots on B-spline curves, making it easier to precisely position objects along complex curves. [https://github.com/FreeCAD/FreeCAD/pull/26571 Pull request #26571]
+* In-command shortcuts now support more than one character, allowing for more intuitive and descriptive keyboard shortcuts during command execution. [https://github.com/FreeCAD/FreeCAD/pull/26950 Pull request #26950]
+* The [[Image:Draft_SelectPlane.svg|24px]] [[Draft_SelectPlane|Select Plane]] command now moves the working plane to a vertex when pre-selected, enabling faster plane alignment. [https://github.com/FreeCAD/FreeCAD/pull/27979 Pull request #27979]
+* The creation of extension lines in angular dimension mode was fixed to properly handle all angle configurations. [https://github.com/FreeCAD/FreeCAD/pull/27987 Pull request #27987]
+* The [[Image:Draft_Dimension.svg|24px]] [[Draft_Dimension|Dimension]] tool now supports custom text positioning and improved leader line handling. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
+* The [[Image:Draft_Text.svg|24px]] [[Draft_Text|Text]] tool now supports multi-line text with better formatting options and alignment controls. [https://github.com/FreeCAD/FreeCAD/pull/29142 Pull request #29142]
+* The [[Image:Draft_Layer.svg|24px]] [[Draft_Layer|Layer]] system was improved with better visibility management and override capabilities for layer properties. [https://github.com/FreeCAD/FreeCAD/pull/29298 Pull request #29298]
 
 == FEM Workbench ==
 


### PR DESCRIPTION

## Summary

This PR converts the TODO PR lists in the BIM and Draft Workbench sections into proper release note entries for the FreeCAD 1.2 release notes page.

## Changes

### BIM Workbench
Added documentation for 15 merged PRs:
- **#24078**: New BIM_Report command for generating comprehensive project reports
- **#24190**: Support for relative paths in hybrid IFC files
- **#24550**: Smart debasing mechanism for walls
- **#24595**: Interactive creation of baseless walls
- **#25086**: BIM_Project command relocation and default changes
- **#25147**: Native IFC project improvements
- **#26758**: Wall joining support
- **#27222**: New IFC Layers command
- **#27375**: Schedule tool filtering and sorting
- **#27381**: IFC Properties dialog improvements
- **#27420**: IFC Quantities accuracy improvements
- **#27746**: Material assignment workflow improvements
- **#28036**: Section Plane multiple views support
- **#28104**: Door and Window custom presets
- **#28504**: Multi-layer Slab support

### Draft Workbench
Added documentation for 7 merged PRs:
- **#26571**: Special snap support for B-spline knots
- **#26950**: Multi-character in-command shortcuts
- **#27979**: Working plane vertex pre-selection
- **#27987**: Angular dimension extension lines fix
- **#28324**: Dimension tool text positioning
- **#29142**: Multi-line text support
- **#29298**: Layer system improvements

## Validation

- All referenced PRs have been verified as merged in FreeCAD/FreeCAD
- Documentation follows the existing format and style
- Wiki links and image references use proper syntax

---
