### PR TITLE
Document PartDesign New Sketch attachment dialog behavior

### DIFF
--- a/wiki/PartDesign_NewSketch.wikitext
+++ b/wiki/PartDesign_NewSketch.wikitext
@@ -25,6 +25,8 @@
 <!--T:11-->
 This tool creates a new sketch, creates a new [[PartDesign_Body|PartDesign Body]] to contain the sketch if one does not exist and automatically opens the [[Sketcher_Workbench|Sketcher workbench]] after creation.
 
+Starting with FreeCAD 1.1, if a single planar face or datum plane is selected before invoking the command, the new sketch is attached directly to that selection. The '''Select Attachment''' dialog is opened for all other cases, including no selection, multiple selections, non-planar selections, selecting an existing sketch, holding {{KEY|Shift}} while invoking the command, or enabling the related preference.
+
 <!--T:12-->
 When creating models using the [[PartDesign_Workbench|PartDesign workbench]], this tool should be preferred to the {{Button|[[File:Sketcher_NewSketch.svg|16px]] [[Sketcher_NewSketch|Sketcher NewSketch]]}} tool found in the [[Sketcher_Workbench|Sketcher workbench]].
 
@@ -34,15 +36,17 @@ When creating models using the [[PartDesign_Workbench|PartDesign workbench]], th
 # There are several ways to invoke the tool:
 #* Press the {{Button|[[File:PartDesign_NewSketch.svg|16px]] [[PartDesign_NewSketch|New Sketch]]}} button.
 #* Select the {{MenuCommand|Sketch → [[Image:PartDesign_NewSketch.svg|16px]] New Sketch}} option from the menu.
-# In the Tasks panel, the '''Select Attachment''' dialog is brought up. Select one of the planes in the list or in the 3D View which can be reoriented for better visibility.
+# In the Tasks panel, if no suitable single planar selection was made, the '''Select Attachment''' dialog is brought up. Select one of the planes in the list or in the 3D View which can be reoriented for better visibility.
 # Press {{Button|OK}}.
 # The interface automatically switches to the Sketcher workbench and the sketch can be edited. Once the sketch is exited, the interface is brought back to the PartDesign workbench and the 3D View is restored to the view orientation prior to creating the sketch.
-# Alternatively, a plane or a face on the existing active body can be selected before creating the sketch, in which case the sketch is instantly created.
+# Alternatively, a single datum plane or planar face on the existing active body can be selected before creating the sketch, in which case the sketch is instantly created without opening the attachment dialog.
 
 ==Options== <!--T:6-->
 
 <!--T:13-->
 * To change the attachment of an existing sketch, change its {{Emphasis|Map Mode}} property (see [[#Properties|Properties]].)
+
+* To always show the '''Select Attachment''' dialog when creating a new sketch, enable the {{MenuCommand|Always open attachment dialog for new sketches}} preference in [[PartDesign_Preferences#General|Part/Part Design preferences]]. Holding {{KEY|Shift}} while invoking the command has the same effect for that invocation.
 
 <!--T:20-->
 * The ''Select Attachment'' Dialog defines the attachment of a new sketch

--- a/wiki/PartDesign_Preferences.wikitext
+++ b/wiki/PartDesign_Preferences.wikitext
@@ -63,6 +63,9 @@ On this page you can specify the following:
 | {{MenuCommand|Switch to task panel when entering Part Design workbench}}
 | If checked, when Part Design workbench is activated, the [[Task_Panel|task panel]] is automatically opened. {{Version|1.1}}
 |-
+| {{MenuCommand|Always open attachment dialog for new sketches}}
+| If checked, [[PartDesign_NewSketch|New Sketch]] always opens the '''Select Attachment''' dialog instead of attaching directly to a preselected single planar face or datum plane. {{Version|1.1}}
+|-
 | {{MenuCommand|Show final result by default when editing features}}
 | If checked, final result of a feature is shown by default when editing it. {{Version|1.1}}
 |-


### PR DESCRIPTION
Addresses #79.

Scope:
- updates only `wiki/PartDesign_NewSketch.wikitext`
- updates only `wiki/PartDesign_Preferences.wikitext`
- no translation mirror files are changed
- no new `<!--T:...-->` translation markers are added

Source:
- FreeCAD/FreeCAD#29168, merged on 2026-04-24, added the current PartDesign New Sketch attachment-dialog behavior and the related preference.

Summary:
- documents when PartDesign New Sketch opens the Select Attachment dialog
- documents direct attachment for a preselected single planar face or datum plane
- documents the preference that always opens the attachment dialog

Verification:
- checked the current PR diff changes only the two root `wiki/` pages listed above
- checked the behavior against the merged FreeCAD implementation and current page content to avoid duplicate text
- kept the text user-facing; no translation pages, development-only details, or regression-only notes are included
