### PR TITLE
Document Sketcher Auto Color release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -392,6 +392,7 @@ ToDo (last check: 20260430, #29258):
 * A new preference was added to control the font type (in addition to font size) for labels. [https://github.com/FreeCAD/FreeCAD/pull/26600 Pull request #26600]
 * Sketcher line style dropdowns now correctly list the available styles instead of appearing empty. [https://github.com/FreeCAD/FreeCAD/pull/30151 Pull request #30151]
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
+* Enabling the {{PropertyView|Auto Color}} property of a sketch now immediately applies the colors from [[Sketcher_Preferences#Appearance|Sketcher appearance preferences]], without requiring the document to be saved and reopened. [https://github.com/FreeCAD/FreeCAD/pull/30185 Pull request #30185]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 
 == Spreadsheet Workbench == <!--T:53-->


### PR DESCRIPTION
Summary:
- Add a FreeCAD 1.2 Sketcher release-note entry for FreeCAD/FreeCAD#30185.
- Document that enabling a sketch's Auto Color property now applies Sketcher appearance preference colors immediately.
- Keep the update scoped to the English and translation-source release notes.

Source:
- https://github.com/FreeCAD/FreeCAD/pull/30185

Validation:
- git diff --check -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext

Refs #94