### PR TITLE
Document PartDesign Pad Up to shape fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -316,6 +316,7 @@ ToDo (last check: 20260430, #29258):
 * Pressing {{KEY|Space}} on an element selected from the 3D view (e.g. from selecting a face) now toggles the visibility of the entire [[PartDesign_Body|PartDesign Body]] instead of the last feature, making it easier to show or hide bodies in assemblies or files with multiple bodies. Selection in the Tree view still toggles the selected object. [https://github.com/FreeCAD/FreeCAD/pull/29110 Pull request #29110] and [https://github.com/FreeCAD/FreeCAD/pull/30231 Pull request #30231]
 * Input hints were implemented for the interactive control draggers. [https://github.com/FreeCAD/FreeCAD/pull/29631 Pull request #29631]
 * [[PartDesign_SubShapeBinder|SubShapeBinder]] now uses the ''BuildFace'' face maker to handle overlapping geometry. [https://github.com/FreeCAD/FreeCAD/pull/29249 Pull request #29249]
+* The [[PartDesign_Pad|Pad]] ''Up to shape'' end condition now correctly uses the selected shape when creating the extrusion. [https://github.com/FreeCAD/FreeCAD/pull/29686 Pull request #29686]
 * A ''Fuzzy Tolerance'' property was added to override the default fuzziness/tolerance for boolean operations determined from the size of the input shapes. [https://github.com/FreeCAD/FreeCAD/pull/29984 Pull request #29984]
 
 == Points Workbench == <!--T:44-->

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -283,7 +283,6 @@ ToDo (last check: 20260430, #29258):
 * Pressing {{KEY|Space}} on an element selected from the 3D view (e.g. from selecting a face) now toggles the visibility of the entire [[PartDesign_Body|PartDesign Body]] instead of the last feature, making it easier to show or hide bodies in assemblies or files with multiple bodies. Selection in the Tree view still toggles the selected object. [https://github.com/FreeCAD/FreeCAD/pull/29110 Pull request #29110] and [https://github.com/FreeCAD/FreeCAD/pull/30231 Pull request #30231]
 * Input hints were implemented for the interactive control draggers. [https://github.com/FreeCAD/FreeCAD/pull/29631 Pull request #29631]
 * [[PartDesign_SubShapeBinder|SubShapeBinder]] now uses the ''BuildFace'' face maker to handle overlapping geometry. [https://github.com/FreeCAD/FreeCAD/pull/29249 Pull request #29249]
-* The [[PartDesign_Pad|Pad]] ''Up to shape'' end condition now correctly uses the selected shape when creating the extrusion. [https://github.com/FreeCAD/FreeCAD/pull/29686 Pull request #29686]
 * A ''Fuzzy Tolerance'' property was added to override the default fuzziness/tolerance for boolean operations determined from the size of the input shapes. [https://github.com/FreeCAD/FreeCAD/pull/29984 Pull request #29984]
 
 == Points Workbench ==

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -283,6 +283,7 @@ ToDo (last check: 20260430, #29258):
 * Pressing {{KEY|Space}} on an element selected from the 3D view (e.g. from selecting a face) now toggles the visibility of the entire [[PartDesign_Body|PartDesign Body]] instead of the last feature, making it easier to show or hide bodies in assemblies or files with multiple bodies. Selection in the Tree view still toggles the selected object. [https://github.com/FreeCAD/FreeCAD/pull/29110 Pull request #29110] and [https://github.com/FreeCAD/FreeCAD/pull/30231 Pull request #30231]
 * Input hints were implemented for the interactive control draggers. [https://github.com/FreeCAD/FreeCAD/pull/29631 Pull request #29631]
 * [[PartDesign_SubShapeBinder|SubShapeBinder]] now uses the ''BuildFace'' face maker to handle overlapping geometry. [https://github.com/FreeCAD/FreeCAD/pull/29249 Pull request #29249]
+* The [[PartDesign_Pad|Pad]] ''Up to shape'' end condition now correctly uses the selected shape when creating the extrusion. [https://github.com/FreeCAD/FreeCAD/pull/29686 Pull request #29686]
 * A ''Fuzzy Tolerance'' property was added to override the default fuzziness/tolerance for boolean operations determined from the size of the input shapes. [https://github.com/FreeCAD/FreeCAD/pull/29984 Pull request #29984]
 
 == Points Workbench ==


### PR DESCRIPTION
## Summary
- add a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#29686
- document that PartDesign Pad's `Up to shape` end condition now uses the selected shape when creating the extrusion

References #79
Source: FreeCAD/FreeCAD#29686

## Validation
- `git diff --check -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext`