### PR TITLE
Fix PartDesign Draft note root wiki path

### DIFF
--- a/wiki/PartDesign_Draft.wikitext
+++ b/wiki/PartDesign_Draft.wikitext
@@ -69,6 +69,7 @@ The [[Image:PartDesign_Draft.svg|24px]] '''PartDesign Draft''' tool creates angu
 ** Select one or more faces in the list and press the {{KEY|Del}} key or right-click the list and select {{MenuCommand|Remove}} from the context menu.
 ** Press the {{Button|Remove face}} button. All previously selected faces are highlighted in purple. Select each face to be removed.
 * {{MenuCommand|Draft angle}}: Set the Draft angle either by entering a value or by clicking the up/down arrows.
+** {{Version|1.2}}: If the {{MenuCommand|Show interactive draggers when editing features}} [[PartDesign_Preferences#General|preference]] is enabled, the Draft angle can also be adjusted with an interactive dragger in the [[3D_View|3D View]].
 * {{MenuCommand|Neutral plane}}: Set the the neutral plane by pressing the {{Button|Neutral plane}} button and selecting the plane that must not change dimensionally.
 * {{MenuCommand|Pull direction}}: Set the the pull direction by pressing the {{Button|Pull direction}} button, then select an edge. Pull Direction is only effective if the Neutral Plane has been set. Results can be unpredictable.
 * {{MenuCommand|Reverse pull direction}}: Invert the pull direction by checking the {{MenuCommand|Reverse pull direction}} checkbox. This will toggle the draft between positive and negative angles.

--- a/wiki/en/PartDesign_Draft.wikitext
+++ b/wiki/en/PartDesign_Draft.wikitext
@@ -57,7 +57,6 @@ The [[Image:PartDesign_Draft.svg|24px]] '''PartDesign Draft''' tool creates angu
 ** Select one or more faces in the list and press the {{KEY|Del}} key or right-click the list and select {{MenuCommand|Remove}} from the context menu.
 ** Press the {{Button|Remove face}} button. All previously selected faces are highlighted in purple. Select each face to be removed.
 * {{MenuCommand|Draft angle}}: Set the Draft angle either by entering a value or by clicking the up/down arrows.
-** {{Version|1.2}}: If the {{MenuCommand|Show interactive draggers when editing features}} [[PartDesign_Preferences#General|preference]] is enabled, the Draft angle can also be adjusted with an interactive dragger in the [[3D_View|3D View]].
 * {{MenuCommand|Neutral plane}}: Set the the neutral plane by pressing the {{Button|Neutral plane}} button and selecting the plane that must not change dimensionally.
 * {{MenuCommand|Pull direction}}: Set the the pull direction by pressing the {{Button|Pull direction}} button, then select an edge. Pull Direction is only effective if the Neutral Plane has been set. Results can be unpredictable.
 * {{MenuCommand|Reverse pull direction}}: Invert the pull direction by checking the {{MenuCommand|Reverse pull direction}} checkbox. This will toggle the draft between positive and negative angles.


### PR DESCRIPTION
Follow-up to #82 after the maintainer review.

This moves the added PartDesign Draft interactive-dragger note from the translation page to the root wiki page, so the `wiki/en/...` page is not changed for this documentation update.