### PR TITLE
docs(Draft_Edit): document 1.2 base-less wall endpoint editing

### DIFF
--- a/wiki/Draft_Edit.wikitext
+++ b/wiki/Draft_Edit.wikitext
@@ -156,6 +156,7 @@ The single character keyboard shortcuts available in the task panel can be chang
 
 <!--T:54-->
 * A single node to control the height of the wall is displayed above the {{PropertyData|Placement}} of the wall.
+* {{Version|1.2}}: Endpoints of walls without a base object are editable. This allows adjusting the length and orientation of free-standing walls directly in Draft Edit mode. See [https://github.com/FreeCAD/FreeCAD/pull/29860 FreeCAD PR #29860].
 * No context menus for this object.
 
 ===[[Image:Arch_Structure.svg|24px]] [[Arch_Structure|Arch Structure]]=== <!--T:55-->


### PR DESCRIPTION
## Summary
- Document FreeCAD 1.2 enhancement: base-less Arch Wall endpoints are now editable in Draft Edit mode

## Source
- FreeCAD/FreeCAD#29860 — BIM/Draft: make endpoints of base-less wall Draft editable

## Validation
- No translation marker modifications
- Wikitext syntax preserved

Related to #27.