### PR TITLE
docs(Draft_Trimex): document 1.2 sketch object rejection

### DIFF
--- a/wiki/Draft_Trimex.wikitext
+++ b/wiki/Draft_Trimex.wikitext
@@ -37,7 +37,7 @@ Bottom: a face extruded into a solid body.}}
 ===Usage=== <!--T:21-->
 
 <!--T:5-->
-# Optionally select one object. The object must be a [[Draft_Line|Draft Line]], a [[Draft_Wire|Draft Wire]], a [[Draft_Arc|Draft Arc]] or a [[Draft_Circle|Draft Circle]] (which can only be trimmed). If the selected object is closed it must have its {{PropertyData|Make Face}} property set to {{FALSE}}.
+# Optionally select one object. The object must be a [[Draft_Line|Draft Line]], a [[Draft_Wire|Draft Wire]], a [[Draft_Arc|Draft Arc]] or a [[Draft_Circle|Draft Circle]] (which can only be trimmed). {{Version|1.2}}: [[Sketcher_Workbench|Sketch]] objects are rejected with an error message. If the selected object is closed it must have its {{PropertyData|Make Face}} property set to {{FALSE}}.
 # There are several ways to invoke the command:
 #* Press the {{Button|[[Image:Draft_Trimex.svg|16px]] [[Draft_Trimex|Trimex]]}} button.
 #* [[Draft_Workbench|Draft]]: Select the {{MenuCommand|Modification → [[Image:Draft_Trimex.svg|16px]] Trimex}} option from the menu.


### PR DESCRIPTION
## Summary
- Added {{Version|1.2}} note to Draft_Trimex usage section: sketch objects are now rejected with an error message instead of silently failing

## Source
- FreeCAD/FreeCAD#29845 (Draft: reject Trimex on sketch objects, merged 2026-05-16)

## Validation
- Single-line change, no structural modifications
- Matches existing wikitext conventions ({{Version}} tag)

Related to #27.