### PR TITLE
Document PartDesign Polar Pattern negative angles

### DIFF
--- a/wiki/PartDesign_PolarPattern.wikitext
+++ b/wiki/PartDesign_PolarPattern.wikitext
@@ -83,8 +83,8 @@ The [[Image:PartDesign_PolarPattern.svg|24px]] '''PartDesign PolarPattern''' too
 *** {{MenuCommand|Base Z-axis}}: The Z-axis of the Body.
 *** {{MenuCommand|Select reference…}}: Select a [[PartDesign_Line|Datum Line]] in the [[Tree_View|Tree View]] or a [[PartDesign_Line|Datum Line]] or edge in the [[3D_View|3D View]].
 ** {{Version|1.0}}: Specify the angle {{MenuCommand|Mode}}:
-*** {{MenuCommand|Total Angle}}: If the angle is less than 360°, the occurrences are evenly distributed from 0° (first occurrence) to the given angle (last occurrence). If the angle is 360°, the occurrences are evenly distributed around the circle. For n occurrences an angle of 360° is equivalent to an angle of 360°*(1-1/n). {{Version|1.2}}: Negative angles are supported.
-*** {{Version|1.0}}: {{MenuCommand|Angular spacing}}: Enter the angle from a given point on the first occurrence to the same point on the next occurrence. For n occurrences: TotalAngle=(n-1)*Spacing. {{Version|1.2}}: Negative angular spacing values are supported.
+*** {{MenuCommand|Total Angle}}: If the angle is less than 360°, the occurrences are evenly distributed from 0° (first occurrence) to the given angle (last occurrence). If the angle is 360°, the occurrences are evenly distributed around the circle. For n occurrences an angle of 360° is equivalent to an angle of 360°*(1-1/n). {{Version|1.2}}: A negative angle distributes the occurrences in the opposite angular direction.
+*** {{Version|1.0}}: {{MenuCommand|Angular spacing}}: Enter the angle from a given point on the first occurrence to the same point on the next occurrence. For n occurrences: TotalAngle=(n-1)*Spacing. {{Version|1.2}}: A negative spacing value places each next occurrence in the opposite angular direction.
 ** Specify the number of {{MenuCommand|Occurrences}} (including the original feature).
 * {{Version|1.2}}: The angle or offset and occurrence values can also be edited with [[Sketcher_Workbench#On-View-Parameters|On-View Parameters]] in the [[3D_View|3D View]].
 * If the {{MenuCommand|Recompute on change}} checkbox is checked the view will update in real time.

--- a/wiki/PartDesign_PolarPattern.wikitext
+++ b/wiki/PartDesign_PolarPattern.wikitext
@@ -83,8 +83,8 @@ The [[Image:PartDesign_PolarPattern.svg|24px]] '''PartDesign PolarPattern''' too
 *** {{MenuCommand|Base Z-axis}}: The Z-axis of the Body.
 *** {{MenuCommand|Select reference…}}: Select a [[PartDesign_Line|Datum Line]] in the [[Tree_View|Tree View]] or a [[PartDesign_Line|Datum Line]] or edge in the [[3D_View|3D View]].
 ** {{Version|1.0}}: Specify the angle {{MenuCommand|Mode}}:
-*** {{MenuCommand|Total Angle}}: If the angle is less than 360°, the occurrences are evenly distributed from 0° (first occurrence) to the given angle (last occurrence). If the angle is 360°, the occurrences are evenly distributed around the circle. For n occurrences an angle of 360° is equivalent to an angle of 360°*(1-1/n).
-*** {{Version|1.0}}: {{MenuCommand|Angular spacing}}: Enter the angle from a given point on the first occurrence to the same point on the next occurrence. For n occurrences: TotalAngle=(n-1)*Spacing.
+*** {{MenuCommand|Total Angle}}: If the angle is less than 360°, the occurrences are evenly distributed from 0° (first occurrence) to the given angle (last occurrence). If the angle is 360°, the occurrences are evenly distributed around the circle. For n occurrences an angle of 360° is equivalent to an angle of 360°*(1-1/n). {{Version|1.2}}: Negative angles are supported.
+*** {{Version|1.0}}: {{MenuCommand|Angular spacing}}: Enter the angle from a given point on the first occurrence to the same point on the next occurrence. For n occurrences: TotalAngle=(n-1)*Spacing. {{Version|1.2}}: Negative angular spacing values are supported.
 ** Specify the number of {{MenuCommand|Occurrences}} (including the original feature).
 * {{Version|1.2}}: The angle or offset and occurrence values can also be edited with [[Sketcher_Workbench#On-View-Parameters|On-View Parameters]] in the [[3D_View|3D View]].
 * If the {{MenuCommand|Recompute on change}} checkbox is checked the view will update in real time.


### PR DESCRIPTION
Addresses #79.

This documents the FreeCAD 1.2 PartDesign Polar Pattern support for negative overall angles and negative offset angles.

Source:
- FreeCAD/FreeCAD#25621 enabled negative angles for Polar Pattern, including extent/overall mode.

Summary:
- note that negative overall angles are supported
- note that negative offset angles are supported
- keep the update scoped to `wiki/PartDesign_PolarPattern.wikitext`

Validation:
- `git diff --check -- wiki/PartDesign_PolarPattern.wikitext`

AI-assisted contribution by Codex/GPT-5 under user supervision.