### PR TITLE
[codex] Document PartDesign new sketch attachment behavior

### DIFF
--- a/wiki/PartDesign_NewSketch.wikitext
+++ b/wiki/PartDesign_NewSketch.wikitext
@@ -37,7 +37,10 @@ When creating models using the [[PartDesign_Workbench|PartDesign workbench]], th
 # In the Tasks panel, the '''Select Attachment''' dialog is brought up. Select one of the planes in the list or in the 3D View which can be reoriented for better visibility.
 # Press {{Button|OK}}.
 # The interface automatically switches to the Sketcher workbench and the sketch can be edited. Once the sketch is exited, the interface is brought back to the PartDesign workbench and the 3D View is restored to the view orientation prior to creating the sketch.
-# Alternatively, a plane or a face on the existing active body can be selected before creating the sketch, in which case the sketch is instantly created.
+# Alternatively, a single planar face or datum plane on the existing active body can be selected before creating the sketch, in which case the sketch is instantly created.
+
+<!--T:23-->
+{{Version|1.2}}: If the preselection is not a single planar face or datum plane, the '''Select Attachment''' dialog opens. Hold {{KEY|Shift}} while invoking the tool to open the dialog regardless of the preselection. There is also a related preference to always show the dialog.
 
 ==Options== <!--T:6-->
 

--- a/wiki/PartDesign_Workbench.wikitext
+++ b/wiki/PartDesign_Workbench.wikitext
@@ -48,7 +48,7 @@ The Part Design tools are all located in the {{MenuCommand|Part Design}} menu an
 * <span id="PartDesign_CompSketches">[[Image:PartDesign_NewSketch.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] New Sketch:</span><!--Do not edit span id: the PartDesign_CompSketches pages redirect here-->
 
 <!--T:43-->
-:*[[File:PartDesign_NewSketch.svg|32px]] [[PartDesign_NewSketch|New Sketch]]: creates a new sketch on a selected face or plane. If no face is selected while this tool is executed, the user is prompted to select a plane from the Tasks panel. The interface then switches to the [[Sketcher_Workbench|Sketcher Workbench]] in sketch editing mode.
+:*[[File:PartDesign_NewSketch.svg|32px]] [[PartDesign_NewSketch|New Sketch]]: creates a new sketch on a selected planar face or datum plane. If no such single preselection exists while this tool is executed, the user is prompted to select an attachment from the Tasks panel. The interface then switches to the [[Sketcher_Workbench|Sketcher Workbench]] in sketch editing mode.
 
 <!--T:45-->
 :* [[File:Sketcher_MapSketch.svg|32px]] [[Sketcher_MapSketch|Attach Sketch]]: attaches a sketch to geometry selected from the active body.


### PR DESCRIPTION
Refs #79.

Summary:
- Update `PartDesign_NewSketch` to describe the FreeCAD 1.2 attachment-dialog behavior for single planar face/datum preselection, non-planar or multiple preselection, Shift invocation, and the related always-show preference.
- Update the PartDesign Workbench New Sketch summary to match that behavior.

Source:
- https://github.com/FreeCAD/FreeCAD/pull/29168

Validation:
- git diff --check