### PR TITLE
Document Draft Trimex sketch limitation

### DIFF
--- a/wiki/Draft_Trimex.wikitext
+++ b/wiki/Draft_Trimex.wikitext
@@ -38,6 +38,7 @@ Bottom: a face extruded into a solid body.}}
 
 <!--T:5-->
 # Optionally select one object. The object must be a [[Draft_Line|Draft Line]], a [[Draft_Wire|Draft Wire]], a [[Draft_Arc|Draft Arc]] or a [[Draft_Circle|Draft Circle]] (which can only be trimmed). If the selected object is closed it must have its {{PropertyData|Make Face}} property set to {{FALSE}}.
+# [[Sketcher_Workbench|Sketcher]] Sketch objects are not supported by this command. Use Sketcher tools to edit sketch geometry, or convert suitable geometry to Draft objects before using Trimex.
 # There are several ways to invoke the command:
 #* Press the {{Button|[[Image:Draft_Trimex.svg|16px]] [[Draft_Trimex|Trimex]]}} button.
 #* [[Draft_Workbench|Draft]]: Select the {{MenuCommand|Modification → [[Image:Draft_Trimex.svg|16px]] Trimex}} option from the menu.


### PR DESCRIPTION
## Summary
- Document that Draft Trimex does not support Sketcher Sketch selections.
- Point users to Sketcher tools or converting suitable geometry to Draft objects before using Trimex.

## Context
This is a small, non-overlapping Draft documentation update for #27. It reflects the behavior merged upstream in FreeCAD/FreeCAD#29845, where Trimex rejects Sketch selections instead of entering a misleading no-op workflow.

## Validation
- `git diff --check -- wiki/Draft_Trimex.wikitext`
