### PR TITLE
Document BIM Drawing View cut lines

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -140,6 +140,9 @@ ToDo (last check: 20260430, #27222):
 
 === Further BIM improvements === <!--T:24-->
 
+<!--T:82-->
+* [[BIM_DrawingView|Drawing View]] cut lines now use the default line width and cut-area line thickness ratio preferences. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]
+
 == CAM Workbench == <!--T:25-->
 
 <!--T:71-->

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -122,6 +122,8 @@ ToDo (last check: 20260430, #27222):
 
 === Further BIM improvements ===
 
+* [[BIM_DrawingView|Drawing View]] cut lines now use the default line width and cut-area line thickness ratio preferences. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]
+
 == CAM Workbench ==
 
 {| cellpadding=5


### PR DESCRIPTION
Adds a focused FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#30149, which updates BIM Drawing View cut lines to use the default line width and cut-area line thickness ratio preferences.\n\nTouches the root and English Release_notes_1.2 pages.\n\nRefs #30.\nRefs #26.