### PR TITLE
Document base-less BIM wall endpoint editing

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -140,6 +140,9 @@ ToDo (last check: 20260430, #27222):
 
 === Further BIM improvements === <!--T:24-->
 
+<!--T:82-->
+* Endpoints of base-less [[BIM_Wall|BIM walls]] can now be edited with Draft editing tools. [https://github.com/FreeCAD/FreeCAD/pull/29860 Pull request #29860]
+
 == CAM Workbench == <!--T:25-->
 
 <!--T:71-->

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -122,6 +122,8 @@ ToDo (last check: 20260430, #27222):
 
 === Further BIM improvements ===
 
+* Endpoints of base-less [[BIM_Wall|BIM walls]] can now be edited with Draft editing tools. [https://github.com/FreeCAD/FreeCAD/pull/29860 Pull request #29860]
+
 == CAM Workbench ==
 
 {| cellpadding=5


### PR DESCRIPTION
## Summary
- add a FreeCAD 1.2 BIM release-note bullet for FreeCAD/FreeCAD#29860
- mention that endpoints of base-less BIM walls can now be edited with Draft editing tools
- update both root and English release-note pages

## Checks
- git diff --check

Refs #30
Refs #26
Refs #27