### PR TITLE
docs(Draft_Upgrade): document 1.0 nesting, visual inheritance, and safety checks

### DIFF
--- a/wiki/Draft_Upgrade.wikitext
+++ b/wiki/Draft_Upgrade.wikitext
@@ -46,6 +46,11 @@ The [[Image:Draft_Upgrade.svg|24px]] '''Draft Upgrade''' command upgrades select
 
 <!--T:25-->
 * [[Draft_Line|Draft Lines]] and [[Draft_Wire|Draft Wires]] can be joined with this command, but also with the [[Draft_Join|Draft Join]] command or the [[Draft_Wire|Draft Wire]] command.
+* New objects created by the upgrade are placed in the same container ([[Std_Group|Group]] or [[Std_Part|Part]]) as the original objects, preserving the document structure. For some operations the original objects must reside in the same container. {{Version|1.0}}
+* New objects receive the visual properties (color, line width, transparency) of the original objects where possible. {{Version|1.0}}
+* If a [[PartDesign_Body|PartDesign Body]] feature with a {{PropertyData|Profile}} property is selected, the command can de-parametrize the feature by extracting the profile shape. {{Version|1.0}}
+* Before deleting source objects, the command checks if they are in use elsewhere. Base objects of [[Draft_OrthoArray|arrays]] are preserved when visible. Selecting a [[PartDesign_Body|PartDesign Body]], or any object inside a Body, will delete the entire Body. {{Version|1.0}}
+* The {{incode|force}} parameter works for functions that operate on a single object. {{Version|1.0}}
 
 ==Scripting== <!--T:23-->
 


### PR DESCRIPTION
## Summary
- Document Draft Upgrade 1.0 nesting behavior: new objects placed in same container as originals
- Document visual property inheritance: color, line width, transparency preserved
- Document PartDesign Body Profile de-parametrization support
- Document safety checks: InList validation, array base preservation, Body deletion behavior
- Document force parameter working for single-object functions

## Source
- FreeCAD/FreeCAD#19685

## Validation
- git diff --check
- no translation marker issues

Related to #27.