### PR TITLE
[codex] Document PartDesign Hole cosmetic threads

### DIFF
--- a/wiki/PartDesign_Hole.wikitext
+++ b/wiki/PartDesign_Hole.wikitext
@@ -65,6 +65,8 @@ Depending on the specified options, some fields will be active or stay disabled.
 : If unchecked, the diameter is set according to ''Clearance'' to pass-through a thread without contact.
 * '''Model Thread''': ''Only available if threaded''
 : If checked a real thread is modeled. This consumes much computing power and is usually not used for models, except for display purposes or sometimes for 3D prints. If it is used, it is advised to check it as one of the last actions done to the model, because it will increase recomputation time significantly.
+* '''Cosmetic Thread''': ''Only available if threaded and Model Thread is unchecked'' {{Version|1.2}}
+: If checked a thread texture is shown without modeling the real thread geometry.
 * '''Direction''': ''Only available if threaded''
 : Sets the thread direction as Right Hand or Left hand.
 * '''Size''': ''Only available if threaded''


### PR DESCRIPTION
Refs #79.

Summary:
- Add the FreeCAD 1.2 `Cosmetic Thread` option to `PartDesign_Hole`.
- Clarify that it shows a thread texture without modeling real thread geometry.

Source:
- https://github.com/FreeCAD/FreeCAD/pull/22573

Validation:
- git diff --check