### PR TITLE
Document PartDesign Draft interactive dragger

### DIFF
--- a/wiki/en/PartDesign_Draft.wikitext
+++ b/wiki/en/PartDesign_Draft.wikitext
@@ -57,6 +57,7 @@ The [[Image:PartDesign_Draft.svg|24px]] '''PartDesign Draft''' tool creates angu
 ** Select one or more faces in the list and press the {{KEY|Del}} key or right-click the list and select {{MenuCommand|Remove}} from the context menu.
 ** Press the {{Button|Remove face}} button. All previously selected faces are highlighted in purple. Select each face to be removed.
 * {{MenuCommand|Draft angle}}: Set the Draft angle either by entering a value or by clicking the up/down arrows.
+** {{Version|1.2}}: If the {{MenuCommand|Show interactive draggers when editing features}} [[PartDesign_Preferences#General|preference]] is enabled, the Draft angle can also be adjusted with an interactive dragger in the [[3D_View|3D View]].
 * {{MenuCommand|Neutral plane}}: Set the the neutral plane by pressing the {{Button|Neutral plane}} button and selecting the plane that must not change dimensionally.
 * {{MenuCommand|Pull direction}}: Set the the pull direction by pressing the {{Button|Pull direction}} button, then select an edge. Pull Direction is only effective if the Neutral Plane has been set. Results can be unpredictable.
 * {{MenuCommand|Reverse pull direction}}: Invert the pull direction by checking the {{MenuCommand|Reverse pull direction}} checkbox. This will toggle the draft between positive and negative angles.


### PR DESCRIPTION
Addresses #79.

Summary:
- Document that the PartDesign Draft angle can be adjusted with an interactive dragger when the PartDesign dragger preference is enabled.
- Cross-link the related PartDesign Preferences section and 3D View page.

Source:
- FreeCAD/FreeCAD#27111 added the interactive gizmo for the Draft operation.

Validation:
- Documentation-only change; verified the target page did not already mention the Draft interactive dragger.