### PR TITLE
Document Sketcher line style dropdown fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -371,6 +371,7 @@ ToDo (last check: 20260430, #29258):
 * Dimension labels are now oriented based on the view rotation so that they won't get displayed upside down anymore. [https://github.com/FreeCAD/FreeCAD/pull/29569 Pull request #29569]
 * A reworked [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|polyline]] tool was added with support for [[Sketcher_Workbench#On-View-Parameters|OVPs]]. [https://github.com/FreeCAD/FreeCAD/pull/29336 Pull request #29336]
 * A new preference was added to control the font type (in addition to font size) for labels. [https://github.com/FreeCAD/FreeCAD/pull/26600 Pull request #26600]
+* Sketcher line style dropdowns now correctly list the available styles instead of appearing empty. [https://github.com/FreeCAD/FreeCAD/pull/30151 Pull request #30151]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 
 == Spreadsheet Workbench == <!--T:53-->


### PR DESCRIPTION
Refs #30.

Summary:
- Add a FreeCAD 1.2 release note for FreeCAD/FreeCAD#30151: Sketcher line style dropdowns now list the available styles instead of appearing empty.
- Keep the change scoped to the existing Sketcher release notes section.

Source:
- https://github.com/FreeCAD/FreeCAD/pull/30151

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`