### PR TITLE
[metatron] Document Draft SVG curve approximation (1.2)

### DIFF
--- a/wiki/Draft_SVG.wikitext
+++ b/wiki/Draft_SVG.wikitext
@@ -38,6 +38,9 @@ The following SVG objects can be imported:
 * POLYGON objects
 * POLYLINE objects
 
+<!--T:30-->
+{{Version|1.2}}: Curves such as Bezier curves and B-splines are automatically approximated to arcs and lines during import. This improves compatibility with the [[CAM_Workbench|CAM Workbench]] by producing geometry with well-defined center points and diameters. The approximation accuracy is controlled by the {{MenuCommand|svgDeviation}} preference. A value of {{Incode|0.0}} disables the approximation and preserves the original curve geometry.
+
 ===Limitations=== <!--T:22-->
 
 <!--T:23-->
@@ -73,6 +76,10 @@ The [https://inkscape.org/ Inkscape] SVG Editor currently works only with 90 DPI
 
 <!--T:27-->
 See [[Import_Export_Preferences|Import Export Preferences]].
+
+<!--T:31-->
+{{Version|1.2}}: The Draft → SVG preferences tab provides:
+* {{MenuCommand|svgDeviation}}: the maximum deviation for curve approximation when importing SVG files. Bezier curves and B-splines are converted to arcs and lines within this tolerance. Set to {{Incode|0.0}} to preserve the original curves without approximation.
 
 ==Scripting== <!--T:13-->
 


### PR DESCRIPTION
## Summary
- Documents the SVG curve approximation feature introduced in FreeCAD 1.2
- Adds the `svgDeviation` preference to the Preferences section
- Documents that Bezier curves and B-splines are approximated to arcs and lines during SVG import

## Source
- FreeCAD/FreeCAD#29142 — Draft: importSVG — Approximation to arcs and lines (merged 2026-04-15)

## Changes
- Importing section: added paragraph about curve approximation with `svgDeviation` control
- Preferences section: added `svgDeviation` setting description

## Validation
- `git diff --check` clean
- No translation markers modified
- Follows existing page wikitext conventions

Related to #27.