### PR TITLE
[codex] Document PartDesign Draft angle dragger

### DIFF
--- a/wiki/PartDesign_Draft.wikitext
+++ b/wiki/PartDesign_Draft.wikitext
@@ -68,7 +68,7 @@ The [[Image:PartDesign_Draft.svg|24px]] '''PartDesign Draft''' tool creates angu
 * {{MenuCommand|Remove face}}: Choose a way to remove faces from the selection:
 ** Select one or more faces in the list and press the {{KEY|Del}} key or right-click the list and select {{MenuCommand|Remove}} from the context menu.
 ** Press the {{Button|Remove face}} button. All previously selected faces are highlighted in purple. Select each face to be removed.
-* {{MenuCommand|Draft angle}}: Set the Draft angle either by entering a value or by clicking the up/down arrows.
+* {{MenuCommand|Draft angle}}: Set the Draft angle either by entering a value or by clicking the up/down arrows. {{Version|1.2}} If interactive draggers are enabled in the [[PartDesign_Preferences#General|PartDesign Preferences]], the angle can also be adjusted with the rotation dragger in the [[3D_View|3D View]].
 * {{MenuCommand|Neutral plane}}: Set the the neutral plane by pressing the {{Button|Neutral plane}} button and selecting the plane that must not change dimensionally.
 * {{MenuCommand|Pull direction}}: Set the the pull direction by pressing the {{Button|Pull direction}} button, then select an edge. Pull Direction is only effective if the Neutral Plane has been set. Results can be unpredictable.
 * {{MenuCommand|Reverse pull direction}}: Invert the pull direction by checking the {{MenuCommand|Reverse pull direction}} checkbox. This will toggle the draft between positive and negative angles.


### PR DESCRIPTION
## Summary
- Document the FreeCAD 1.2 rotation dragger for editing PartDesign Draft angle.
- Link the behavior to the PartDesign interactive dragger preference.
- Source: FreeCAD/FreeCAD#27111.

## Validation
- git diff --check -- wiki/PartDesign_Draft.wikitext