### PR TITLE
Document Sketcher constraint double-click rename

### DIFF
--- a/wiki/Sketcher_Dialog.wikitext
+++ b/wiki/Sketcher_Dialog.wikitext
@@ -213,13 +213,13 @@ Available options:
 |-
 | {{MenuCommand|Context menu}}
 | Right-clicking the background of the list, or right-clicking constraints selected in the list opens a context menu. The menu has the following options:
-* {{MenuCommand|Change Value}}: Changes the value of a dimensional constraint. Only works for a single constraint. You can also double click the constraint in the list, or double click its value in the [[3D_View|3D View]].
+* {{MenuCommand|Change Value}}: Changes the value of a dimensional constraint. Only works for a single constraint. You can also double-click a dimensional constraint in the list, or double-click its value in the [[3D_View|3D View]].
 * {{MenuCommand|Toggle Driving/Reference}}: See [[Sketcher_ToggleDrivingConstraint|Sketcher ToggleDrivingConstraint]].
 * {{MenuCommand|Deactivate}} or {{MenuCommand|Activate}}: See [[Sketcher_ToggleActiveConstraint|Sketcher ToggleActiveConstraint]].
 * {{MenuCommand|Show Constraints}}: Same as checking the constraint checkbox. But, unlike the checkbox, also works for more than one constraint.
 * {{MenuCommand|Hide Constraints}}: Same as unchecking the constraint checkbox. Idem.
 * {{MenuCommand|Select Elements}}: See [[Sketcher_SelectElementsAssociatedWithConstraints|Sketcher SelectElementsAssociatedWithConstraints]].
-* {{MenuCommand|Rename}}: Renames the constraint.
+* {{MenuCommand|Rename}}: Renames the constraint. {{Version|1.2}}: You can also double-click a geometric constraint in the list.
 * {{MenuCommand|Center Sketch}}: Centers the 3D View around the selected constraints.
 * {{MenuCommand|Delete}}: Deletes the selected constrains. The {{KEY|Del}} key can also be used.
 * {{MenuCommand|Swap Constraint Names}}: Swaps the names of selected constraints. Only works if two constraints with user given names are selected.


### PR DESCRIPTION
Summary:
- Clarify that double-clicking a dimensional constraint in the Sketcher constraint list edits its value.
- Document that, in FreeCAD 1.2, double-clicking a geometric constraint in the list renames it.

Source:
- FreeCAD/FreeCAD#27678

Verification:
- git diff --check -- wiki/Sketcher_Dialog.wikitext

Refs #94