### PR TITLE
Document SubShapeBinder face creation behavior

### DIFF
--- a/wiki/PartDesign_SubShapeBinder.wikitext
+++ b/wiki/PartDesign_SubShapeBinder.wikitext
@@ -102,7 +102,7 @@ A PartDesign SubShapeBinder object is derived from a [[Part_Feature|Part Feature
 <!--T:15-->
 * {{PropertyData|Support|XLinkSubList}}: support for the geometry.
 * {{PropertyData|Fuse|Bool}}: if it is {{TRUE}} it will fuse the solid linked shapes.
-* {{PropertyData|Make Face|Bool}}: if it is {{TRUE}} it will created a face for the linked wires.
+* {{PropertyData|Make Face|Bool}}: if it is {{TRUE}} it will create faces for the linked wires. {{Version|1.2}}: Overlapping or intersecting linked geometry is handled more reliably when bounded faces are created.
 * {{PropertyData|Claim Children|PropertyBool}}: if it is {{TRUE}} it will claim the linked objects as children in the [[Tree_View|Tree View]].
 * {{PropertyData|Relative|Bool}}: if it is {{TRUE}} it will enable relative sub-object linking.
 * {{PropertyData|Bind Mode|Enumeration}}: binding mode, {{value|Synchronized}}, {{Value|Frozen}}, {{Value|Detached}}.


### PR DESCRIPTION
Addresses #79.

Summary:
- Document the FreeCAD 1.2 SubShapeBinder Make Face behavior for overlapping or intersecting linked geometry.
- Keep the change scoped to the existing PartDesign SubShapeBinder property list.

Source:
- https://github.com/FreeCAD/FreeCAD/pull/29249

Validation:
- git diff --check -- wiki/PartDesign_SubShapeBinder.wikitext