### PR TITLE
Document grounded Assembly placement lock

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -116,6 +116,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Solver messages (overconstraint reports) were added to the Assembly task panel. [https://github.com/FreeCAD/FreeCAD/pull/24623 Pull request #24623]
 * A new command has been added to select all joints associated with a chosen component. [https://github.com/FreeCAD/FreeCAD/pull/27530 Pull request #27530]
 * A button was added to rotate joint offsets by 90 degrees. [https://github.com/FreeCAD/FreeCAD/pull/29717 Pull request #29717]
+* Grounded components now have their placement locked while grounded, preventing transform tools from moving them until the ground is removed. [https://github.com/FreeCAD/FreeCAD/pull/28087 Pull request #28087]
 
 == BIM Workbench == <!--T:23-->
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -100,6 +100,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Solver messages (overconstraint reports) were added to the Assembly task panel. [https://github.com/FreeCAD/FreeCAD/pull/24623 Pull request #24623]
 * A new command has been added to select all joints associated with a chosen component. [https://github.com/FreeCAD/FreeCAD/pull/27530 Pull request #27530]
 * A button was added to rotate joint offsets by 90 degrees. [https://github.com/FreeCAD/FreeCAD/pull/29717 Pull request #29717]
+* Grounded components now have their placement locked while grounded, preventing transform tools from moving them until the ground is removed. [https://github.com/FreeCAD/FreeCAD/pull/28087 Pull request #28087]
 
 == BIM Workbench ==
 


### PR DESCRIPTION
## Summary
- add an Assembly release note for FreeCAD 1.2 grounded component behavior
- document that grounded components have their placement locked while grounded
- update both root and English release-note pages

## Verification
- git diff --check upstream/main..HEAD

Source: FreeCAD/FreeCAD#28087

AI-assisted with OpenAI Codex; I reviewed the final diff before submitting.