### PR TITLE
Document Sketcher clipboard release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -384,6 +384,7 @@ ToDo (last check: 20260430, #29258):
 
 <!--T:52-->
 * It is now possible to import Bézier and Offset curves as [[Image:Sketcher_Projection.svg|24px]] [[Sketcher_Projection|External geometry]]. [https://github.com/FreeCAD/FreeCAD/pull/25144 Pull request #25144]
+* [[Sketcher_Workbench#Copy,_cut_and_paste|Copy, cut and paste]] now support text geometry and [[Image:Sketcher_ConstrainGroup.svg|24px]] [[Sketcher_ConstrainGroup|Group constraints]]. [https://github.com/FreeCAD/FreeCAD/pull/28728 Pull request #28728]
 * When creating or editing circular dimensions, it is now possible to switch between the radius and diameter type. [https://github.com/FreeCAD/FreeCAD/pull/26794 Pull request #26794]
 * The constraint list now displays the type of the constraint in the name. [https://github.com/FreeCAD/FreeCAD/pull/26797 Pull request #26797]
 * A new selection mode was added to [[Image:Sketcher_ConstrainSymmetric.svg|24px]] [[Sketcher_ConstrainSymmetric|Symmetric constraint]]. Now it is also possible to select an element (line, arc, or open B-spline) and a symmetry line. [https://github.com/FreeCAD/FreeCAD/pull/25525 Pull request #25525]


### PR DESCRIPTION
Adds a FreeCAD 1.2 release note for FreeCAD/FreeCAD#28728: Sketcher copy/cut/paste support for text geometry and group constraints.\n\nContributes to #30.