### PR TITLE
[codex] Document PartDesign pipe edge-list multi-selection

### DIFF
--- a/wiki/PartDesign_AdditivePipe.wikitext
+++ b/wiki/PartDesign_AdditivePipe.wikitext
@@ -48,7 +48,7 @@ The example image above shows two different cross-section shapes. The text below
 #* Alternatively, a sketch or a face of a 3D object can be selected before starting the tool. You will not get this dialog then.
 # In the '''Pipe Parameters''' under '''Path to Sweep Along''', press the {{Button|Object}} button.
 # Select the sketch to be used as a path in the 3D View. In this case, the whole sketch will be used as a path.
-#* Alternatively, single edges of the sketch can be selected by pressing {{Button|Add Edge}} and selecting edges in the 3D View. Note that you must press the {{Button|Add Edge}} for each edge again. You must select a continuous line with no branches.
+#* Alternatively, single edges of the sketch can be selected by pressing {{Button|Add Edge}} and selecting edges in the 3D View. Note that you must press the {{Button|Add Edge}} for each edge. You must select a continuous line with no branches. {{Version|1.2}} In the edge list, use {{KEY|Ctrl}} or {{KEY|Shift}} to select multiple entries, {{KEY|Ctrl}}+{{KEY|A}} to select all entries, and {{Button|Remove Edge}} to remove the selected entries together.
 # The other settings should work with the default settings in most cases.
 # Click {{Button|OK}}.
 

--- a/wiki/PartDesign_SubtractivePipe.wikitext
+++ b/wiki/PartDesign_SubtractivePipe.wikitext
@@ -39,7 +39,7 @@
 #* Alternatively, a sketch or a face of a 3D object can be selected before starting the tool. You will not get this dialog then.
 # In the '''Pipe Parameters''' under '''Profile''', press the {{Button|Object}} button.
 # Select the sketch to be used as path in the 3D View:
-#* Alternatively, edges of the body can be selected by pressing {{Button|Add Edge}} and selecting edges in the 3D View. 
+#* Alternatively, edges of the body can be selected by pressing {{Button|Add Edge}} and selecting edges in the 3D View. {{Version|1.2}} In the edge list, use {{KEY|Ctrl}} or {{KEY|Shift}} to select multiple entries, {{KEY|Ctrl}}+{{KEY|A}} to select all entries, and {{Button|Remove Edge}} to remove the selected entries together.
 # To use more than one cross-section, under '''Section Transformation''' set the Transform mode to ''Multisection''; press {{Button|Add Section}} then select a sketch in the 3D View. Repeat for each additional cross-section.
 # Set options if needed and click {{Button|OK}}.
 


### PR DESCRIPTION
## Summary
- Document FreeCAD 1.2 Additive/Subtractive Pipe edge-list multi-selection.
- Mention Ctrl/Shift multi-selection, Ctrl+A select-all, and removing selected edge entries together.
- Source: FreeCAD/FreeCAD#27962.

## Validation
- git diff --check -- wiki/PartDesign_AdditivePipe.wikitext wiki/PartDesign_SubtractivePipe.wikitext