### PR TITLE
[codex] Document PartDesign pattern OVP controls

### DIFF
--- a/wiki/PartDesign_LinearPattern.wikitext
+++ b/wiki/PartDesign_LinearPattern.wikitext
@@ -86,6 +86,7 @@ The [[Image:PartDesign_LinearPattern.svg|24px]] '''PartDesign LinearPattern''' t
 *** {{MenuCommand|Extent}}: Enter the {{MenuCommand|Length}} from a given point on the first occurrence to the same point on the last occurrence.
 *** {{Version|1.0}}: {{MenuCommand|Spacing}}: Enter the {{MenuCommand|Spacing}} from a given point on the first occurrence to the same point on the next occurrence. For n occurrences: Extent=(n-1)*Spacing.
 ** Specify the number of {{MenuCommand|Occurrences}} (including the original feature).
+** {{Version|1.2}}: The length or spacing and occurrence values can also be edited with [[Sketcher_Workbench#On-View-Parameters|On-View Parameters]] in the [[3D_View|3D View]].
 * {{MenuCommand|Direction 2}}: Idem. {{Version|1.1}}
 * If the {{MenuCommand|Recompute on change}} checkbox is checked the view will update in real time.
 

--- a/wiki/PartDesign_PolarPattern.wikitext
+++ b/wiki/PartDesign_PolarPattern.wikitext
@@ -85,6 +85,7 @@ The [[Image:PartDesign_PolarPattern.svg|24px]] '''PartDesign PolarPattern''' too
 ** {{MenuCommand|Overall Angle}}: Enter the overall {{MenuCommand|Angle}}. If the angle is less than 360°, the occurrences are evenly distributed from 0° (first occurrence) to the given angle (last occurrence). If the angle is 360°, the occurrences are evenly distributed around the circle. For n occurrences an angle of 360° is equivalent to an angle of 360°*(1-1/n).
 ** {{Version|1.0}}: {{MenuCommand|Offset Angle}}: Enter the {{MenuCommand|Offset}} angle from a given point on the first occurrence to the same point on the next occurrence. For n occurrences: OverallAngle=(n-1)*Offset.
 * Specify the number of {{MenuCommand|Occurrences}} (including the original feature).
+* {{Version|1.2}}: The angle or offset and occurrence values can also be edited with [[Sketcher_Workbench#On-View-Parameters|On-View Parameters]] in the [[3D_View|3D View]].
 * If the {{MenuCommand|Recompute on change}} checkbox is checked the view will update in real time.
 
 == Ordering features == <!--T:35-->


### PR DESCRIPTION
Refs #79.

Summary:
- Add the FreeCAD 1.2 On-View Parameter note to `PartDesign_LinearPattern`.
- Add the matching note to `PartDesign_PolarPattern`.

Source:
- https://github.com/FreeCAD/FreeCAD/pull/23997

Validation:
- git diff --check