### PR TITLE
Document Draft SubelementHighlight warning behavior

### DIFF
--- a/wiki/Draft_SubelementHighlight.wikitext
+++ b/wiki/Draft_SubelementHighlight.wikitext
@@ -55,6 +55,9 @@ The [[Image:Draft_SubelementHighlight.svg|24px]] '''Draft SubelementHighlight'''
 * If objects have been highlighted with this command the temporary visual changes should be reverted before saving and reopening the file.
 * Highlighted objects should not be copied if subelement mode is off. The temporary visual changes cannot be reverted for copies created in this manner.
 
+<!--T:19-->
+* In FreeCAD 1.2 and later the command reports a warning instead of a Python error for unsupported selections. Objects with an empty {{PropertyData|Base}} property, or with a base object that is not an editable Draft line, wire or curve, are skipped.
+
 
 <!--T:13-->
 {{Docnav


### PR DESCRIPTION
Documents the FreeCAD 1.2 behavior added by FreeCAD/FreeCAD#29425 for Draft SubelementHighlight.

The page now notes that unsupported selections are skipped with a warning instead of producing a Python error, including objects with an empty Base property or non-editable base geometry.

Source: FreeCAD/FreeCAD#29425
Related: #27

Verification:
- git diff --check -- wiki/Draft_SubelementHighlight.wikitext