### PR TITLE
Document Sketcher angle dimension placement

### DIFF
--- a/wiki/Sketcher_ConstrainAngle.wikitext
+++ b/wiki/Sketcher_ConstrainAngle.wikitext
@@ -83,6 +83,9 @@ The angle of the line with the positive X-axis of the sketch is fixed.
 <!--T:13-->
 The aperture angle of the arc is fixed.
 
+<!--T:44-->
+{{Version|1.2}}: When the constraint is created, the dimension label is placed outside the arc for better readability.
+
 ===Between two lines=== <!--T:34-->
 
 </translate>
@@ -90,7 +93,10 @@ The aperture angle of the arc is fixed.
 <translate>
 
 <!--T:16-->
-The angle between the two lines is fixed. It is not required that the lines intersect. 
+The angle between the two lines is fixed. It is not required that the lines intersect.
+
+<!--T:45-->
+{{Version|1.2}}: If the selected lines do not intersect within the current view, the dimension label is placed near the visible geometry instead of at the off-screen intersection point.
 
 ===Between two edges at point=== <!--T:35-->
 

--- a/wiki/Sketcher_ConstrainDistance.wikitext
+++ b/wiki/Sketcher_ConstrainDistance.wikitext
@@ -73,6 +73,7 @@ See also: [[Sketcher_Workbench#Drawing_aids|Drawing aids]].
 
 <!--T:30-->
 See [[Sketcher_Dimension#Notes|Sketcher Dimension]].
+* {{Version|1.2}} The dimension label is initially placed away from the measured line to reduce overlap with the selected geometry.
 * {{Version|1.2}} For point-line and circle/arc distance constraints, the solver preserves the intended orientation of the constraint more reliably. This reduces unexpected [[Sketcher_Workbench#Flipping|flips]] when geometry changes.
 * If needed, toggling a constraint between [[Sketcher_ToggleDrivingConstraint|driving and reference]], or deactivating and reactivating it, can recompute its orientation.
 

--- a/wiki/Sketcher_ConstrainDistanceX.wikitext
+++ b/wiki/Sketcher_ConstrainDistanceX.wikitext
@@ -69,6 +69,7 @@ See also: [[Sketcher_Workbench#Drawing_aids|Drawing aids]].
 
 <!--T:23-->
 See [[Sketcher_Dimension#Notes|Sketcher Dimension]].
+* {{Version|1.2}} The dimension label is initially placed to the side of the measured horizontal span to reduce overlap with the selected geometry.
 
 == Scripting == <!--T:13-->
 

--- a/wiki/Sketcher_ConstrainDistanceY.wikitext
+++ b/wiki/Sketcher_ConstrainDistanceY.wikitext
@@ -56,6 +56,7 @@ See [[Sketcher_ConstrainDistanceX#Run-once_mode|Sketcher ConstrainDistanceX]].
 
 <!--T:23-->
 See [[Sketcher_Dimension#Notes|Sketcher Dimension]].
+* {{Version|1.2}} The dimension label is initially placed to the side of the measured vertical span to reduce overlap with the selected geometry.
 
 == Scripting == <!--T:13-->
 


### PR DESCRIPTION
Summary:
- Add FreeCAD 1.2 notes for Sketcher angle dimension label placement.
- Cover arc angle labels and non-intersecting line angle labels.

Testing:
- Documentation-only change; checked the edited wikitext manually.

Refs #94