### PR TITLE
Document Assembly simulation playback controls

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -116,6 +116,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Solver messages (overconstraint reports) were added to the Assembly task panel. [https://github.com/FreeCAD/FreeCAD/pull/24623 Pull request #24623]
 * A new command has been added to select all joints associated with a chosen component. [https://github.com/FreeCAD/FreeCAD/pull/27530 Pull request #27530]
 * A button was added to rotate joint offsets by 90 degrees. [https://github.com/FreeCAD/FreeCAD/pull/29717 Pull request #29717]
+* The Assembly simulation playback controls now use larger, more distinguishable buttons. [https://github.com/FreeCAD/FreeCAD/pull/30257 Pull request #30257]
 
 == BIM Workbench == <!--T:23-->
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -100,6 +100,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Solver messages (overconstraint reports) were added to the Assembly task panel. [https://github.com/FreeCAD/FreeCAD/pull/24623 Pull request #24623]
 * A new command has been added to select all joints associated with a chosen component. [https://github.com/FreeCAD/FreeCAD/pull/27530 Pull request #27530]
 * A button was added to rotate joint offsets by 90 degrees. [https://github.com/FreeCAD/FreeCAD/pull/29717 Pull request #29717]
+* The Assembly simulation playback controls now use larger, more distinguishable buttons. [https://github.com/FreeCAD/FreeCAD/pull/30257 Pull request #30257]
 
 == BIM Workbench ==
 


### PR DESCRIPTION
Adds a focused FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#30257, which made the Assembly simulation playback controls larger and easier to distinguish.\n\nTouches the root and English Release_notes_1.2 pages.\n\nRefs #30.