### PR TITLE
Document Draft annotation input hints on tool pages

### DIFF
--- a/wiki/Draft_Dimension.wikitext
+++ b/wiki/Draft_Dimension.wikitext
@@ -111,6 +111,7 @@ The single character keyboard shortcuts available in the task panel can be chang
 ==Notes== <!--T:40-->
 
 <!--T:15-->
+* {{Version|1.2}}: The command shows input hints for edge selection, point picking, chained dimensions and modifier keys such as snap, constraint, horizontal/vertical and radial dimension modes.
 * Linear and radial Draft Dimensions can be edited with the [[Draft_Edit|Draft Edit]] command.
 * Draft Dimensions created or saved with [[Release_notes_0.21|FreeCAD version 0.21]] are not backward compatible.
 

--- a/wiki/Draft_Label.wikitext
+++ b/wiki/Draft_Label.wikitext
@@ -91,6 +91,7 @@ The following label types are available:
 ==Notes== <!--T:30-->
 
 <!--T:17-->
+* {{Version|1.2}}: The command shows input hints while the arrow, corner and text points are being picked, including the snap modifier when applicable.
 * {{Version|1.1}}: A Draft Label can be edited with the [[Draft_Edit|Draft Edit]] command.
 * The direction of the second segment of the leader determines the alignment of the text. If the segment is horizontal and pointing to the right the text is aligned to the left and vice versa. If the second segment goes vertically up, the text is aligned to the left. If it goes vertically down, the text is aligned to the right.
 * Draft Labels created or saved with [[Release_notes_0.21|FreeCAD version 0.21]] are not backward compatible.

--- a/wiki/Draft_ShapeString.wikitext
+++ b/wiki/Draft_ShapeString.wikitext
@@ -94,6 +94,7 @@ See the [[#Preferences|Preferences]] paragraph below for the location of the men
 ==Notes== <!--T:33-->
 
 <!--T:12-->
+* {{Version|1.2}}: The task panel shows input hints while the insertion point is being picked, including the snap modifier when applicable.
 * A Draft ShapeString can be edited by double-clicking it in the [[Tree_View|Tree View]].
 * Supported fonts include TrueType Collection ({{FileName|.ttc}}, {{Version|1.1}}), TrueType ({{FileName|.ttf}}), OpenType ({{FileName|.otf}}) and Type 1 ({{FileName|.pfb}}). Note that only the first font in a TrueType Collection file can be used.
 * The command is restricted to left-to-right text. Right-to-left and top-to-bottom text are not supported.

--- a/wiki/Draft_Text.wikitext
+++ b/wiki/Draft_Text.wikitext
@@ -63,6 +63,7 @@ The single character keyboard shortcuts available in the task panel can be chang
 ==Notes== <!--T:26-->
 
 <!--T:21-->
+* {{Version|1.2}}: The command shows input hints while the insertion point is being picked, including the snap modifier when applicable.
 * A Draft Text can be edited by double-clicking it in the [[Tree_View|Tree View]].
 * Draft Texts created or saved with [[Release_notes_0.21|FreeCAD version 0.21]] are not backward compatible.
 

--- a/wiki/en/Draft_Dimension.wikitext
+++ b/wiki/en/Draft_Dimension.wikitext
@@ -95,6 +95,7 @@ The single character keyboard shortcuts available in the task panel can be chang
 
 ==Notes==
 
+* {{Version|1.2}}: The command shows input hints for edge selection, point picking, chained dimensions and modifier keys such as snap, constraint, horizontal/vertical and radial dimension modes.
 * Linear and radial Draft Dimensions can be edited with the [[Draft_Edit|Draft Edit]] command.
 * Draft Dimensions created or saved with [[Release_notes_0.21|FreeCAD version 0.21]] are not backward compatible.
 

--- a/wiki/en/Draft_Label.wikitext
+++ b/wiki/en/Draft_Label.wikitext
@@ -75,6 +75,7 @@ The following label types are available:
 
 ==Notes==
 
+* {{Version|1.2}}: The command shows input hints while the arrow, corner and text points are being picked, including the snap modifier when applicable.
 * {{Version|1.1}}: A Draft Label can be edited with the [[Draft_Edit|Draft Edit]] command.
 * The direction of the second segment of the leader determines the alignment of the text. If the segment is horizontal and pointing to the right the text is aligned to the left and vice versa. If the second segment goes vertically up, the text is aligned to the left. If it goes vertically down, the text is aligned to the right.
 * Draft Labels created or saved with [[Release_notes_0.21|FreeCAD version 0.21]] are not backward compatible.

--- a/wiki/en/Draft_ShapeString.wikitext
+++ b/wiki/en/Draft_ShapeString.wikitext
@@ -76,6 +76,7 @@ See the [[#Preferences|Preferences]] paragraph below for the location of the men
 
 ==Notes==
 
+* {{Version|1.2}}: The task panel shows input hints while the insertion point is being picked, including the snap modifier when applicable.
 * A Draft ShapeString can be edited by double-clicking it in the [[Tree_View|Tree View]].
 * Supported fonts include TrueType Collection ({{FileName|.ttc}}, {{Version|1.1}}), TrueType ({{FileName|.ttf}}), OpenType ({{FileName|.otf}}) and Type 1 ({{FileName|.pfb}}). Note that only the first font in a TrueType Collection file can be used.
 * The command is restricted to left-to-right text. Right-to-left and top-to-bottom text are not supported.

--- a/wiki/en/Draft_Text.wikitext
+++ b/wiki/en/Draft_Text.wikitext
@@ -52,6 +52,7 @@ The single character keyboard shortcuts available in the task panel can be chang
 
 ==Notes==
 
+* {{Version|1.2}}: The command shows input hints while the insertion point is being picked, including the snap modifier when applicable.
 * A Draft Text can be edited by double-clicking it in the [[Tree_view|Tree view]].
 * Draft Texts created or saved with [[Release_notes_0.21|FreeCAD version 0.21]] are not backward compatible.
 


### PR DESCRIPTION
## Summary
- add FreeCAD 1.2 notes to the Draft Text, Label, Dimension and ShapeString command pages
- document the new input hints for point picking, edge selection, chained dimensions and relevant modifier keys
- update both root and English wiki pages

## Verification
- git diff --check upstream/main..HEAD

Source: FreeCAD/FreeCAD#29649

AI-assisted with OpenAI Codex; I reviewed the final diff before submitting.