### PR TITLE
Document PartDesign Boolean Fuzzy Tolerance property

### DIFF
--- a/wiki/PartDesign_Boolean.wikitext
+++ b/wiki/PartDesign_Boolean.wikitext
@@ -58,6 +58,7 @@ Alternatively, objects can be selected prior to pressing the Boolean button. The
 
 <!--T:13-->
 * {{PropertyData|Type}}: sets the Boolean operation (Fuse, Cut, Common)
+* {{PropertyData|Fuzzy Tolerance}}: overrides the default tolerance used by the Boolean operation. {{Version|1.2}}
 * {{PropertyData|Label}}: name given to the operation, this name can be changed at convenience.
 * {{PropertyData|Group}}: lists the tool bodies.
 * {{PropertyView|Display}}: sets the display between 2 modes:


### PR DESCRIPTION
Addresses #79.

This documents the PartDesign Boolean Fuzzy Tolerance property added by FreeCAD/FreeCAD#29984.

The FreeCAD 1.2 release notes mention this property, but the PartDesign_Boolean command page did not list it yet.

Summary:
- add Fuzzy Tolerance to the PartDesign Boolean properties list
- mark it as {{Version|1.2}}
- keep the change scoped to the root English wiki page