### PR TITLE
Document VarSet group rename autocomplete

### DIFF
--- a/wiki/Std_VarSet.wikitext
+++ b/wiki/Std_VarSet.wikitext
@@ -81,7 +81,7 @@ FreeCAD supports many property types. The table below lists some of the most com
 <!--T:12-->
 * Properties can also be added to existing VarSets in the [[Expressions|Expression editor]] by checking the '''Store in Variable Set…''' checkbox.
 * A property can be removed from a VarSet via the [[Property_View#Context_menu|context menu]] of the [[Property_View|Property View]].
-* A group name can be changed via the same menu.
+* A group name can be changed via the same menu. {{Version|1.2}}: The input field for the new group name offers autocompletion for existing group names.
 * {{VersionMinus|1.0}}: The command cannot set the list of allowed items of an {{Incode|App::PropertyEnumeration}} property. This can be done via [[FeaturePython_Custom_Properties#App::PropertyEnumeration|Python code]] or in the Property View. The steps for the latter option are:
 *# Select {{MenuCommand|Show hidden}} in the context menu of the Property View.
 *# Expand the node of the property.


### PR DESCRIPTION
Refs #30.

Summary:
- Document the FreeCAD 1.2 autocompletion added to the VarSet property-group rename field.
- Keep the update scoped to the existing Std_VarSet notes section.

Source:
- https://github.com/FreeCAD/FreeCAD/pull/30200

Validation:
- git diff --check -- wiki/Std_VarSet.wikitext