### PR TITLE
Document Draft Edit nodes for base-less walls

### DIFF
--- a/wiki/Draft_Edit.wikitext
+++ b/wiki/Draft_Edit.wikitext
@@ -156,6 +156,7 @@ The single character keyboard shortcuts available in the task panel can be chang
 
 <!--T:54-->
 * A single node to control the height of the wall is displayed above the {{PropertyData|Placement}} of the wall.
+* {{Version|1.2}}: For a wall without a base object, the endpoints of the wall can also be moved.
 * No context menus for this object.
 
 ===[[Image:Arch_Structure.svg|24px]] [[Arch_Structure|Arch Structure]]=== <!--T:55-->

--- a/wiki/en/Draft_Edit.wikitext
+++ b/wiki/en/Draft_Edit.wikitext
@@ -132,6 +132,7 @@ The single character keyboard shortcuts available in the task panel can be chang
 ===[[Image:Arch_Wall.svg|24px]] [[Arch_Wall|Arch Wall]]===
 
 * A single node to control the height of the wall is displayed above the {{PropertyData|Placement}} of the wall.
+* {{Version|1.2}}: For a wall without a base object, the endpoints of the wall can also be moved.
 * No context menus for this object.
 
 ===[[Image:Arch_Structure.svg|24px]] [[Arch_Structure|Arch Structure]]===


### PR DESCRIPTION
## Summary
- update Draft Edit documentation for FreeCAD/FreeCAD#29860
- mention that Arch Walls without a base object expose movable endpoint nodes in FreeCAD 1.2
- update both root and English Draft_Edit pages

## Checks
- git diff --check

Refs #27
Refs #26