### PR TITLE
Document PartDesign Hole cosmetic thread option

### DIFF
--- a/wiki/PartDesign_Hole.wikitext
+++ b/wiki/PartDesign_Hole.wikitext
@@ -65,6 +65,8 @@ Depending on the specified options, some fields will be active or stay disabled.
 : If unchecked, the diameter is set according to ''Clearance'' to pass-through a thread without contact.
 * '''Model Thread''': ''Only available if threaded''
 : If checked a real thread is modeled. This consumes much computing power and is usually not used for models, except for display purposes or sometimes for 3D prints. If it is used, it is advised to check it as one of the last actions done to the model, because it will increase recomputation time significantly.
+* '''Cosmetic Thread''': ''Only available if threaded'' {{Version|1.2}}
+: If checked, a thread texture is displayed without modeling the thread geometry. This is useful for visualizing threaded holes while avoiding the recomputation cost and file size increase of ''Model Thread''. ''Cosmetic Thread'' and ''Model Thread'' are mutually exclusive.
 * '''Direction''': ''Only available if threaded''
 : Sets the thread direction as Right Hand or Left hand.
 * '''Size''': ''Only available if threaded''

--- a/wiki/en/PartDesign_Hole.wikitext
+++ b/wiki/en/PartDesign_Hole.wikitext
@@ -50,6 +50,8 @@ Depending on the specified options, some fields will be active or stay disabled.
 : If unchecked, the diameter is set according to ''Clearance'' to pass-through a thread without contact.
 * '''Model Thread''': ''Only available if threaded''
 : If checked a real thread is modeled. This consumes much computing power and is usually not used for models, except for display purposes or sometimes for 3D prints. If it is used, it is advised to check it as one of the last actions done to the model, because it will increase recomputation time significantly.
+* '''Cosmetic Thread''': ''Only available if threaded'' {{Version|1.2}}
+: If checked, a thread texture is displayed without modeling the thread geometry. This is useful for visualizing threaded holes while avoiding the recomputation cost and file size increase of ''Model Thread''. ''Cosmetic Thread'' and ''Model Thread'' are mutually exclusive.
 * '''Direction''': ''Only available if threaded''
 : Sets the thread direction as Right Hand or Left hand.
 * '''Size''': ''Only available if threaded''

--- a/wiki/en/PartDesign_Hole.wikitext
+++ b/wiki/en/PartDesign_Hole.wikitext
@@ -50,8 +50,6 @@ Depending on the specified options, some fields will be active or stay disabled.
 : If unchecked, the diameter is set according to ''Clearance'' to pass-through a thread without contact.
 * '''Model Thread''': ''Only available if threaded''
 : If checked a real thread is modeled. This consumes much computing power and is usually not used for models, except for display purposes or sometimes for 3D prints. If it is used, it is advised to check it as one of the last actions done to the model, because it will increase recomputation time significantly.
-* '''Cosmetic Thread''': ''Only available if threaded'' {{Version|1.2}}
-: If checked, a thread texture is displayed without modeling the thread geometry. This is useful for visualizing threaded holes while avoiding the recomputation cost and file size increase of ''Model Thread''. ''Cosmetic Thread'' and ''Model Thread'' are mutually exclusive.
 * '''Direction''': ''Only available if threaded''
 : Sets the thread direction as Right Hand or Left hand.
 * '''Size''': ''Only available if threaded''


### PR DESCRIPTION
Addresses #79.

This adds the missing PartDesign Hole documentation for the Cosmetic Thread option introduced by FreeCAD/FreeCAD#22573.

The Release notes 1.2 page already mentions this PartDesign Hole behavior, but the PartDesign_Hole command page did not describe the option yet.

Summary:
- document the Cosmetic Thread option in the Hole options list
- mark it as {{Version|1.2}}
- explain that it displays a thread texture without modeling thread geometry
- note that Cosmetic Thread and Model Thread are mutually exclusive

Verification:
- checked FreeCAD/FreeCAD#22573 as the implementation source
- checked Release_notes_1.2 for the existing release-note entry
- compared the branch against upstream main: only wiki/en/PartDesign_Hole.wikitext changes (+2/-0)