### PR TITLE
Document BIM release note fixes

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -150,6 +150,7 @@ ToDo (last check: 20260430, #27222):
 * [[BIM_Windows|BIM Windows]] now include a Sliding Door preset whose opening follows the {{incode|Opening}} property, and the Tree View context menu can invert the sliding direction. [https://github.com/FreeCAD/FreeCAD/pull/27375 Pull request #27375]
 * [[BIM_Windows|BIM Windows]] now provide a task-panel options box for editing common window properties with expression-aware fields and a cancel action. [https://github.com/FreeCAD/FreeCAD/pull/27381 Pull request #27381]
 * Stair railings now follow stair visibility changes, including visibility inherited from parent objects such as levels. [https://github.com/FreeCAD/FreeCAD/pull/29173 Pull request #29173]
+* IFC import now treats a multicore preference value of 0 as disabled before creating the IfcOpenShell geometry iterator, avoiding invalid worker counts when multicore processing is turned off. [https://github.com/FreeCAD/FreeCAD/pull/30201 Pull request #30201]
 
 == CAM Workbench == <!--T:25-->
 


### PR DESCRIPTION
## Summary
- add BIM 1.2 release notes for the updated Classification download URL
- add the IFC multicore-disabled handling fix to the BIM release notes

References FreeCAD/FreeCAD#30247 and FreeCAD/FreeCAD#30201.
