### PR TITLE
Document Sketcher OVP cursor stability fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -362,6 +362,7 @@ ToDo (last check: 20260430, #29258):
 * Double-clicking a geometric constraint now triggers its rename. [https://github.com/FreeCAD/FreeCAD/pull/27678 Pull request #27678]
 * Double-clicking selection now also works with external geometry. [https://github.com/FreeCAD/FreeCAD/pull/28105 Pull request #28105]
 * The Grid and Make Internals properties are now enabled by default for new sketches, and a grid transparency preference has been added. [https://github.com/FreeCAD/FreeCAD/pull/28771 Pull request #28771] and [https://github.com/FreeCAD/FreeCAD/pull/28791 Pull request #28791]
+* Text cursor movement in Sketcher [[Sketcher_Workbench#On-View-Parameters|On-View Parameters]] now remains stable when the input field resizes while editing. [https://github.com/FreeCAD/FreeCAD/pull/29287 Pull request #29287]
 * Selected distance constraints (point-line, circle-circle, and circle-line) now use orientation to prevent [[Sketcher_Workbench#Flipping|flipping]]. [https://github.com/FreeCAD/FreeCAD/pull/26518 Pull request #26518]
 * The ''Create symmetry constraints'' option of the [[Image:Sketcher_Symmetry.svg|24px]] [[Sketcher_Symmetry|Symmetry]] tool was improved to avoid overconstraints. It is now also enabled by default. [https://github.com/FreeCAD/FreeCAD/pull/28118 Pull request #28118] and [https://github.com/FreeCAD/FreeCAD/pull/28319 Pull request #28319]
 * There is now a ''Cancel'' button, making it possible to discard modifications in a sketch.  [https://github.com/FreeCAD/FreeCAD/pull/29337 Pull request #29337]

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -327,6 +327,7 @@ ToDo (last check: 20260430, #29258):
 * Double-clicking a geometric constraint now triggers its rename. [https://github.com/FreeCAD/FreeCAD/pull/27678 Pull request #27678]
 * Double-clicking selection now also works with external geometry. [https://github.com/FreeCAD/FreeCAD/pull/28105 Pull request #28105]
 * The Grid and Make Internals properties are now enabled by default for new sketches, and a grid transparency preference has been added. [https://github.com/FreeCAD/FreeCAD/pull/28771 Pull request #28771] and [https://github.com/FreeCAD/FreeCAD/pull/28791 Pull request #28791]
+* Text cursor movement in Sketcher [[Sketcher_Workbench#On-View-Parameters|On-View Parameters]] now remains stable when the input field resizes while editing. [https://github.com/FreeCAD/FreeCAD/pull/29287 Pull request #29287]
 * Selected distance constraints (point-line, circle-circle, and circle-line) now use orientation to prevent [[Sketcher_Workbench#Flipping|flipping]]. [https://github.com/FreeCAD/FreeCAD/pull/26518 Pull request #26518]
 * The ''Create symmetry constraints'' option of the [[Image:Sketcher_Symmetry.svg|24px]] [[Sketcher_Symmetry|Symmetry]] tool was improved to avoid overconstraints. It is now also enabled by default. [https://github.com/FreeCAD/FreeCAD/pull/28118 Pull request #28118] and [https://github.com/FreeCAD/FreeCAD/pull/28319 Pull request #28319]
 * There is now a ''Cancel'' button, making it possible to discard modifications in a sketch.  [https://github.com/FreeCAD/FreeCAD/pull/29337 Pull request #29337]


### PR DESCRIPTION
Summary:
- Add FreeCAD 1.2 release-note entries for Sketcher On-View Parameter cursor stability.
- Reference FreeCAD/FreeCAD#29287, which fixed text cursor movement when editable input fields resize while editing.

Validation:
- git diff --check -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext

Refs #94