### PR TITLE
Document PartDesign New Sketch attachment dialog behavior

### DIFF
--- a/wiki/en/PartDesign_NewSketch.wikitext
+++ b/wiki/en/PartDesign_NewSketch.wikitext
@@ -28,14 +28,17 @@ When creating models using the [[PartDesign_Workbench|PartDesign workbench]], th
 # There are several ways to invoke the tool:
 #* Press the {{Button|[[File:PartDesign_NewSketch.svg|16px]] [[PartDesign_NewSketch|New Sketch]]}} button.
 #* Select the {{MenuCommand|Sketch → [[Image:PartDesign_NewSketch.svg|16px]] New Sketch}} option from the menu.
-# In the Tasks panel, the '''Select Attachment''' dialog is brought up. Select one of the planes in the list or in the 3D View which can be reoriented for better visibility.
+# If a single planar face or datum plane in the active body was selected before invoking the command, and the [[PartDesign_Preferences#General|Always open attachment dialog for new sketches]] preference is disabled, the sketch is instantly created on that support. {{Version|1.2}}
+# Otherwise the '''Select Attachment''' dialog is brought up in the Tasks panel. This includes cases where no support is selected, the selection contains multiple items, the selection is not a planar face or datum plane, a sketch is selected, the {{KEY|Shift}} key is held while invoking the command, or the preference mentioned above is enabled. {{Version|1.2}}
+# Select one of the planes in the list or in the 3D View. The view can be reoriented for better visibility.
 # Press {{Button|OK}}.
 # The interface automatically switches to the Sketcher workbench and the sketch can be edited. Once the sketch is exited, the interface is brought back to the PartDesign workbench and the 3D View is restored to the view orientation prior to creating the sketch.
-# Alternatively, a plane or a face on the existing active body can be selected before creating the sketch, in which case the sketch is instantly created.
 
 ==Options==
 
 * To change the attachment of an existing sketch, change its {{Emphasis|Map Mode}} property (see [[#Properties|Properties]].)
+
+* {{Version|1.2}} To force the ''Select Attachment'' dialog for the current command, hold {{KEY|Shift}} while invoking the tool. To make that the default behavior, enable the [[PartDesign_Preferences#General|Always open attachment dialog for new sketches]] preference.
 
 * The ''Select Attachment'' Dialog defines the attachment of a new sketch
 ::[[File:PartDesign.CreateSketch.SelectFeatureDialog.jpeg|300px]]

--- a/wiki/en/PartDesign_Preferences.wikitext
+++ b/wiki/en/PartDesign_Preferences.wikitext
@@ -49,6 +49,9 @@ On this page you can specify the following:
 * '''Points, circles and arcs'''
 * '''Points'''
 |-
+| {{MenuCommand|Always open attachment dialog for new sketches}}
+| If checked, the [[Part_EditAttachment|Attachment]] dialog is opened whenever [[PartDesign_NewSketch|New Sketch]] is used. If unchecked, a single selected planar face or datum plane creates the sketch directly; other selections, no selection, or holding {{KEY|Shift}} still open the dialog. {{Version|1.2}}
+|-
 | {{MenuCommand|Switch to task panel when entering Part Design workbench}}
 | If checked, when Part Design workbench is activated, the [[Task_Panel|task panel]] is automatically opened. {{Version|1.1}}
 |-
@@ -151,7 +154,6 @@ In order to display an object efficiently its surface is [https://en.wikipedia.o
 There is a lower limit for the tessellation of 0.01%. If you really want to spend the additional time you can reduce the lower limit even further by opening the [[Std_DlgParameter|Parameter Editor]].
 
 In the Parameter Editor navigate to {{MenuCommand|BaseApp → Preferences → Mod → Part}}, right-click on '''MeshDeviation''', and choose '''Change value''' from the context menu. Set the value to the minimum tessellation of your choice. Please keep in mind that the value is in %, i.e. for a value of 0.005% you have to enter {{Value|0.00005}}. The smallest possible value is {{Value|1e-7}}. Note that in the [[Preferences_Editor|Preferences Editor]] you will still see 0.01% even if you have set a lower value.
-
 
 {{Docnav
 |[[PartDesign_MoveFeatureInTree|Move Feature After…]]


### PR DESCRIPTION
Addresses #79.

Summary:
- updates the PartDesign New Sketch page for the FreeCAD 1.2 attachment-dialog workflow
- documents when a single selected planar face or datum plane skips the dialog
- documents the fallback cases that still open Select Attachment, including no selection, multiple selections, sketches, non-planar selections, Shift, and the new preference
- adds the Part/Part Design preference entry for Always open attachment dialog for new sketches

Verification:
- checked the wording against the upstream FreeCAD implementation and UI label
- checked the branch is based on the current upstream main and is not behind it
- checked the edited wikitext keeps the existing navigation blocks and balanced preference tables
