### PR TITLE
Document Sketcher external geometry double-click selection

### DIFF
--- a/wiki/Sketcher_Workbench.wikitext
+++ b/wiki/Sketcher_Workbench.wikitext
@@ -631,7 +631,7 @@ You can box-select edges and points, constraints cannot be box-selected. {{Versi
 {{Version|1.0}}
 
 <!--T:248-->
-Double-clicking an edge in the 3D View will select all edges directly and indirectly connected with that edge via endpoints. There is no need for the edges to be connected with [[Sketcher_ConstrainCoincident|coincident constraints]], endpoints need only have the same coordinates.
+Double-clicking an edge in the 3D View will select all edges directly and indirectly connected with that edge via endpoints. There is no need for the edges to be connected with [[Sketcher_ConstrainCoincident|coincident constraints]], endpoints need only have the same coordinates. {{Version|1.2}}: The same double-click selection also works for [[Sketcher_External|external geometry]] edges.
 
 === Sketcher Dialog selection === <!--T:249-->
 


### PR DESCRIPTION
Refs #94.

Summary:
- Document that Sketcher's double-click connected-edge selection also supports external geometry edges in FreeCAD 1.2.
- Keep the update scoped to the existing Sketcher Workbench selection-methods section.

Source:
- https://github.com/FreeCAD/FreeCAD/pull/28105

Validation:
- git diff --check -- wiki/Sketcher_Workbench.wikitext