### PR TITLE
Document BIM Wall unsupported base handling

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -140,6 +140,8 @@ ToDo (last check: 20260430, #27222):
 
 === Further BIM improvements === <!--T:24-->
 
+* [[BIM_Wall|BIM Walls]] created from base objects with unsupported edge types now filter for supported line, circle, arc and closed ellipse edges, and warn instead of producing traceback errors when no supported edges are available. [https://github.com/FreeCAD/FreeCAD/pull/29810 Pull request #29810]
+
 == CAM Workbench == <!--T:25-->
 
 <!--T:71-->

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -122,6 +122,8 @@ ToDo (last check: 20260430, #27222):
 
 === Further BIM improvements ===
 
+* [[BIM_Wall|BIM Walls]] created from base objects with unsupported edge types now filter for supported line, circle, arc and closed ellipse edges, and warn instead of producing traceback errors when no supported edges are available. [https://github.com/FreeCAD/FreeCAD/pull/29810 Pull request #29810]
+
 == CAM Workbench ==
 
 {| cellpadding=5


### PR DESCRIPTION
## Summary
- add a BIM release note for unsupported BIM Wall base-object handling
- document that unsupported base edge types are filtered and warn instead of producing tracebacks when no supported edges are available
- update both root and English release-note pages

## Verification
- git diff --check upstream/main..HEAD

Source: FreeCAD/FreeCAD#29810

AI-assisted with OpenAI Codex; I reviewed the final diff before submitting.