### PR TITLE
docs: add Sketcher CreatePolyline2 tool documentation

### DIFF
--- a/wiki/Sketcher_CreatePolyline2.wikitext
+++ b/wiki/Sketcher_CreatePolyline2.wikitext
@@ -1,7 +1,6 @@
 <languages/>
 <translate>
 
-<!--T:1-->
 {{Docnav
 |[[Sketcher_CreatePoint|Point]]
 |[[Sketcher_CreateLine|Line]]
@@ -11,7 +10,6 @@
 |IconC=Workbench_Sketcher.svg
 }}
 
-<!--T:2-->
 {{GuiCommand
 |Name=Sketcher CreatePolyline2
 |MenuLocation=Sketch → Geometries → Polyline
@@ -20,17 +18,14 @@
 |SeeAlso=[[Sketcher_CreatePolyline|Sketcher CreatePolyline]]
 }}
 
-==Description== <!--T:3-->
+==Description==
 
-<!--T:4-->
-The [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline2|Sketcher CreatePolyline2]] tool creates a series of line and arc segments connected by their endpoints. This is the reworked version of the [[Sketcher_CreatePolyline|Polyline]] tool with support for [[Sketcher_Workbench#On-View-Parameters|On-View Parameters (OVP)]] and autoconstraints.
+The [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline2|Sketcher CreatePolyline2]] tool is the reworked version of the [[Sketcher_CreatePolyline|Polyline]] tool. It adds support for [[Sketcher_Workbench#On-View-Parameters|On-View Parameters (OVP)]] and improved autoconstraints.
 
-==Usage== <!--T:5-->
+==Usage==
 
-<!--T:6-->
 See also: [[Sketcher_Workbench#Drawing_aids|Drawing aids]].
 
-<!--T:7-->
 # There are several ways to invoke the tool:
 #* Press the {{Button|[[Image:Sketcher_CreatePolyline.svg|16px]] [[Sketcher_CreatePolyline2|Polyline]]}} button.
 #* Select the {{MenuCommand|Sketch → Geometries → [[Image:Sketcher_CreatePolyline.svg|16px]] Polyline}} option from the menu.
@@ -47,14 +42,12 @@ See also: [[Sketcher_Workbench#Drawing_aids|Drawing aids]].
 #* Right-click or press {{KEY|Esc}} to create an open polyline.
 # The polyline segments have been created and applicable [[Sketcher_Workbench#Auto_constraints|autoconstraints]] have been added.
 
-==Autoconstraints== <!--T:8-->
+==Autoconstraints==
 
-<!--T:9-->
 This tool supports the following [[Sketcher_Workbench#Auto_constraints|autoconstraints]]:
 * Tangent constraints for arcs.
 * Parallel and perpendicular constraints for lines.
 
-<!--T:10-->
 {{Docnav
 |[[Sketcher_CreatePoint|Point]]
 |[[Sketcher_CreateLine|Line]]

--- a/wiki/Sketcher_CreatePolyline2.wikitext
+++ b/wiki/Sketcher_CreatePolyline2.wikitext
@@ -1,0 +1,69 @@
+<languages/>
+<translate>
+
+<!--T:1-->
+{{Docnav
+|[[Sketcher_CreatePoint|Point]]
+|[[Sketcher_CreateLine|Line]]
+|[[Sketcher_Workbench|Sketcher]]
+|IconL=Sketcher_CreatePoint.svg
+|IconR=Sketcher_CreateLine.svg
+|IconC=Workbench_Sketcher.svg
+}}
+
+<!--T:2-->
+{{GuiCommand
+|Name=Sketcher CreatePolyline2
+|MenuLocation=Sketch → Geometries → Polyline
+|Workbenches=[[Sketcher_Workbench|Sketcher]]
+|Shortcut={{KEY|G}} {{KEY|M}}
+|SeeAlso=[[Sketcher_CreatePolyline|Sketcher CreatePolyline]]
+}}
+
+==Description== <!--T:3-->
+
+<!--T:4-->
+The [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline2|Sketcher CreatePolyline2]] tool creates a series of line and arc segments connected by their endpoints. This is the reworked version of the [[Sketcher_CreatePolyline|Polyline]] tool with support for [[Sketcher_Workbench#On-View-Parameters|On-View Parameters (OVP)]] and autoconstraints.
+
+==Usage== <!--T:5-->
+
+<!--T:6-->
+See also: [[Sketcher_Workbench#Drawing_aids|Drawing aids]].
+
+<!--T:7-->
+# There are several ways to invoke the tool:
+#* Press the {{Button|[[Image:Sketcher_CreatePolyline.svg|16px]] [[Sketcher_CreatePolyline2|Polyline]]}} button.
+#* Select the {{MenuCommand|Sketch → Geometries → [[Image:Sketcher_CreatePolyline.svg|16px]] Polyline}} option from the menu.
+#* Right-click in the [[3D_View|3D View]] and select the {{MenuCommand|[[Image:Sketcher_CreatePolyline.svg|16px]] Polyline}} option from the context menu.
+#* Use the keyboard shortcut: {{KEY|G}} then {{KEY|M}}.
+# The cursor changes to a cross with the tool icon.
+# Optionally press the {{KEY|M}} key one or more times to cycle through the available modes.
+# Pick the first point.
+# While moving the pointer, the [[Sketcher_Workbench#On-View-Parameters|On-View Parameters]] are displayed.
+# Pick the next point to create a segment.
+# Optionally repeat to create more segments.
+# To finish the input do one of the following:
+#* Snap to the start point to create a closed polyline.
+#* Right-click or press {{KEY|Esc}} to create an open polyline.
+# The polyline segments have been created and applicable [[Sketcher_Workbench#Auto_constraints|autoconstraints]] have been added.
+
+==Autoconstraints== <!--T:8-->
+
+<!--T:9-->
+This tool supports the following [[Sketcher_Workbench#Auto_constraints|autoconstraints]]:
+* Tangent constraints for arcs.
+* Parallel and perpendicular constraints for lines.
+
+<!--T:10-->
+{{Docnav
+|[[Sketcher_CreatePoint|Point]]
+|[[Sketcher_CreateLine|Line]]
+|[[Sketcher_Workbench|Sketcher]]
+|IconL=Sketcher_CreatePoint.svg
+|IconR=Sketcher_CreateLine.svg
+|IconC=Workbench_Sketcher.svg
+}}
+
+</translate>
+{{Sketcher_Tools_navi{{#translation:}}}}
+{{Userdocnavi{{#translation:}}}}

--- a/wiki/Sketcher_Workbench.wikitext
+++ b/wiki/Sketcher_Workbench.wikitext
@@ -170,6 +170,7 @@ These are tools for creating objects.
 
 <!--T:42-->
 * [[Image:Sketcher_CreatePolyline.svg|32px]] [[Sketcher_CreatePolyline|Polyline]]: Creates a series of line and arc segments connected by their endpoints. The tool has several modes.
+* [[Image:Sketcher_CreatePolyline.svg|32px]] [[Sketcher_CreatePolyline2|Polyline (Reworked)]]: Reworked version of the Polyline tool with [[Sketcher_Workbench#On-View-Parameters|On-View Parameters (OVP)]] support and autoconstraints. {{Version|1.2}}
 
 <!--T:36-->
 * [[Image:Sketcher_CreateLine.svg|32px]] [[Sketcher_CreateLine|Line]]: Creates a line. {{Version|1.0}}: The tool has three modes.

--- a/wiki/Sketcher_Workbench.wikitext
+++ b/wiki/Sketcher_Workbench.wikitext
@@ -170,7 +170,7 @@ These are tools for creating objects.
 
 <!--T:42-->
 * [[Image:Sketcher_CreatePolyline.svg|32px]] [[Sketcher_CreatePolyline|Polyline]]: Creates a series of line and arc segments connected by their endpoints. The tool has several modes.
-* [[Image:Sketcher_CreatePolyline.svg|32px]] [[Sketcher_CreatePolyline2|Polyline (Reworked)]]: Reworked version of the Polyline tool with [[Sketcher_Workbench#On-View-Parameters|On-View Parameters (OVP)]] support and autoconstraints. {{Version|1.2}}
+* [[Image:Sketcher_CreatePolyline.svg|32px]] [[Sketcher_CreatePolyline2|Polyline (Reworked)]]: Reworked version of the Polyline tool with [[Sketcher_Workbench#On-View-Parameters|On-View Parameters (OVP)]] support and improved autoconstraints. {{Version|1.2}}
 
 <!--T:36-->
 * [[Image:Sketcher_CreateLine.svg|32px]] [[Sketcher_CreateLine|Line]]: Creates a line. {{Version|1.0}}: The tool has three modes.


### PR DESCRIPTION
## Summary

This PR adds documentation for the new **Sketcher CreatePolyline2** tool, which is the reworked version of the Polyline tool with support for On-View Parameters (OVP) and autoconstraints.

## Changes

1. **`wiki/Sketcher_CreatePolyline2.wikitext`**: New documentation page for the reworked Polyline tool
2. **`wiki/Sketcher_Workbench.wikitext`**: Added the new tool to the tools list

## Source

- FreeCAD source PR: [FreeCAD/FreeCAD#29336](https://github.com/FreeCAD/FreeCAD/pull/29336)
- Fixes: [FreeCAD/FreeCAD#12462](https://github.com/FreeCAD/FreeCAD/issues/12462)

## What's new in the reworked tool

- On-View Parameters (OVP) support for precise input
- Autoconstraints (tangent, parallel, perpendicular)
- Improved toolbar integration

## Notes

- Follows existing wiki format and conventions
- Uses `{{Version|1.2}}` template as the tool was added in FreeCAD 1.2
- References the original Polyline tool for comparison
