### PR TITLE
Document BIM CutPlane selection handling

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -140,6 +140,8 @@ ToDo (last check: 20260430, #27222):
 
 === Further BIM improvements === <!--T:24-->
 
+* The [[BIM_CutPlane|CutPlane]] task panel now keeps the original object selection for the final cut even if objects are deselected while the preview is open. [https://github.com/FreeCAD/FreeCAD/pull/29699 Pull request #29699]
+
 == CAM Workbench == <!--T:25-->
 
 <!--T:71-->

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -122,6 +122,8 @@ ToDo (last check: 20260430, #27222):
 
 === Further BIM improvements ===
 
+* The [[BIM_CutPlane|CutPlane]] task panel now keeps the original object selection for the final cut even if objects are deselected while the preview is open. [https://github.com/FreeCAD/FreeCAD/pull/29699 Pull request #29699]
+
 == CAM Workbench ==
 
 {| cellpadding=5


### PR DESCRIPTION
## Summary
- add a BIM release note for the CutPlane task-panel selection fix
- document that the original selection is kept for the final cut even if objects are deselected during preview
- update both root and English release-note pages

## Verification
- git diff --check upstream/main..HEAD

Source: FreeCAD/FreeCAD#29699

AI-assisted with OpenAI Codex; I reviewed the final diff before submitting.