### PR TITLE
Document AssemblyLink double-click fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -116,6 +116,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Solver messages (overconstraint reports) were added to the Assembly task panel. [https://github.com/FreeCAD/FreeCAD/pull/24623 Pull request #24623]
 * A new command has been added to select all joints associated with a chosen component. [https://github.com/FreeCAD/FreeCAD/pull/27530 Pull request #27530]
 * A button was added to rotate joint offsets by 90 degrees. [https://github.com/FreeCAD/FreeCAD/pull/29717 Pull request #29717]
+* Double-clicking an AssemblyLink to edit a linked assembly in an external file no longer raises an attribute error when that file is already loaded without a view. [https://github.com/FreeCAD/FreeCAD/pull/28848 Pull request #28848]
 
 == BIM Workbench == <!--T:23-->
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -100,6 +100,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Solver messages (overconstraint reports) were added to the Assembly task panel. [https://github.com/FreeCAD/FreeCAD/pull/24623 Pull request #24623]
 * A new command has been added to select all joints associated with a chosen component. [https://github.com/FreeCAD/FreeCAD/pull/27530 Pull request #27530]
 * A button was added to rotate joint offsets by 90 degrees. [https://github.com/FreeCAD/FreeCAD/pull/29717 Pull request #29717]
+* Double-clicking an AssemblyLink to edit a linked assembly in an external file no longer raises an attribute error when that file is already loaded without a view. [https://github.com/FreeCAD/FreeCAD/pull/28848 Pull request #28848]
 
 == BIM Workbench ==
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -100,7 +100,6 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Solver messages (overconstraint reports) were added to the Assembly task panel. [https://github.com/FreeCAD/FreeCAD/pull/24623 Pull request #24623]
 * A new command has been added to select all joints associated with a chosen component. [https://github.com/FreeCAD/FreeCAD/pull/27530 Pull request #27530]
 * A button was added to rotate joint offsets by 90 degrees. [https://github.com/FreeCAD/FreeCAD/pull/29717 Pull request #29717]
-* Double-clicking an AssemblyLink to edit a linked assembly in an external file no longer raises an attribute error when that file is already loaded without a view. [https://github.com/FreeCAD/FreeCAD/pull/28848 Pull request #28848]
 
 == BIM Workbench ==
 


### PR DESCRIPTION
## Summary
- document FreeCAD/FreeCAD#28848 in the Assembly Workbench release notes
- note that AssemblyLink double-click editing for linked external assemblies no longer raises an attribute error when the external file is already loaded without a view

## Validation
- `git diff --check -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext`

Related to #30.