### PR TITLE
Document quantity spin box cursor fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -51,6 +51,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * SpaceMouse rotations now honor the active navigation rotation center mode, including ''Object center'' and ''Drag at cursor'' modes. [https://github.com/FreeCAD/FreeCAD/pull/29998 Pull request #29998]
 * The VarSet ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 * There is now a warning when saving files created in older versions. A preference was added to allow disabling it. [https://github.com/FreeCAD/FreeCAD/pull/28389 Pull request #28389]
+* Editing quantity spin boxes no longer moves the cursor to the end after the first typed character, making it easier to insert digits in values such as CAM feed/speed fields. [https://github.com/FreeCAD/FreeCAD/pull/30062 Pull request #30062]
 
 == Core system and API == <!--T:10-->
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -40,6 +40,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * SpaceMouse rotations now honor the active navigation rotation center mode, including ''Object center'' and ''Drag at cursor'' modes. [https://github.com/FreeCAD/FreeCAD/pull/29998 Pull request #29998]
 * The VarSet ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 * There is now a warning when saving files created in older versions. A preference was added to allow disabling it. [https://github.com/FreeCAD/FreeCAD/pull/28389 Pull request #28389]
+* Editing quantity spin boxes no longer moves the cursor to the end after the first typed character, making it easier to insert digits in values such as CAM feed/speed fields. [https://github.com/FreeCAD/FreeCAD/pull/30062 Pull request #30062]
 
 == Core system and API ==
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -40,7 +40,6 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * SpaceMouse rotations now honor the active navigation rotation center mode, including ''Object center'' and ''Drag at cursor'' modes. [https://github.com/FreeCAD/FreeCAD/pull/29998 Pull request #29998]
 * The VarSet ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 * There is now a warning when saving files created in older versions. A preference was added to allow disabling it. [https://github.com/FreeCAD/FreeCAD/pull/28389 Pull request #28389]
-* Editing quantity spin boxes no longer moves the cursor to the end after the first typed character, making it easier to insert digits in values such as CAM feed/speed fields. [https://github.com/FreeCAD/FreeCAD/pull/30062 Pull request #30062]
 
 == Core system and API ==
 


### PR DESCRIPTION
Adds a focused FreeCAD 1.2 user-interface release-note bullet for FreeCAD/FreeCAD#30062, covering the fixed cursor-jump regression when editing quantity spin boxes.

Upstream reference: FreeCAD/FreeCAD#30062
Related bounty issue: #30

Validation:
- git diff --check -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext