### PR TITLE
Document suppressed PartDesign feature strikethrough

### DIFF
--- a/wiki/en/Tree_View.wikitext
+++ b/wiki/en/Tree_View.wikitext
@@ -86,6 +86,8 @@ This indicates the so called [[PartDesign_Body#Tip|Tip]] of a [[PartDesign_Body|
 
 This indicates a suppressed [[PartDesign_Workbench|PartDesign]] feature.
 
+{{Version|1.2}} Suppressed PartDesign features are also displayed with a strikethrough label in the Tree View. The strikethrough is restored when a document with suppressed features is reopened.
+
 === [[File:FreeCAD_Tree_view_link.png]] White upwards curved arrow ===
 
 This indicates a [[Std_LinkMake|linked]] object.


### PR DESCRIPTION
Addresses #79.

Summary:
- documents the FreeCAD 1.2 Tree View behavior for suppressed PartDesign features
- notes that suppressed features now show a strikethrough label in addition to the red backslash overlay
- notes that the strikethrough state is restored after reopening a document

Verification:
- checked the wording against the upstream FreeCAD suppressed-feature change
- checked no open PR currently edits wiki/en/Tree_View.wikitext
- checked the branch is ahead of current main and not behind it
