### PR TITLE
Document Sketcher 1.2 default preferences

### DIFF
--- a/wiki/Sketcher_Preferences.wikitext
+++ b/wiki/Sketcher_Preferences.wikitext
@@ -90,7 +90,7 @@ On this page you can specify the following:
 <!--T:74-->
 |-
 | {{MenuCommand|Generate internal faces}} {{Version|1.1}}
-| If checked, closed loops will automatically generate internal faces which are selectable to be used with other tools. {{Version|1.2}}: Enabled by default for new sketches.
+| If checked, closed loops will automatically generate internal faces which are selectable to be used with other tools.
 
 <!--T:57-->
 |-
@@ -142,7 +142,7 @@ On this page you can specify the following:
 !style="width: 66%;"|Description
 |-
 | {{MenuCommand|Grid}}
-| If checked, a grid will be shown while the sketch is in edit mode. Used for new sketches. Is stored in the {{PropertyView|Show Grid}} property of sketches. {{Version|1.2}}: Enabled by default for new sketches.
+| If checked, a grid will be shown while the sketch is in edit mode. Used for new sketches. Is stored in the {{PropertyView|Show Grid}} property of sketches.
 |-
 | {{MenuCommand|Grid auto-spacing}}
 | If checked, grid spacing is automatically adapted based on the view dimensions. Used for new sketches. Is stored in the {{PropertyView|Grid Auto}} property of sketches.
@@ -167,7 +167,7 @@ On this page you can specify the following:
 * {{MenuCommand|Line color}}
 |-
 | {{MenuCommand|Grid transparency}} {{Version|1.2}}
-| Sets the transparency of the grid displayed while a sketch is in edit mode. Used for new sketches. The default value is 60%.
+| Sets the transparency of the grid displayed while a sketch is in edit mode. Used for new sketches.
 |}
 
 ==Display== <!--T:29-->

--- a/wiki/Sketcher_Preferences.wikitext
+++ b/wiki/Sketcher_Preferences.wikitext
@@ -90,7 +90,7 @@ On this page you can specify the following:
 <!--T:74-->
 |-
 | {{MenuCommand|Generate internal faces}} {{Version|1.1}}
-| If checked, closed loops will automatically generate internal faces which are selectable to be used with other tools.
+| If checked, closed loops will automatically generate internal faces which are selectable to be used with other tools. {{Version|1.2}}: Enabled by default for new sketches.
 
 <!--T:57-->
 |-
@@ -142,7 +142,7 @@ On this page you can specify the following:
 !style="width: 66%;"|Description
 |-
 | {{MenuCommand|Grid}}
-| If checked, a grid will be shown while the sketch is in edit mode. Used for new sketches. Is stored in the {{PropertyView|Show Grid}} property of sketches.
+| If checked, a grid will be shown while the sketch is in edit mode. Used for new sketches. Is stored in the {{PropertyView|Show Grid}} property of sketches. {{Version|1.2}}: Enabled by default for new sketches.
 |-
 | {{MenuCommand|Grid auto-spacing}}
 | If checked, grid spacing is automatically adapted based on the view dimensions. Used for new sketches. Is stored in the {{PropertyView|Grid Auto}} property of sketches.
@@ -167,7 +167,7 @@ On this page you can specify the following:
 * {{MenuCommand|Line color}}
 |-
 | {{MenuCommand|Grid transparency}} {{Version|1.2}}
-| Sets the transparency of the grid displayed while a sketch is in edit mode. Used for new sketches.
+| Sets the transparency of the grid displayed while a sketch is in edit mode. Used for new sketches. The default value is 60%.
 |}
 
 ==Display== <!--T:29-->


### PR DESCRIPTION
Updates the Sketcher Preferences page for FreeCAD 1.2 preference changes from FreeCAD/FreeCAD#28771 and FreeCAD/FreeCAD#28791:\n\n- grid display is enabled by default for new sketches\n- internal face generation is enabled by default for new sketches\n- grid transparency's default value is 60%\n\nContributes to #94.