### PR TITLE
Add Sketcher AutoColor release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -367,6 +367,7 @@ ToDo (last check: 20260430, #27222):
 * A reworked [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|polyline]] tool was added with support for [[Sketcher_Workbench#On-View-Parameters|OVPs]]. [https://github.com/FreeCAD/FreeCAD/pull/29336 Pull request #29336]
 * A new preference was added to control the font type (in addition to font size) for labels. [https://github.com/FreeCAD/FreeCAD/pull/26600 Pull request #26600]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
+* Sketches using automatic outside-Sketcher colors now update vertex, edge, and face colors immediately when the automatic coloring option is enabled. [https://github.com/FreeCAD/FreeCAD/pull/30185 Pull request #30185]
 
 == Spreadsheet Workbench == <!--T:53-->
 


### PR DESCRIPTION
Refs #30.

Summary:
- Add the missing FreeCAD 1.2 Sketcher release-note item for automatic outside-Sketcher colors applying immediately when AutoColor is enabled.

Source:
- https://github.com/FreeCAD/FreeCAD/pull/30185

Validation:
- Documentation-only API edit; verified the inserted wikitext line has no trailing whitespace.