### PR TITLE
docs(Draft_Text): document 1.2 task panel hints

### DIFF
--- a/wiki/Draft_Text.wikitext
+++ b/wiki/Draft_Text.wikitext
@@ -65,6 +65,7 @@ The single character keyboard shortcuts available in the task panel can be chang
 <!--T:21-->
 * A Draft Text can be edited by double-clicking it in the [[Tree_View|Tree View]].
 * Draft Texts created or saved with [[Release_notes_0.21|FreeCAD version 0.21]] are not backward compatible.
+* {{Version|1.2}}: The task panel displays hint messages for keyboard shortcuts and modifier keys. See [[Fine-tuning|Fine-tuning]] for details.
 
 ==Properties== <!--T:7-->
 


### PR DESCRIPTION
## Summary
- Document FreeCAD 1.2 task panel hints for Draft Text tool

## Changes
- Add `{{Version|1.2}}` note about task panel hint messages

## Source
- FreeCAD/FreeCAD#29649 (Draft: add hints for annotation tools)

Related to #27.