### PR TITLE
Document Draft annotation input hints

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -215,6 +215,7 @@ ToDo (last check: 20260430, #29258):
 * [[Draft_PolarArray|Polar Array]] and [[Draft_CircularArray|Circular Array]] are now aware of the active working plane. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
 * SVG import can now approximate suitable curves to arcs and lines. [https://github.com/FreeCAD/FreeCAD/pull/29142 Pull request #29142]
 * Draft angular dimensions now honor overshoot settings. [https://github.com/FreeCAD/FreeCAD/pull/29298 Pull request #29298]
+* Input hints were added to Draft annotation tools, including [[Draft_Dimension|Dimension]], [[Draft_Label|Label]], [[Draft_Text|Text]] and [[Draft_ShapeString|ShapeString]]. [https://github.com/FreeCAD/FreeCAD/pull/29649 Pull request #29649]
 
 === Further Draft improvements === <!--T:28-->
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -192,6 +192,7 @@ ToDo (last check: 20260430, #29258):
 * [[Draft_PolarArray|Polar Array]] and [[Draft_CircularArray|Circular Array]] are now aware of the active working plane. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
 * SVG import can now approximate suitable curves to arcs and lines. [https://github.com/FreeCAD/FreeCAD/pull/29142 Pull request #29142]
 * Draft angular dimensions now honor overshoot settings. [https://github.com/FreeCAD/FreeCAD/pull/29298 Pull request #29298]
+* Input hints were added to Draft annotation tools, including [[Draft_Dimension|Dimension]], [[Draft_Label|Label]], [[Draft_Text|Text]] and [[Draft_ShapeString|ShapeString]]. [https://github.com/FreeCAD/FreeCAD/pull/29649 Pull request #29649]
 
 === Further Draft improvements ===
 


### PR DESCRIPTION
## Summary
- add a FreeCAD 1.2 Draft release-note bullet for annotation tool input hints
- cite FreeCAD/FreeCAD#29649 and cover Dimension, Label, Text, and ShapeString
- update both root and English Release_notes_1.2 pages

## Verification
- git diff --check

Source: FreeCAD/FreeCAD#29649

AI-assisted with OpenAI Codex; I reviewed the final diff before submitting.