### PR TITLE
Document TechDraw snapping release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -435,6 +435,7 @@ ToDo (last check: 20260430, #29258):
 * [[TechDraw_Workbench|TechDraw]] angle dimensions now support displaying the supplementary angle (180° minus the measured angle) via a view property. [https://github.com/FreeCAD/FreeCAD/pull/27055 Pull request #27055]
 * Scene drawing is now significantly faster. [https://github.com/FreeCAD/FreeCAD/pull/25898 Pull request #25898] and [https://github.com/FreeCAD/FreeCAD/pull/28702 Pull request #28702]
 * Rendered scene views now exclude viewer decorations such as the NaviCube from TechDraw scene captures. [https://github.com/FreeCAD/FreeCAD/pull/28943 Pull request #28943]
+* Manual changes to [[TechDraw_Workbench|TechDraw]] view and dimension X/Y position properties now take priority over snapping, and dimension snapping parameters are configurable in the preferences. [https://github.com/FreeCAD/FreeCAD/pull/30154 Pull request #30154]
 * The [[TechDraw_ActiveView|Insert Active View]] task panel has been redesigned with improved spacing, a combobox for background style selection, and grouped crop settings that disable automatically when not in use. [https://github.com/FreeCAD/FreeCAD/pull/28085 Pull request #28085]
 * There is now a context menu option to toggle grid for the active page. [https://github.com/FreeCAD/FreeCAD/pull/29083 Pull request #29083]
 * The default TechDraw page color in the FreeCAD Light preference pack is now white, avoiding gray page backgrounds when printing. [https://github.com/FreeCAD/FreeCAD/pull/30129 Pull request #30129]


### PR DESCRIPTION
Adds a FreeCAD 1.2 release note for FreeCAD/FreeCAD#30154: manual X/Y position edits for TechDraw views and dimensions now take priority over snapping, and dimension snapping parameters are configurable in preferences.

Contributes to #30.

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext`