### PR TITLE
[codex] Document PartDesign dragger snapping preferences

### DIFF
--- a/wiki/PartDesign_Preferences.wikitext
+++ b/wiki/PartDesign_Preferences.wikitext
@@ -73,10 +73,25 @@ On this page you can specify the following:
 | TBD. {{Version|1.1}}
 |-
 | {{MenuCommand|Show interactive draggers when editing features}}
-| TBD. {{Version|1.1}}
+| If checked, supported Part and PartDesign features show interactive draggers in the [[3D_View|3D View]] while being edited. {{Version|1.1}}
 |-
 | {{MenuCommand|Disable recompute while dragging}}
-| TBD. {{Version|1.1}}
+| If checked, edited features are recomputed after a drag operation finishes instead of continuously while the dragger is moved. {{Version|1.1}}
+|-
+| {{MenuCommand|Enable coarse snapping while dragging}}
+| If checked, interactive draggers can use coarse and fine movement while being dragged. When interactive draggers and coarse snapping are enabled, the [[Status_bar|status bar]] shows the active fine or coarse modifier hint. {{Version|1.2}}
+|-
+| {{MenuCommand|Fine snap modifier}}
+| Selects the modifier key, {{KEY|Shift}} or {{KEY|Ctrl}}, used to switch to fine movement while dragging. {{Version|1.2}}
+|-
+| {{MenuCommand|Default coarse drag behavior}}
+| Selects whether dragging uses coarse or fine movement when the fine snap modifier key is not held. {{Version|1.2}}
+|-
+| {{MenuCommand|Coarse movement multiplier}}
+| Sets the multiplier for coarse linear dragger movement. {{Version|1.2}}
+|-
+| {{MenuCommand|Coarse rotation step (degrees)}}
+| Sets the angular step, in degrees, for coarse rotation dragger movement. {{Version|1.2}}
 |}
 
 ===Shape View=== <!--T:5-->


### PR DESCRIPTION
## Summary
- Replace the PartDesign interactive dragger preference TBDs with concrete descriptions.
- Document FreeCAD 1.2 coarse snapping preferences for draggers: fine modifier, default coarse behavior, movement multiplier, and rotation step.
- Mention the status-bar fine/coarse modifier hint added for PartDesign draggers.
- Sources: FreeCAD/FreeCAD#28384 and FreeCAD/FreeCAD#29631.

## Validation
- git diff --check -- wiki/PartDesign_Preferences.wikitext