### PR TITLE
Document PartDesign Helix multiple-solid guidance

### DIFF
--- a/wiki/PartDesign_AdditiveHelix.wikitext
+++ b/wiki/PartDesign_AdditiveHelix.wikitext
@@ -131,6 +131,7 @@ If checked, the helix will be shown in the view, and updated automatically on ev
 <!--T:38-->
 * {{VersionMinus|0.21}}: A [[File:PartDesign_ShapeBinder.svg|16px]] [[PartDesign_ShapeBinder|ShapeBinder]] cannot be used for the profile.
 * {{VersionMinus|0.21}}: When using a [[File:PartDesign_SubShapeBinder.svg|16px]] [[PartDesign_SubShapeBinder|SubShapeBinder]] for the profile, selecting the binder in the [[Tree_View|Tree View]] will fail, instead the binder's face has to be selected in the [[3D_View|3D View]].
+* If the helix result intentionally creates more than one solid, enable the {{PropertyData|Allow Compound}} property of the active [[PartDesign_Body|Body]]. {{Version|1.2}}
 * Helixes are very difficult for the underlying engine to calculate correctly because the curves involved push floating point precision to its limit. That means that performing further operations on a helix like attempting boolean operations with another object can be very sensitive to small changes. When they fail, they often break the model in surprising ways. To avoid this, you should try to make operations on a helix either clearly overlap (interfere) or clearly not overlap. Exact matches where the surface of the helix is perfectly aligned with the surface of another object are fragile. A thread around a bolt cylinder is an example of this. It may even work initially, and then break later when objects are moved slightly.
 
 == Examples == <!--T:31-->

--- a/wiki/PartDesign_SubtractiveHelix.wikitext
+++ b/wiki/PartDesign_SubtractiveHelix.wikitext
@@ -136,6 +136,7 @@ If checked, the helix will be shown in the view, and updated automatically on ev
 <!--T:37-->
 * {{VersionMinus|0.21}}: A [[File:PartDesign_ShapeBinder.svg|16px]] [[PartDesign_ShapeBinder|ShapeBinder]] cannot be used for the profile.
 * {{VersionMinus|0.21}}: When using a [[File:PartDesign_SubShapeBinder.svg|16px]] [[PartDesign_SubShapeBinder|SubShapeBinder]] for the profile, selecting the binder in the [[Tree_View|Tree View]] will fail, instead the binder's face has to selected in the [[3D_View|3D View]].
+* If the helix result intentionally creates more than one solid, enable the {{PropertyData|Allow Compound}} property of the active [[PartDesign_Body|Body]]. {{Version|1.2}}
 
 
 <!--T:33-->

--- a/wiki/en/PartDesign_AdditiveHelix.wikitext
+++ b/wiki/en/PartDesign_AdditiveHelix.wikitext
@@ -113,6 +113,7 @@ If checked, the helix will be shown in the view, and updated automatically on ev
 
 * {{VersionMinus|0.21}}: A [[File:PartDesign_ShapeBinder.svg|16px]] [[PartDesign_ShapeBinder|ShapeBinder]] cannot be used for the profile.
 * {{VersionMinus|0.21}}: When using a [[File:PartDesign_SubShapeBinder.svg|16px]] [[PartDesign_SubShapeBinder|SubShapeBinder]] for the profile, selecting the binder in the [[Tree_view|Tree view]] will fail, instead the binder's face has to be selected in the [[3D_view|3D view]].
+* If the helix result intentionally creates more than one solid, enable the {{PropertyData|Allow Compound}} property of the active [[PartDesign_Body|Body]]. {{Version|1.2}}
 * Helixes are very difficult for the underlying engine to calculate correctly because the curves involved push floating point precision to its limit. That means that performing further operations on a helix like attempting boolean operations with another object can be very sensitive to small changes. When they fail, they often break the model in surprising ways. To avoid this, you should try to make operations on a helix either clearly overlap (interfere) or clearly not overlap. Exact matches where the surface of the helix is perfectly aligned with the surface of another object are fragile. A thread around a bolt cylinder is an example of this. It may even work initially, and then break later when objects are moved slightly.
 
 == Examples ==

--- a/wiki/en/PartDesign_SubtractiveHelix.wikitext
+++ b/wiki/en/PartDesign_SubtractiveHelix.wikitext
@@ -117,6 +117,7 @@ If checked, the helix will be shown in the view, and updated automatically on ev
 
 * {{VersionMinus|0.21}}: A [[File:PartDesign_ShapeBinder.svg|16px]] [[PartDesign_ShapeBinder|ShapeBinder]] cannot be used for the profile.
 * {{VersionMinus|0.21}}: When using a [[File:PartDesign_SubShapeBinder.svg|16px]] [[PartDesign_SubShapeBinder|SubShapeBinder]] for the profile, selecting the binder in the [[Tree_view|Tree view]] will fail, instead the binder's face has to selected in the [[3D_view|3D view]].
+* If the helix result intentionally creates more than one solid, enable the {{PropertyData|Allow Compound}} property of the active [[PartDesign_Body|Body]]. {{Version|1.2}}
 
 
 {{Docnav


### PR DESCRIPTION
Summary:
- Add a PartDesign Helix note that intentional multiple-solid helix results require enabling the active Body's Allow Compound property.
- Apply the note to Additive Helix and Subtractive Helix pages in both source and English wiki pages.

Source:
- FreeCAD/FreeCAD#29339

Validation:
- git diff --check -- wiki/PartDesign_AdditiveHelix.wikitext wiki/PartDesign_SubtractiveHelix.wikitext wiki/en/PartDesign_AdditiveHelix.wikitext wiki/en/PartDesign_SubtractiveHelix.wikitext

Refs #79