### PR TITLE
Document Sketcher Merge Sketches 1.2 behavior

### DIFF
--- a/wiki/Sketcher_MergeSketches.wikitext
+++ b/wiki/Sketcher_MergeSketches.wikitext
@@ -24,6 +24,8 @@
 <!--T:3-->
 The [[Image:Sketcher_MergeSketches.svg|24px]] [[Sketcher_MergeSketches|Sketcher MergeSketches]] tool merges two or more sketches.
 
+{{Version|1.2}}: External geometry referenced by the source sketches is imported into the merged sketch when it is in scope, and constraints that reference this geometry are remapped. If all selected sketches are inside the same [[PartDesign_Body|PartDesign Body]], the merged sketch is created inside that Body.
+
 ==Usage== <!--T:4-->
 
 <!--T:5-->
@@ -32,6 +34,12 @@ The [[Image:Sketcher_MergeSketches.svg|24px]] [[Sketcher_MergeSketches|Sketcher 
 #* Press the {{Button|[[Image:Sketcher_MergeSketches.svg|16px]] [[Sketcher_MergeSketches|Merge Sketches]]}} button (not available in the [[PartDesign_Workbench|PartDesign Workbench]]).
 #* Select the {{MenuCommand|Sketch → [[Image:Sketcher_MergeSketches.svg|16px]] Merge Sketches}} option from the menu.
 # A new sketch is created.
+
+==Notes== <!--T:8-->
+
+<!--T:9-->
+* External geometry that is out of scope for the destination sketch is not imported.
+* If equivalent external geometry is already present in the destination sketch, it is reused.
 
 
 <!--T:7-->


### PR DESCRIPTION
Summary:
- Document the FreeCAD 1.2 Merge Sketches behavior added in FreeCAD/FreeCAD#29497.
- Mention external geometry import/reuse rules and same-Body placement for merged sketches.

Testing:
- Documentation-only change.
- Ran `git diff --check -- wiki/Sketcher_MergeSketches.wikitext`.

Refs #94