### PR TITLE
Document PartDesign Revolution and Groove draggers

### DIFF
--- a/wiki/PartDesign_Groove.wikitext
+++ b/wiki/PartDesign_Groove.wikitext
@@ -102,6 +102,8 @@ Note that when changing the axis, the '''Reversed''' option may be (un)checked a
 <!--T:13-->
 Defines the angle of the groove. This option is only available if '''Type''' is '''Angle''' or '''Two angles'''. Angles larger than 360° are not possible. Nor are negative values, use the '''Reversed''' option instead.
 
+{{Version|1.1}}: If the {{MenuCommand|Show interactive draggers when editing features}} [[PartDesign_Preferences#General|preference]] is selected, the angle can be adjusted with an interactive gizmo in the [[3D_View|3D View]].
+
 ===2nd angle=== <!--T:43-->
 
 <!--T:44-->

--- a/wiki/PartDesign_Revolution.wikitext
+++ b/wiki/PartDesign_Revolution.wikitext
@@ -102,6 +102,8 @@ Note that when changing the axis, the '''Reversed''' option may be (un)checked a
 <!--T:15-->
 Defines the angle of the revolution. This option is only available if '''Type''' is '''Angle''' or '''Two angles'''. Angles larger than 360° are not possible. Nor are negative values, use the '''Reversed''' option instead.
 
+{{Version|1.1}}: If the {{MenuCommand|Show interactive draggers when editing features}} [[PartDesign_Preferences#General|preference]] is selected, the angle can be adjusted with an interactive gizmo in the [[3D_View|3D View]].
+
 ===2nd angle=== <!--T:50-->
 
 <!--T:51-->


### PR DESCRIPTION
Addresses #79.

This documents the FreeCAD 1.1/1.2 interactive dragger behavior for PartDesign Revolution and Groove angle editing.

Sources:
- FreeCAD/FreeCAD#22880 added interactive controls for Part Design Revolution and Groove.
- FreeCAD/FreeCAD#25656 fixed Revolution/Groove dragger behavior in symmetric/two-angle modes.

Summary:
- add a short interactive-gizmo note to `PartDesign_Revolution`
- add the matching note to `PartDesign_Groove`
- keep the update scoped to the root wiki pages

Validation:
- `git diff --check -- wiki/PartDesign_Revolution.wikitext wiki/PartDesign_Groove.wikitext`

AI-assisted contribution by Codex/GPT-5 under user supervision.