### PR TITLE
Document Sketcher edit value menu label

### DIFF
--- a/wiki/Sketcher_Dialog.wikitext
+++ b/wiki/Sketcher_Dialog.wikitext
@@ -213,7 +213,7 @@ Available options:
 |-
 | {{MenuCommand|Context menu}}
 | Right-clicking the background of the list, or right-clicking constraints selected in the list opens a context menu. The menu has the following options:
-* {{MenuCommand|Change Value}}: Changes the value of a dimensional constraint. Only works for a single constraint. You can also double click the constraint in the list, or double click its value in the [[3D_View|3D View]].
+* {{MenuCommand|Edit Value}}: Changes the value of a dimensional constraint. Only works for a single constraint. You can also double click the constraint in the list, or double click its value in the [[3D_View|3D View]].
 * {{MenuCommand|Toggle Driving/Reference}}: See [[Sketcher_ToggleDrivingConstraint|Sketcher ToggleDrivingConstraint]].
 * {{MenuCommand|Deactivate}} or {{MenuCommand|Activate}}: See [[Sketcher_ToggleActiveConstraint|Sketcher ToggleActiveConstraint]].
 * {{MenuCommand|Show Constraints}}: Same as checking the constraint checkbox. But, unlike the checkbox, also works for more than one constraint.

--- a/wiki/Sketcher_Workbench.wikitext
+++ b/wiki/Sketcher_Workbench.wikitext
@@ -66,7 +66,7 @@ You can enter a numerical value or an [[Expressions|expression]], and it is poss
 To edit the value of an existing dimensional constraint do one of the following:
 * Double-click the constraint value in the [[3D_View|3D View]].
 * Double-click the constraint in the [[Sketcher_Dialog|Sketcher Dialog]].
-* Right-click the constraint in the Sketcher Dialog and select the {{MenuCommand|Change value}} option from the context menu.
+* Right-click the constraint in the Sketcher Dialog and select the {{MenuCommand|Edit value}} option from the context menu.
 
 === Reposition constraints === <!--T:206-->
 


### PR DESCRIPTION
Refs #94.

Summary:
- Update the Sketcher constraints context-menu label from "Change Value" to "Edit Value".
- Keep the Sketcher Dialog and Workbench pages aligned with the FreeCAD 1.2 UI text.

Source:
- https://github.com/FreeCAD/FreeCAD/pull/29556

Validation:
- git diff --check -- wiki/Sketcher_Dialog.wikitext wiki/Sketcher_Workbench.wikitext