### PR TITLE
Document PartDesign Std Group Boolean fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -317,6 +317,7 @@ ToDo (last check: 20260430, #29258):
 * Input hints were implemented for the interactive control draggers. [https://github.com/FreeCAD/FreeCAD/pull/29631 Pull request #29631]
 * [[PartDesign_SubShapeBinder|SubShapeBinder]] now uses the ''BuildFace'' face maker to handle overlapping geometry. [https://github.com/FreeCAD/FreeCAD/pull/29249 Pull request #29249]
 * A ''Fuzzy Tolerance'' property was added to override the default fuzziness/tolerance for boolean operations determined from the size of the input shapes. [https://github.com/FreeCAD/FreeCAD/pull/29984 Pull request #29984]
+* [[PartDesign_Boolean|Boolean operations]] with Bodies placed in a [[Std_Group|Std Group]] no longer report an out-of-scope link warning for the containing group. [https://github.com/FreeCAD/FreeCAD/pull/29534 Pull request #29534]
 
 == Points Workbench == <!--T:44-->
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -284,6 +284,7 @@ ToDo (last check: 20260430, #29258):
 * Input hints were implemented for the interactive control draggers. [https://github.com/FreeCAD/FreeCAD/pull/29631 Pull request #29631]
 * [[PartDesign_SubShapeBinder|SubShapeBinder]] now uses the ''BuildFace'' face maker to handle overlapping geometry. [https://github.com/FreeCAD/FreeCAD/pull/29249 Pull request #29249]
 * A ''Fuzzy Tolerance'' property was added to override the default fuzziness/tolerance for boolean operations determined from the size of the input shapes. [https://github.com/FreeCAD/FreeCAD/pull/29984 Pull request #29984]
+* [[PartDesign_Boolean|Boolean operations]] with Bodies placed in a [[Std_Group|Std Group]] no longer report an out-of-scope link warning for the containing group. [https://github.com/FreeCAD/FreeCAD/pull/29534 Pull request #29534]
 
 == Points Workbench ==
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -284,7 +284,6 @@ ToDo (last check: 20260430, #29258):
 * Input hints were implemented for the interactive control draggers. [https://github.com/FreeCAD/FreeCAD/pull/29631 Pull request #29631]
 * [[PartDesign_SubShapeBinder|SubShapeBinder]] now uses the ''BuildFace'' face maker to handle overlapping geometry. [https://github.com/FreeCAD/FreeCAD/pull/29249 Pull request #29249]
 * A ''Fuzzy Tolerance'' property was added to override the default fuzziness/tolerance for boolean operations determined from the size of the input shapes. [https://github.com/FreeCAD/FreeCAD/pull/29984 Pull request #29984]
-* [[PartDesign_Boolean|Boolean operations]] with Bodies placed in a [[Std_Group|Std Group]] no longer report an out-of-scope link warning for the containing group. [https://github.com/FreeCAD/FreeCAD/pull/29534 Pull request #29534]
 
 == Points Workbench ==
 


### PR DESCRIPTION
Adds a focused FreeCAD 1.2 release-note bullet for FreeCAD/FreeCAD#29534, covering the resolved out-of-scope link warning when PartDesign Boolean is used with Bodies in a Std Group.

Upstream reference: FreeCAD/FreeCAD#29534
Related bounty issue: #30

Validation:
- git diff --check -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext