### PR TITLE
Document Sketcher dimension label orientation

### DIFF
--- a/wiki/Sketcher_Workbench.wikitext
+++ b/wiki/Sketcher_Workbench.wikitext
@@ -73,7 +73,6 @@ To edit the value of an existing dimensional constraint do one of the following:
 <!--T:207-->
 Dimensional constraints can be repositioned in the 3D View by dragging. Hold down the left mouse button over the constraint value and move the mouse. The symbols of geometric constraints are positioned automatically and cannot be moved.
 
-<!--T:271-->
 In {{Version|1.2}} dimensional constraint labels stay upright when the 3D View is rotated, keeping their text readable after the sketch orientation changes.
 
 == Profile sketches == <!--T:208-->

--- a/wiki/Sketcher_Workbench.wikitext
+++ b/wiki/Sketcher_Workbench.wikitext
@@ -73,6 +73,9 @@ To edit the value of an existing dimensional constraint do one of the following:
 <!--T:207-->
 Dimensional constraints can be repositioned in the 3D View by dragging. Hold down the left mouse button over the constraint value and move the mouse. The symbols of geometric constraints are positioned automatically and cannot be moved.
 
+<!--T:271-->
+In {{Version|1.2}} dimensional constraint labels stay upright when the 3D View is rotated, keeping their text readable after the sketch orientation changes.
+
 == Profile sketches == <!--T:208-->
 
 <!--T:209-->


### PR DESCRIPTION
Refs #94.

Summary:
- Add a FreeCAD 1.2 note that Sketcher dimensional constraint labels stay upright/readable when the 3D View is rotated.

Source:
- https://github.com/FreeCAD/FreeCAD/pull/29569

Validation:
- Documentation-only API edit; verified the inserted wikitext has no trailing whitespace.