### PR TITLE
Document PartDesign preference tooltips

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -309,6 +309,7 @@ ToDo (last check: 20260430, #29258):
 
 <!--T:61-->
 * Interactive draggers now support configurable coarse snapping, allowing larger steps by default with a modifier key (e.g. {{KEY|Shift}}) for fine movement; the snap step sizes and modifier key are configurable in the preferences. [https://github.com/FreeCAD/FreeCAD/pull/28384 Pull request #28384]
+* The [[PartDesign_Preferences#General|Part/PartDesign General preferences]] now include tooltips for boolean operations, Part Design workflow and visual feedback options. [https://github.com/FreeCAD/FreeCAD/pull/26943 Pull request #26943]
 * Interactive dragger was added to the [[Image:PartDesign_Draft.svg|24px]] [[PartDesign_Draft|Draft]] tool. [https://github.com/FreeCAD/FreeCAD/pull/27111 Pull request #27111]
 * Interactive draggers were added to the Sphere, Box and Cylinder primitive tools. [https://github.com/FreeCAD/FreeCAD/pull/23700 Pull request #23700]
 * Multi-selection is now supported for the [[PartDesign_AdditivePipe|Additive]] and [[PartDesign_SubtractivePipe|Subtractive Pipe]] path edges list. [https://github.com/FreeCAD/FreeCAD/pull/27962 Pull request #27962]

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -276,7 +276,6 @@ ToDo (last check: 20260430, #29258):
 === Further Part Design improvements ===
 
 * Interactive draggers now support configurable coarse snapping, allowing larger steps by default with a modifier key (e.g. {{KEY|Shift}}) for fine movement; the snap step sizes and modifier key are configurable in the preferences. [https://github.com/FreeCAD/FreeCAD/pull/28384 Pull request #28384]
-* The [[PartDesign_Preferences#General|Part/PartDesign General preferences]] now include tooltips for boolean operations, Part Design workflow and visual feedback options. [https://github.com/FreeCAD/FreeCAD/pull/26943 Pull request #26943]
 * Interactive dragger was added to the [[Image:PartDesign_Draft.svg|24px]] [[PartDesign_Draft|Draft]] tool. [https://github.com/FreeCAD/FreeCAD/pull/27111 Pull request #27111]
 * Interactive draggers were added to the Sphere, Box and Cylinder primitive tools. [https://github.com/FreeCAD/FreeCAD/pull/23700 Pull request #23700]
 * Multi-selection is now supported for the [[PartDesign_AdditivePipe|Additive]] and [[PartDesign_SubtractivePipe|Subtractive Pipe]] path edges list. [https://github.com/FreeCAD/FreeCAD/pull/27962 Pull request #27962]

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -276,6 +276,7 @@ ToDo (last check: 20260430, #29258):
 === Further Part Design improvements ===
 
 * Interactive draggers now support configurable coarse snapping, allowing larger steps by default with a modifier key (e.g. {{KEY|Shift}}) for fine movement; the snap step sizes and modifier key are configurable in the preferences. [https://github.com/FreeCAD/FreeCAD/pull/28384 Pull request #28384]
+* The [[PartDesign_Preferences#General|Part/PartDesign General preferences]] now include tooltips for boolean operations, Part Design workflow and visual feedback options. [https://github.com/FreeCAD/FreeCAD/pull/26943 Pull request #26943]
 * Interactive dragger was added to the [[Image:PartDesign_Draft.svg|24px]] [[PartDesign_Draft|Draft]] tool. [https://github.com/FreeCAD/FreeCAD/pull/27111 Pull request #27111]
 * Interactive draggers were added to the Sphere, Box and Cylinder primitive tools. [https://github.com/FreeCAD/FreeCAD/pull/23700 Pull request #23700]
 * Multi-selection is now supported for the [[PartDesign_AdditivePipe|Additive]] and [[PartDesign_SubtractivePipe|Subtractive Pipe]] path edges list. [https://github.com/FreeCAD/FreeCAD/pull/27962 Pull request #27962]


### PR DESCRIPTION
## Summary
- add a FreeCAD 1.2 Part Design release-note bullet for the Part/PartDesign General preference tooltips added in FreeCAD/FreeCAD#26943
- update both root and English release-note pages

## Validation
- git diff --check -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext

Related to #30.