### PR TITLE
Document PartDesign pattern on-view spacing labels

### DIFF
--- a/wiki/PartDesign_LinearPattern.wikitext
+++ b/wiki/PartDesign_LinearPattern.wikitext
@@ -86,7 +86,7 @@ The [[Image:PartDesign_LinearPattern.svg|24px]] '''PartDesign LinearPattern''' t
 *** {{MenuCommand|Extent}}: Enter the {{MenuCommand|Length}} from a given point on the first occurrence to the same point on the last occurrence.
 *** {{Version|1.0}}: {{MenuCommand|Spacing}}: Enter the {{MenuCommand|Spacing}} from a given point on the first occurrence to the same point on the next occurrence. For n occurrences: Extent=(n-1)*Spacing.
 ** Specify the number of {{MenuCommand|Occurrences}} (including the original feature).
-** {{Version|1.2}}: The length or spacing and occurrence values can also be edited with [[Sketcher_Workbench#On-View-Parameters|On-View Parameters]] in the [[3D_View|3D View]].
+** {{Version|1.2}}: The length or spacing and occurrence values can also be edited with [[Sketcher_Workbench#On-View-Parameters|On-View Parameters]] in the [[3D_View|3D View]]. Individual spacing labels can be edited to override specific gaps; right-click an overridden label and choose {{MenuCommand|Reset spacing}} to restore the uniform spacing.
 * {{MenuCommand|Direction 2}}: Idem. {{Version|1.1}}
 * If the {{MenuCommand|Recompute on change}} checkbox is checked the view will update in real time.
 

--- a/wiki/PartDesign_PolarPattern.wikitext
+++ b/wiki/PartDesign_PolarPattern.wikitext
@@ -86,7 +86,7 @@ The [[Image:PartDesign_PolarPattern.svg|24px]] '''PartDesign PolarPattern''' too
 *** {{MenuCommand|Total Angle}}: If the angle is less than 360°, the occurrences are evenly distributed from 0° (first occurrence) to the given angle (last occurrence). If the angle is 360°, the occurrences are evenly distributed around the circle. For n occurrences an angle of 360° is equivalent to an angle of 360°*(1-1/n).
 *** {{Version|1.0}}: {{MenuCommand|Angular spacing}}: Enter the angle from a given point on the first occurrence to the same point on the next occurrence. For n occurrences: TotalAngle=(n-1)*Spacing.
 ** Specify the number of {{MenuCommand|Occurrences}} (including the original feature).
-* {{Version|1.2}}: The angle or offset and occurrence values can also be edited with [[Sketcher_Workbench#On-View-Parameters|On-View Parameters]] in the [[3D_View|3D View]].
+* {{Version|1.2}}: The angle or offset and occurrence values can also be edited with [[Sketcher_Workbench#On-View-Parameters|On-View Parameters]] in the [[3D_View|3D View]]. Individual angular spacing labels can be edited to override specific gaps; right-click an overridden label and choose {{MenuCommand|Reset spacing}} to restore the uniform spacing.
 * If the {{MenuCommand|Recompute on change}} checkbox is checked the view will update in real time.
 
 == Ordering features == <!--T:35-->


### PR DESCRIPTION
Addresses #79.

Scope:
- updates only `wiki/PartDesign_LinearPattern.wikitext`
- updates only `wiki/PartDesign_PolarPattern.wikitext`
- no translation mirror files are changed
- no new `<!--T:...-->` translation markers are added

Source:
- FreeCAD/FreeCAD#23997, merged on 2026-05-08, introduced the PartDesign pattern on-view parameter controls and spacing/angle override UI.

Summary:
- keeps the existing current-wiki On-View Parameters notes for Linear Pattern and Polar Pattern
- adds the missing user-facing detail that individual spacing/angular spacing labels can override specific gaps
- documents the reset action for restoring uniform spacing

Verification:
- checked the current PR diff changes only the two root `wiki/` pages listed above
- aligned the branch with the latest upstream `main` content so the PR no longer conflicts with the already merged generic OVP wording
- checked the remaining wording against the merged FreeCAD implementation and current page content to avoid duplicate text
- kept the text user-facing; no translation pages, development-only details, or regression-only notes are included
