### PR TITLE
Document reworked Sketcher Polyline tool

### DIFF
--- a/wiki/Sketcher_CreatePolyline.wikitext
+++ b/wiki/Sketcher_CreatePolyline.wikitext
@@ -16,14 +16,14 @@
 |Name=Sketcher CreatePolyline
 |MenuLocation=Sketch → Geometries → Polyline
 |Workbenches=[[Sketcher_Workbench|Sketcher]]
-|Shortcut={{KEY|G}} {{KEY|M}}
+|Shortcut={{KEY|L}}
 |SeeAlso=[[Sketcher_CreateLine|Sketcher CreateLine]]
 }}
 
 ==Description== <!--T:2-->
 
 <!--T:3-->
-The [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|Sketcher CreatePolyline]] tool creates a series of line and arc segments connected by their endpoints. The tool has several modes.
+The [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|Sketcher CreatePolyline]] tool creates a connected chain of line and circular arc segments. {{Version|1.2}}: The Polyline command uses the reworked Sketcher polyline tool, with a Line/Arc segment selector, On-View-Parameters support, an optional fillet mode, and automatic constraints while the chain is being drawn.
 
 </translate>
 [[Image:Sketcher_PolylineExample1.png]]
@@ -42,28 +42,31 @@ See also: [[Sketcher_Workbench#Drawing_aids|Drawing aids]].
 #* Press the {{Button|[[Image:Sketcher_CreatePolyline.svg|16px]] [[Sketcher_CreatePolyline|Polyline]]}} button.
 #* Select the {{MenuCommand|Sketch → Geometries → [[Image:Sketcher_CreatePolyline.svg|16px]] Polyline}} option from the menu.
 #* Right-click in the [[3D_View|3D View]] and select the {{MenuCommand|[[Image:Sketcher_CreatePolyline.svg|16px]] Polyline}} option from the context menu.
-#* Use the keyboard shortcut: {{KEY|G}} then {{KEY|M}}.
+#* Use the keyboard shortcut: {{KEY|L}}.
 # The cursor changes to a cross with the tool icon.
-# The modes of the tool require a previous segment. Do one of the following:
-#* Pick two points to define a line segment.
-#* Pick the endpoint of an existing line or arc segment ([[Sketcher_Workbench#Auto_constraints|Auto constraints]] must be enabled).
-# Optionally press the {{KEY|M}} key one or more times to cycle through the modes for the next segment. The available modes are:
-#* Line perpendicular to the previous segment.
-#* Line tangential to the previous segment (this is the initial mode if the previous segment is an arc).
-#* Arc tangential to the previous segment.
-#* Arc perpendicular (left) to the previous segment.
-#* Arc perpendicular (right) to the previous segment.
-#* Line only connected to the previous segment.
-# While in any of the arc modes, optionally hold down the {{KEY|Ctrl}} key to snap the arc to increments of 45° relative to the previous segment.
+# Pick the start point of the polyline.
+#* If positional [[Sketcher_Workbench#On-View-Parameters|On-View-Parameters]] are enabled, enter the X and Y coordinates and confirm them with {{KEY|Enter}} or {{KEY|Tab}}.
+# The first segment is created as a line. For later segments, choose {{MenuCommand|Line}} or {{MenuCommand|Arc}} in the task panel, or press {{KEY|M}} to cycle through the segment modes.
+# Optionally enable {{MenuCommand|Fillet}} in the task panel, or press {{KEY|F}}, to add a fillet between the current and previous line segment.
+# Move the pointer to preview the next segment.
+#* For a line segment, dimensional On-View-Parameters can set the segment length and angle. For the first segment the angle is measured from the sketch X-axis. For later line segments the angle is measured from the direction of the previous segment.
+#* For an arc segment, dimensional On-View-Parameters can set the radius, the arc angle, and the angle relative to the previous segment.
 # Pick the endpoint of the segment.
-# Optionally repeat this to create more segments.
+# The segment is created and applicable constraints are added. Depending on the geometry and the entered parameters, these can include coincident, tangent, perpendicular, dimensional, radius, or angle constraints.
+# Optionally repeat the previous steps to create more segments.
+# To remove the last segment while the tool is still active, press {{KEY|R}}.
 # To finish the input do one of the following:
 #* Snap to the start point to create a closed polyline.
 #* Right-click or press {{KEY|Esc}} to create an open polyline.
-# The polyline segments have been created and applicable constraints have been added.
 # If the tool runs in [[Sketcher_Workbench#Continue_modes|continue mode]]:
 ## Optionally keep creating polylines.
 ## To finish, right-click or press {{KEY|Esc}}, or start another geometry or constraint creation tool.
+
+<!--T:16-->
+Notes:
+* A polyline always starts with a line segment. Arc segments can be selected after at least one segment exists.
+* The {{KEY|R}} shortcut only removes the last segment created in the current active polyline operation.
+* The {{MenuCommand|Fillet}} option is intended for line-to-line transitions. It creates a fillet as the new segment is accepted.
 
 
 <!--T:11-->

--- a/wiki/Sketcher_CreatePolyline.wikitext
+++ b/wiki/Sketcher_CreatePolyline.wikitext
@@ -62,7 +62,6 @@ See also: [[Sketcher_Workbench#Drawing_aids|Drawing aids]].
 ## Optionally keep creating polylines.
 ## To finish, right-click or press {{KEY|Esc}}, or start another geometry or constraint creation tool.
 
-<!--T:16-->
 Notes:
 * A polyline always starts with a line segment. Arc segments can be selected after at least one segment exists.
 * The {{KEY|R}} shortcut only removes the last segment created in the current active polyline operation.


### PR DESCRIPTION
Refs #94.

Scope:
- updates only `wiki/Sketcher_CreatePolyline.wikitext`
- no translation mirror files are changed
- no new `<!--T:...-->` translation markers are added; follow-up commit `e98e830` removes the manually added marker from the first draft

Source:
- FreeCAD/FreeCAD#29336, merged through commit `d77c964` on 2026-05-18, reworked the Sketcher Polyline tool.
- FreeCAD commits `c6fe0ab` and `256459a` add later UI hints and cleanup for the same reworked tool.

Summary:
- updates the shortcut to `L`
- replaces the old six-mode workflow with the current Line/Arc segment selector flow
- documents On-View-Parameters behavior for start points, line segments, and arc segments
- documents the `F` fillet toggle and the `R` remove-last-segment shortcut
- adds user-facing notes for first-segment, fillet, and active-operation behavior

Verification:
- Windows: `git diff --check`; confirmed only `wiki/Sketcher_CreatePolyline.wikitext` changes and the manual T marker is gone
- WSL Ubuntu-26.04: `git diff --check`; confirmed the same file has no diff whitespace issues and no `<!--T:16-->` marker
- checked the text against the merged FreeCAD implementation and current page content to avoid duplicate text
- kept the text user-facing; no translation pages, development-only details, or regression-only notes are included
