### PR TITLE
Document Sketcher OVP keyboard handling

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -387,6 +387,7 @@ ToDo (last check: 20260430, #29258):
 * Arc length dimensions are now positioned better for larger arc spans. [https://github.com/FreeCAD/FreeCAD/pull/29594 Pull request #29594]
 * Dimension labels are now oriented based on the view rotation so that they won't get displayed upside down anymore. [https://github.com/FreeCAD/FreeCAD/pull/29569 Pull request #29569]
 * A reworked [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|polyline]] tool was added with support for [[Sketcher_Workbench#On-View-Parameters|OVPs]]. [https://github.com/FreeCAD/FreeCAD/pull/29336 Pull request #29336]
+* [[Sketcher_Workbench#On-View-Parameters|OVP]] keyboard handling was improved: entering numbers, punctuation, deletion keys or pasted values switches directly to value editing, while holding {{KEY|Alt}} temporarily restores camera controls. [https://github.com/FreeCAD/FreeCAD/pull/29477 Pull request #29477]
 * The [[Image:Sketcher_CreateText.svg|24px]] [[Sketcher_CreateText|Text]] tool now stores only the font name in the document instead of an absolute local font path, improving file portability between systems. [https://github.com/FreeCAD/FreeCAD/pull/28418 Pull request #28418]
 * A new preference was added to control the font type (in addition to font size) for labels. [https://github.com/FreeCAD/FreeCAD/pull/26600 Pull request #26600]
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]


### PR DESCRIPTION
Adds a FreeCAD 1.2 release note for FreeCAD/FreeCAD#29477: improved Sketcher On-View Parameter keyboard handling for direct value editing, paste detection, and temporary camera control with Alt.\n\nContributes to #30 and #94.