### PR TITLE
docs(Draft_ShapeString): document 1.2 coordinate entry improvement

### DIFF
--- a/wiki/Draft_ShapeString.wikitext
+++ b/wiki/Draft_ShapeString.wikitext
@@ -46,7 +46,7 @@ For Windows users: please read the [[#Font_file_selection_on_Windows|Font file s
 #* [[Draft_Workbench|Draft]]: Select the {{MenuCommand|Drafting → [[Image:Draft_ShapeString.svg|16px]] Shape From Text}} option from the menu.
 #* [[BIM_Workbench|BIM]]: Select the {{MenuCommand|Annotation → [[Image:Draft_ShapeString.svg|16px]] Shape From Text}} option from the menu.
 # The {{MenuCommand|ShapeString}} task panel opens.
-# Click a point in the [[3D_View|3D View]], or enter coordinates.
+# Click a point in the [[3D_View|3D View]], or enter coordinates. {{Version|1.2}}: Point is now set when coordinates are entered, without requiring a 3D view click.
 # Optionally click the {{MenuCommand|Global}} checkbox to toggle global mode. If global mode is on, coordinates are relative to the global coordinate system, else they are relative to the [[Draft_SelectPlane|working plane]] coordinate system. {{Version|1.1}}
 # Optionally press the {{Button|Reset Point}} button to reset the point to the origin of the current coordinate system.
 # Specify the {{MenuCommand|Height}}.


### PR DESCRIPTION
## Summary
- Document FreeCAD 1.2 ShapeString coordinate entry improvement
- In 1.2, entering coordinates in the task panel now properly sets the point without requiring a separate 3D view click
- Previously, users had to both click in the 3D view AND enter coordinates, which was confusing

## Source
- FreeCAD/FreeCAD#29762 (merged May 4, 2026)
- Fixes FreeCAD issue #29753

## Validation
- git diff --check
- Follows existing `{{Version|X.X}}` convention established on this page (lines 49, 135-138, 140-141)

Related to #27.