### PR TITLE
Add Addon Manager installed mods release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -117,6 +117,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 === Further Addon Manager improvements ===
 
 * Duplicate disabled addon notices are now suppressed when the same disabled addon is discovered from both the user {{FileName|Mod}} directory and an additional flat module path. [https://github.com/FreeCAD/FreeCAD/pull/29380 Pull request #29380]
+* The installed mods list in the {{MenuCommand|About → Version}} information is now sorted alphabetically. [https://github.com/FreeCAD/FreeCAD/pull/29325 Pull request #29325]
 
 == Assembly Workbench == <!--T:21-->
 


### PR DESCRIPTION
Refs #30.

Summary:
- add a FreeCAD 1.2 release note for alphabetic sorting of the installed mods list in About > Version

Source:
- https://github.com/FreeCAD/FreeCAD/pull/29325

Validation:
- git diff --check -- wiki/Release_notes_1.2.wikitext