### PR TITLE
docs: update old FreeCAD forum links

### DIFF
--- a/wiki/Talk;Expressions.wikitext
+++ b/wiki/Talk;Expressions.wikitext
@@ -1,7 +1,7 @@
 == Related forum posts ==
-* PR #2475: Expression syntax extension [https://forum.freecadweb.org/viewtopic.php?f=27&t=38974]
-* "Name (optional)" field in sketcher accepts any string [https://forum.freecadweb.org/viewtopic.php?f=8&t=54320&p=467039#p467039]
-* space character [https://forum.freecadweb.org/viewtopic.php?t=32437]
+* PR #2475: Expression syntax extension [https://forum.freecad.org/viewtopic.php?f=27&t=38974]
+* "Name (optional)" field in sketcher accepts any string [https://forum.freecad.org/viewtopic.php?f=8&t=54320&p=467039#p467039]
+* space character [https://forum.freecad.org/viewtopic.php?t=32437]
 
 == Freeform discussion ==
 
@@ -9,7 +9,7 @@
 
 : I had a look, and really everything is possible as object label, e.g. "Tab üß$" works. Only the operator characters are not working and that becomes clear when looking at the expression code. There is however the issue that for the alias of table cells, one cannot use spaces or umlauts -> I'll bring this to the list because it seems to be a bug.--[[User:Uwestoehr|uwestoehr]] ([[User talk:Uwestoehr|talk]]) 18:10, 20 January 2021 (UTC)
 
-:: forum thread: https://forum.freecadweb.org/viewtopic.php?f=3&t=54586 --[[User:Uwestoehr|uwestoehr]] ([[User talk:Uwestoehr|talk]]) 18:23, 20 January 2021 (UTC)
+:: forum thread: https://forum.freecad.org/viewtopic.php?f=3&t=54586 --[[User:Uwestoehr|uwestoehr]] ([[User talk:Uwestoehr|talk]]) 18:23, 20 January 2021 (UTC)
 
 == Two-argument separator ==
 

--- a/wiki/Transportation_Workbench.wikitext
+++ b/wiki/Transportation_Workbench.wikitext
@@ -10,9 +10,9 @@ A subset of the [[Civil Engineering Workbench|Civil Engineering Workbench]]
 == Related Forum Threads == <!--T:3--> 
 
 <!--T:4-->
-* Civil engineering feature implementation (Transportation Engineering) [https://forum.freecadweb.org/viewtopic.php?f=8&t=22277 thread]
-* Civil Engineering Design functions [https://forum.freecadweb.org/viewtopic.php?f=8&t=6973 thread]
-* Thread tracking FreeCAD & QGIS integration [https://forum.freecadweb.org/viewtopic.php?f=8&t=22390 thread]
+* Civil engineering feature implementation (Transportation Engineering) [https://forum.freecad.org/viewtopic.php?f=8&t=22277 thread]
+* Civil Engineering Design functions [https://forum.freecad.org/viewtopic.php?f=8&t=6973 thread]
+* Thread tracking FreeCAD & QGIS integration [https://forum.freecad.org/viewtopic.php?f=8&t=22390 thread]
 
 == Related Links == <!--T:5-->
 

--- a/wiki/Workarounds.wikitext
+++ b/wiki/Workarounds.wikitext
@@ -585,7 +585,7 @@ The goal of this article is to list some currently missing features in FreeCAD a
 | 11
 | A tool for kinematic analysis on properly constrained sketches
 |
-* [[Scripting_and_macros|Python scripting]] - [https://forum.freecadweb.org/viewtopic.php?f=8&t=68826&start=10#p596531 example]
+* [[Scripting_and_macros|Python scripting]] - [https://forum.freecad.org/viewtopic.php?f=8&t=68826&start=10#p596531 example]
 
 <!--T:89-->
 |-


### PR DESCRIPTION
## Summary

- Update old `forum.freecadweb.org` links to the current `forum.freecad.org` domain.
- Keep original thread IDs and wording unchanged.
- Cover `Transportation_Workbench`, `Workarounds`, and `Talk;Expressions`.

## Why

Issue #28 tracks outdated documentation. This removes stale FreeCAD forum-domain references without changing page meaning.

## Verification

- All eight updated `forum.freecad.org` links return HTTP 200.
- The selected edited files no longer contain `forum.freecadweb.org`.
- `git apply --check` passed against fresh upstream file copies.

Fixes a focused part of #28.
