### PR TITLE
Document PartDesign pattern on-view spacing labels

### DIFF
--- a/wiki/en/PartDesign_LinearPattern.wikitext
+++ b/wiki/en/PartDesign_LinearPattern.wikitext
@@ -76,6 +76,7 @@ The [[Image:PartDesign_LinearPattern.svg|24px]] '''PartDesign LinearPattern''' t
 ** {{MenuCommand|Overall Length}}: Enter the {{MenuCommand|Length}} from a given point on the first occurrence to the same point on the last occurrence.
 ** {{Version|1.0}}: {{MenuCommand|Offset}}: Enter the {{MenuCommand|Offset}} from a given point on the first occurrence to the same point on the next occurrence. For n occurrences: OverallLength=(n-1)*Offset.
 * Specify the number of {{MenuCommand|Occurrences}} (including the original feature).
+* {{Version|1.2}} While the task panel is open, editable dimension labels are displayed in the [[3D_View|3D View]]. In overall length mode the label controls the total pattern length. In spacing mode, individual spacing labels can be edited to override the spacing between specific occurrences; right-click an overridden label and select {{MenuCommand|Reset spacing}} to return it to the common spacing value.
 * If the {{MenuCommand|Update view}} checkbox is checked the view will update in real time.
 
 ==Limitations==

--- a/wiki/en/PartDesign_PolarPattern.wikitext
+++ b/wiki/en/PartDesign_PolarPattern.wikitext
@@ -76,6 +76,7 @@ The [[Image:PartDesign_PolarPattern.svg|24px]] '''PartDesign PolarPattern''' too
 ** {{MenuCommand|Overall Angle}}: Enter the overall {{MenuCommand|Angle}}. If the angle is less than 360°, the occurrences are evenly distributed from 0° (first occurrence) to the given angle (last occurrence). If the angle is 360°, the occurrences are evenly distributed around the circle. For n occurrences an angle of 360° is equivalent to an angle of 360°*(1-1/n).
 ** {{Version|1.0}}: {{MenuCommand|Offset Angle}}: Enter the {{MenuCommand|Offset}} angle from a given point on the first occurrence to the same point on the next occurrence. For n occurrences: OverallAngle=(n-1)*Offset.
 * Specify the number of {{MenuCommand|Occurrences}} (including the original feature).
+* {{Version|1.2}} While the task panel is open, editable angle labels are displayed in the [[3D_View|3D View]]. In overall angle mode the label controls the total pattern angle. In angular spacing mode, individual spacing labels can be edited to override the angle between specific occurrences; right-click an overridden label and select {{MenuCommand|Reset spacing}} to return it to the common angular spacing value.
 * If the {{MenuCommand|Update view}} checkbox is checked the view will update in real time.
 
 == Ordering features ==


### PR DESCRIPTION
Addresses #79.

Summary:
- documents the FreeCAD 1.2 on-view labels added to PartDesign LinearPattern and PolarPattern editing
- explains that the total length/angle label can be edited in overall mode
- explains individual spacing overrides in spacing mode and the Reset spacing context action

Verification:
- checked the wording against the current FreeCAD PatternParametersWidget behavior and UI action text
- checked no open PR currently edits these two wiki/en PartDesign pattern pages
- checked the branch is ahead of current main and not behind it
