### PR TITLE
Document FEM CalculiX old project migration

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -255,6 +255,7 @@ ToDo (last check: 20260430, #29258):
 * Materials now have the ''Material Name'' property, making it easier to identify the actual materials represented by the material objects in the Analysis container. [https://github.com/FreeCAD/FreeCAD/pull/29609 Pull request #29609]
 * Three new [[Image:FEM_Examples.svg|24px]] [[FEM_Examples|FEM examples]] were added for [[Image:FEM_SolverCalculixCcxtools.svg|24px]] [[FEM_SolverCalculixCcxtools|CalculiX]]: basic 1D fluid network, axisymmetric shaft and plane stress plate with a hole. [https://github.com/FreeCAD/FreeCAD/pull/29697 Pull request #29697] and [https://github.com/FreeCAD/FreeCAD/pull/29711 Pull request #29711]
 * Several CalculiX preference labels were changed for clarity, including geometrical nonlinearity, advanced solver controls, eigenmode count, and frequency bounds. [https://github.com/FreeCAD/FreeCAD/pull/30099 Pull request #30099]
+* Older FEM analyses now migrate CalculiX solver properties when project files are restored, preserving the analysis type, eigenmode limit units and property groups. [https://github.com/FreeCAD/FreeCAD/pull/30198 Pull request #30198]
 
 == Inspection Workbench == <!--T:32-->
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -228,7 +228,6 @@ ToDo (last check: 20260430, #29258):
 * Materials now have the ''Material Name'' property, making it easier to identify the actual materials represented by the material objects in the Analysis container. [https://github.com/FreeCAD/FreeCAD/pull/29609 Pull request #29609]
 * Three new [[Image:FEM_Examples.svg|24px]] [[FEM_Examples|FEM examples]] were added for [[Image:FEM_SolverCalculixCcxtools.svg|24px]] [[FEM_SolverCalculixCcxtools|CalculiX]]: basic 1D fluid network, axisymmetric shaft and plane stress plate with a hole. [https://github.com/FreeCAD/FreeCAD/pull/29697 Pull request #29697] and [https://github.com/FreeCAD/FreeCAD/pull/29711 Pull request #29711]
 * Several CalculiX preference labels were changed for clarity, including geometrical nonlinearity, advanced solver controls, eigenmode count, and frequency bounds. [https://github.com/FreeCAD/FreeCAD/pull/30099 Pull request #30099]
-* Older FEM analyses now migrate CalculiX solver properties when project files are restored, preserving the analysis type, eigenmode limit units and property groups. [https://github.com/FreeCAD/FreeCAD/pull/30198 Pull request #30198]
 
 == Inspection Workbench ==
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -228,6 +228,7 @@ ToDo (last check: 20260430, #29258):
 * Materials now have the ''Material Name'' property, making it easier to identify the actual materials represented by the material objects in the Analysis container. [https://github.com/FreeCAD/FreeCAD/pull/29609 Pull request #29609]
 * Three new [[Image:FEM_Examples.svg|24px]] [[FEM_Examples|FEM examples]] were added for [[Image:FEM_SolverCalculixCcxtools.svg|24px]] [[FEM_SolverCalculixCcxtools|CalculiX]]: basic 1D fluid network, axisymmetric shaft and plane stress plate with a hole. [https://github.com/FreeCAD/FreeCAD/pull/29697 Pull request #29697] and [https://github.com/FreeCAD/FreeCAD/pull/29711 Pull request #29711]
 * Several CalculiX preference labels were changed for clarity, including geometrical nonlinearity, advanced solver controls, eigenmode count, and frequency bounds. [https://github.com/FreeCAD/FreeCAD/pull/30099 Pull request #30099]
+* Older FEM analyses now migrate CalculiX solver properties when project files are restored, preserving the analysis type, eigenmode limit units and property groups. [https://github.com/FreeCAD/FreeCAD/pull/30198 Pull request #30198]
 
 == Inspection Workbench ==
 


### PR DESCRIPTION
Adds a focused FreeCAD 1.2 release-note bullet for FreeCAD/FreeCAD#30198, covering the restored migration of older CalculiX solver properties when old FEM project files are opened.

Upstream reference: FreeCAD/FreeCAD#30198
Related bounty issue: #30

Validation:
- git diff --check -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext