### PR TITLE
Document suppressed PartDesign feature strikethrough

### DIFF
--- a/wiki/Tree_View.wikitext
+++ b/wiki/Tree_View.wikitext
@@ -110,7 +110,7 @@ This indicates the so called [[PartDesign_Body#Tip|Tip]] of a [[PartDesign_Body|
 {{Version|1.0}}
 
 <!--T:64-->
-This indicates a suppressed [[PartDesign_Workbench|PartDesign]] feature.
+This indicates a suppressed [[PartDesign_Workbench|PartDesign]] feature. Suppressed PartDesign features also show their label with strikethrough text in the Tree View.
 
 === [[File:FreeCAD_Tree_view_link.png]] White upwards curved arrow === <!--T:69-->
 


### PR DESCRIPTION
Addresses #79.

This replaces the earlier closed attempt by updating the root wiki page under `wiki/` instead of the `wiki/en/` mirror page.

Summary:
- updates the suppressed PartDesign feature overlay entry in the Tree View page
- documents that suppressed feature labels are shown with strikethrough text

Verification:
- checked the changed file is `wiki/Tree_View.wikitext`
- checked the behavior against FreeCAD PR #27808
