### PR TITLE
Document Tree View greyed text

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -51,6 +51,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * SpaceMouse rotations now honor the active navigation rotation center mode, including ''Object center'' and ''Drag at cursor'' modes. [https://github.com/FreeCAD/FreeCAD/pull/29998 Pull request #29998]
 * The VarSet ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 * There is now a warning when saving files created in older versions. A preference was added to allow disabling it. [https://github.com/FreeCAD/FreeCAD/pull/28389 Pull request #28389]
+* Non-visible objects in the [[Tree_View|Tree View]] now use greyed text. [https://github.com/FreeCAD/FreeCAD/pull/28114 Pull request #28114]
 
 == Core system and API == <!--T:10-->
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -40,6 +40,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * SpaceMouse rotations now honor the active navigation rotation center mode, including ''Object center'' and ''Drag at cursor'' modes. [https://github.com/FreeCAD/FreeCAD/pull/29998 Pull request #29998]
 * The VarSet ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 * There is now a warning when saving files created in older versions. A preference was added to allow disabling it. [https://github.com/FreeCAD/FreeCAD/pull/28389 Pull request #28389]
+* Non-visible objects in the [[Tree_View|Tree View]] now use greyed text. [https://github.com/FreeCAD/FreeCAD/pull/28114 Pull request #28114]
 
 == Core system and API ==
 


### PR DESCRIPTION
Adds a focused FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#28114, which makes non-visible objects in the Tree View use greyed text.\n\nTouches the root and English Release_notes_1.2 pages.\n\nRefs #30.