### PR TITLE
Document PartDesign Body spacebar visibility

### DIFF
--- a/wiki/PartDesign_Body.wikitext
+++ b/wiki/PartDesign_Body.wikitext
@@ -207,7 +207,10 @@ Once the sub-elements have been used with other workbenches, {{PropertyView|Disp
 The Body's visibility supersedes the visibility of any object it contains. If the Body is hidden, the objects it contains will be hidden as well, even if their individual {{PropertyView|Visibility}} property is set to {{TRUE}}.
 
 <!--T:86-->
-Multiple [[Sketch|Sketches]] may be visible at one time, but only one [[PartDesign_Feature|PartDesign Feature]] (solid result) can be visible at a time. Selecting a hidden feature and pressing the {{KEY|Space}} bar in the keyboard will make it visible, and automatically hide the previously visible feature.
+Multiple [[Sketch|Sketches]] may be visible at one time, but only one [[PartDesign_Feature|PartDesign Feature]] (solid result) can be visible at a time. In the [[Tree_View|Tree View]], selecting a hidden feature and pressing the {{KEY|Space}} bar on the keyboard will make it visible, and automatically hide the previously visible feature.
+
+<!--T:102-->
+{{Version|1.2}} Pressing the {{KEY|Space}} bar for an element selected from the [[3D_View|3D View]] toggles the visibility of the whole Body. Pressing the {{KEY|Space}} bar for an element selected from the [[Tree_View|Tree View]] toggles the selected object.
 
 <!--T:87-->
 [[File:PartDesign_Body_Visibility.png]]


### PR DESCRIPTION
Addresses #79. Documents the FreeCAD 1.2 PartDesign Body Space-bar visibility behavior from FreeCAD/FreeCAD#29110 and FreeCAD/FreeCAD#30231. Verification: git diff --check. Page-scoped docs-only change to wiki/PartDesign_Body.wikitext; no wiki/en files touched.