### PR TITLE
[metatron] Document CAM Profile vertical face selection (1.2)

### DIFF
--- a/wiki/CAM_Profile.wikitext
+++ b/wiki/CAM_Profile.wikitext
@@ -40,6 +40,9 @@ A Contour operation is the default. It creates a simple external contour cut of 
 <!--T:74-->
 A Profile Face operation creates a simple contour path from one or more selected faces of an object.
 
+<!--T:contour_vertical_faces-->
+In FreeCAD 1.2 and above, vertical faces can also be selected ([https://github.com/FreeCAD/FreeCAD/pull/27236 PR #27236]). Selecting vertical faces creates both open and closed area contours, with the internal {{incode|areaOpShapes()}} logic handling classification automatically.
+
 ===Profile Edges operation=== <!--T:75-->
 
 <!--T:76-->


### PR DESCRIPTION
## Summary
- Document CAM Profile vertical face selection support in FreeCAD 1.2
- Add usage note: vertical faces can be selected for open/closed area contours
- Reference internal areaOpShapes() refactor

## Source
- FreeCAD/FreeCAD#27236

## Validation
- Content diff: +1 paragraph in Profile Face section
- No translation markers changed

Related to #25.