### PR TITLE
Document Attachment input hints

### DIFF
--- a/wiki/Part_EditAttachment.wikitext
+++ b/wiki/Part_EditAttachment.wikitext
@@ -59,6 +59,7 @@ The rest of this page focuses on the Engine 3D. The modes of the other engines a
 #* Select the {{MenuCommand|Part → [[Image:Part_EditAttachment.svg|16px]] Attachment}} option from the menu.
 # The {{MenuCommand|Attachment}} task panel opens.
 # At the top of the task panel ''Not attached'' can be read. The first button labeled {{Button|Selecting…}} is highlighted to indicate a selection in the [[3D_View|3D View]] is expected.
+# {{Version|1.2}}: The status bar shows input hints for selecting a reference, and for selecting and confirming where supported.
 # Select a vertex, edge or face/plane belonging to another object.
 # In the input field to the right of the button, the referenced object and subelement are shown. For example, if a face of a [[Part_Box|Part Box]] is selected, the field may show {{Value|Box:Face6}}. The label of the button displays the subelement type now.
 # The available modes are filtered based on the selected references and their order. For example, for modes [[#Align_O-Z-X|Align O-Z-X]] to [[#Align_O-Y-X|Align O-Y-X]] the first reference must be a vertex. If the first reference is a subelement of a different type, they are removed from the list.


### PR DESCRIPTION
Refs #28.

Summary:
- document the FreeCAD 1.2 status-bar input hints shown by the Attachment task panel

Source:
- https://github.com/FreeCAD/FreeCAD/pull/29614

Validation:
- git diff --check -- wiki/Part_EditAttachment.wikitext