### PR TITLE
Document Sketcher symmetry constraint defaults

### DIFF
--- a/wiki/Sketcher_Symmetry.wikitext
+++ b/wiki/Sketcher_Symmetry.wikitext
@@ -40,10 +40,10 @@ See also: [[Sketcher_Workbench#Drawing_aids|Drawing aids]].
 # The cursor changes to a cross with the tool icon.
 # The '''Symmetry Parameters''' section ({{Version|1.0}}) is added at the top of the [[Sketcher_Dialog|Sketcher Dialog]].
 # Optionally press the {{KEY|U}} key or check the '''Delete original geometries''' checkbox to only keep the mirrored elements. {{Version|1.0}}
-# Optionally press the {{KEY|J}} key or check the '''Create symmetry constraints''' checkbox to add a [[Sketcher_ConstrainSymmetric|symmetric constraint]] between each original and mirrored point. {{Version|1.0}}
+# Optionally press the {{KEY|J}} key or check the '''Create symmetry constraints''' checkbox to add a [[Sketcher_ConstrainSymmetric|symmetric constraint]] between each original and mirrored point. {{Version|1.0}} {{Version|1.2}}: This option is enabled by default.
 # Select a line or a sketch axis to define the symmetry line, or a point to define the symmetry point.
 # Mirrored copies are created. Constraints restricted to the selected elements are also processed.
-#* If '''Create Symmetry constraints''' has been selected symmetric constraints are added.
+#* If '''Create Symmetry constraints''' has been selected symmetric constraints are added. {{Version|1.2}}: To avoid overconstraining the sketch, coincident constraints are created instead for points that lie on the symmetry axis, and mirrored wires get coincident constraints where needed so they remain closed if the symmetry relation is later removed.
 #* If '''Delete original geometries''' has been selected the original geometry is removed.
 
 


### PR DESCRIPTION
Refs #94.

Summary:
- Document that the Sketcher Symmetry tool's Create symmetry constraints option is enabled by default in FreeCAD 1.2.
- Note the FreeCAD 1.2 behavior that avoids redundant symmetric constraints by using coincident constraints where appropriate.

Sources:
- https://github.com/FreeCAD/FreeCAD/pull/28118
- https://github.com/FreeCAD/FreeCAD/pull/28319

Validation:
- git diff --check -- wiki/Sketcher_Symmetry.wikitext