### PR TITLE
Document PartDesign interactive dragger preferences

### DIFF
--- a/wiki/PartDesign_Preferences.wikitext
+++ b/wiki/PartDesign_Preferences.wikitext
@@ -49,7 +49,7 @@ On this page you can specify the following:
 | If checked, the model is [[Part_RefineShape|refined]] after [[Part_Boolean|boolean operations]].
 |-
 | {{MenuCommand|Automatically refine model after applying operation}}
-| TBD. {{Version|1.1}}? (or relabeled?)
+| If checked, a refinement pass is run after creating Part Design features to remove redundant edges and clean up the geometry.
 |-
 | {{MenuCommand|Allow multiple solids in Part Design bodies by default}}
 | If checked, the {{PropertyData|Allow Compound}} property of newly created bodies is set to {{TRUE}} so that they can have multiple solids. {{Version|1.0}}
@@ -70,13 +70,28 @@ On this page you can specify the following:
 | If checked, transparent preview overlay of a feature is shown by default when editing it. {{Version|1.1}}
 |-
 | {{MenuCommand|Highlight the profile used to create features}}
-| TBD. {{Version|1.1}}
+| If checked, the source sketch or geometry used to generate the feature currently being edited is highlighted. {{Version|1.1}}
 |-
 | {{MenuCommand|Show interactive draggers when editing features}}
-| TBD. {{Version|1.1}}
+| If checked, on-screen draggers are shown in the [[3D_View|3D View]] when editing supported Part Design features, allowing dimensions and parameters to be adjusted interactively. {{Version|1.1}}
 |-
 | {{MenuCommand|Disable recompute while dragging}}
-| TBD. {{Version|1.1}}
+| If checked, the model is not recomputed continuously while an interactive dragger is being moved; the shape is updated after the mouse button is released. {{Version|1.1}}
+|-
+| {{MenuCommand|Enable coarse snapping while dragging}}
+| If checked, interactive draggers can use larger snap steps for coarse adjustments. {{Version|1.2}}
+|-
+| {{MenuCommand|Fine snap modifier}}
+| Selects the modifier key used to temporarily switch to fine snap behavior while dragging. {{Version|1.2}}
+|-
+| {{MenuCommand|Default coarse drag behavior}}
+| Determines whether dragging is coarse or fine when the fine snap modifier key is not pressed. {{Version|1.2}}
+|-
+| {{MenuCommand|Coarse movement multiplier}}
+| Sets the multiplier applied to linear dragger snap steps in coarse mode. {{Version|1.2}}
+|-
+| {{MenuCommand|Coarse rotation step (degrees)}}
+| Sets the rotation snap step used by rotational draggers in coarse mode. {{Version|1.2}}
 |}
 
 ===Shape View=== <!--T:5-->

--- a/wiki/en/PartDesign_Preferences.wikitext
+++ b/wiki/en/PartDesign_Preferences.wikitext
@@ -38,7 +38,7 @@ On this page you can specify the following:
 | If checked, the model is [[Part_RefineShape|refined]] after [[Part_Boolean|boolean operations]].
 |-
 | {{MenuCommand|Automatically refine model after applying operation}}
-| If checked, a refinement pass is run after creating Part Design features to remove redundant edges and clean up the geometry.
+| TBD. {{Version|1.1}}? (or relabeled?)
 |-
 | {{MenuCommand|Allow multiple solids in Part Design bodies by default}}
 | If checked, the {{PropertyData|Allow Compound}} property of newly created bodies is set to {{TRUE}} so that they can have multiple solids. {{Version|1.0}}
@@ -59,28 +59,13 @@ On this page you can specify the following:
 | If checked, transparent preview overlay of a feature is shown by default when editing it. {{Version|1.1}}
 |-
 | {{MenuCommand|Highlight the profile used to create features}}
-| If checked, the source sketch or geometry used to generate the feature currently being edited is highlighted. {{Version|1.1}}
+| TBD. {{Version|1.1}}
 |-
 | {{MenuCommand|Show interactive draggers when editing features}}
-| If checked, on-screen draggers are shown in the [[3D_View|3D View]] when editing supported Part Design features, allowing dimensions and parameters to be adjusted interactively. {{Version|1.1}}
+| TBD. {{Version|1.1}}
 |-
 | {{MenuCommand|Disable recompute while dragging}}
-| If checked, the model is not recomputed continuously while an interactive dragger is being moved; the shape is updated after the mouse button is released. {{Version|1.1}}
-|-
-| {{MenuCommand|Enable coarse snapping while dragging}}
-| If checked, interactive draggers can use larger snap steps for coarse adjustments. {{Version|1.2}}
-|-
-| {{MenuCommand|Fine snap modifier}}
-| Selects the modifier key used to temporarily switch to fine snap behavior while dragging. {{Version|1.2}}
-|-
-| {{MenuCommand|Default coarse drag behavior}}
-| Determines whether dragging is coarse or fine when the fine snap modifier key is not pressed. {{Version|1.2}}
-|-
-| {{MenuCommand|Coarse movement multiplier}}
-| Sets the multiplier applied to linear dragger snap steps in coarse mode. {{Version|1.2}}
-|-
-| {{MenuCommand|Coarse rotation step (degrees)}}
-| Sets the rotation snap step used by rotational draggers in coarse mode. {{Version|1.2}}
+| TBD. {{Version|1.1}}
 |}
 
 ===Shape View===

--- a/wiki/en/PartDesign_Preferences.wikitext
+++ b/wiki/en/PartDesign_Preferences.wikitext
@@ -38,7 +38,7 @@ On this page you can specify the following:
 | If checked, the model is [[Part_RefineShape|refined]] after [[Part_Boolean|boolean operations]].
 |-
 | {{MenuCommand|Automatically refine model after applying operation}}
-| TBD. {{Version|1.1}}? (or relabeled?)
+| If checked, a refinement pass is run after creating Part Design features to remove redundant edges and clean up the geometry.
 |-
 | {{MenuCommand|Allow multiple solids in Part Design bodies by default}}
 | If checked, the {{PropertyData|Allow Compound}} property of newly created bodies is set to {{TRUE}} so that they can have multiple solids. {{Version|1.0}}
@@ -59,13 +59,28 @@ On this page you can specify the following:
 | If checked, transparent preview overlay of a feature is shown by default when editing it. {{Version|1.1}}
 |-
 | {{MenuCommand|Highlight the profile used to create features}}
-| TBD. {{Version|1.1}}
+| If checked, the source sketch or geometry used to generate the feature currently being edited is highlighted. {{Version|1.1}}
 |-
 | {{MenuCommand|Show interactive draggers when editing features}}
-| TBD. {{Version|1.1}}
+| If checked, on-screen draggers are shown in the [[3D_View|3D View]] when editing supported Part Design features, allowing dimensions and parameters to be adjusted interactively. {{Version|1.1}}
 |-
 | {{MenuCommand|Disable recompute while dragging}}
-| TBD. {{Version|1.1}}
+| If checked, the model is not recomputed continuously while an interactive dragger is being moved; the shape is updated after the mouse button is released. {{Version|1.1}}
+|-
+| {{MenuCommand|Enable coarse snapping while dragging}}
+| If checked, interactive draggers can use larger snap steps for coarse adjustments. {{Version|1.2}}
+|-
+| {{MenuCommand|Fine snap modifier}}
+| Selects the modifier key used to temporarily switch to fine snap behavior while dragging. {{Version|1.2}}
+|-
+| {{MenuCommand|Default coarse drag behavior}}
+| Determines whether dragging is coarse or fine when the fine snap modifier key is not pressed. {{Version|1.2}}
+|-
+| {{MenuCommand|Coarse movement multiplier}}
+| Sets the multiplier applied to linear dragger snap steps in coarse mode. {{Version|1.2}}
+|-
+| {{MenuCommand|Coarse rotation step (degrees)}}
+| Sets the rotation snap step used by rotational draggers in coarse mode. {{Version|1.2}}
 |}
 
 ===Shape View===


### PR DESCRIPTION
Addresses #79.

This updates the PartDesign preferences page for entries that are present in the current FreeCAD UI but were still undocumented or marked as TBD.

Summary:
- replace TBD descriptions for Part Design refinement, profile highlighting, and interactive dragger preferences
- document the FreeCAD 1.2 coarse/fine dragger snapping preferences
- keep the update limited to wiki/en/PartDesign_Preferences.wikitext

Sources checked:
- FreeCAD/FreeCAD#22880 introduced interactive Part Design draggers
- FreeCAD/FreeCAD#28384 added configurable coarse/fine dragger snapping preferences
- FreeCAD/FreeCAD#29631 added input hints for fine/coarse draggers

Verification:
- compared the descriptions against the current FreeCAD DlgSettingsGeneral.ui preference labels and tooltips
- searched open PRs; found no existing open PR for these PartDesign_Preferences dragger entries
- compared the branch against upstream main: only wiki/en/PartDesign_Preferences.wikitext changes (+20/-5)