### PR TITLE
Document Sketcher clipboard support for groups and text

### DIFF
--- a/wiki/Sketcher_Workbench.wikitext
+++ b/wiki/Sketcher_Workbench.wikitext
@@ -654,6 +654,8 @@ To select everything within a sketch, use the standard keyboard shortcut {{KEY|C
 <!--T:235-->
 The standard keyboard shortcuts, {{KEY|Ctrl}}+{{KEY|C}}, {{KEY|Ctrl}}+{{KEY|X}} and {{KEY|Ctrl}}+{{KEY|V}}, can be used to copy, cut and paste selected Sketcher geometry including related constraints. But these tools are also available from the {{MenuCommand|Sketch → Sketcher Tools}} menu. They can be used within the same sketch but also between different sketches or separate instances of FreeCAD. Since the data is copied to the clipboard in the form of Python code, it can be used in other ways too (e.g. shared on the forum).
 
+{{Version|1.2}}: Text geometry and [[Sketcher_ConstrainGroup|group constraints]] are supported by the copy, cut and paste tools.
+
 == Best practices == <!--T:148-->
 
 <!--T:14-->


### PR DESCRIPTION
Updates the Sketcher Workbench clipboard section for the FreeCAD 1.2 change from FreeCAD/FreeCAD#28728, which fixed copy/cut/paste support for text geometry and group constraints.\n\nContributes to #94.