### PR TITLE
Document Draft Shape2DView Auto Update icon fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -217,6 +217,7 @@ ToDo (last check: 20260430, #29258):
 * [[Draft_PolarArray|Polar Array]] and [[Draft_CircularArray|Circular Array]] are now aware of the active working plane. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
 * SVG import can now approximate suitable curves to arcs and lines. [https://github.com/FreeCAD/FreeCAD/pull/29142 Pull request #29142]
 * Draft angular dimensions now honor overshoot settings. [https://github.com/FreeCAD/FreeCAD/pull/29298 Pull request #29298]
+* Changing the [[Draft_Shape2DView|Shape2DView]] ''Auto Update'' property now updates its [[Tree_View|Tree View]] icon immediately. [https://github.com/FreeCAD/FreeCAD/pull/30063 Pull request #30063]
 
 === Further Draft improvements === <!--T:28-->
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -192,6 +192,7 @@ ToDo (last check: 20260430, #29258):
 * [[Draft_PolarArray|Polar Array]] and [[Draft_CircularArray|Circular Array]] are now aware of the active working plane. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
 * SVG import can now approximate suitable curves to arcs and lines. [https://github.com/FreeCAD/FreeCAD/pull/29142 Pull request #29142]
 * Draft angular dimensions now honor overshoot settings. [https://github.com/FreeCAD/FreeCAD/pull/29298 Pull request #29298]
+* Changing the [[Draft_Shape2DView|Shape2DView]] ''Auto Update'' property now updates its [[Tree_View|Tree View]] icon immediately. [https://github.com/FreeCAD/FreeCAD/pull/30063 Pull request #30063]
 
 === Further Draft improvements ===
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -192,7 +192,6 @@ ToDo (last check: 20260430, #29258):
 * [[Draft_PolarArray|Polar Array]] and [[Draft_CircularArray|Circular Array]] are now aware of the active working plane. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
 * SVG import can now approximate suitable curves to arcs and lines. [https://github.com/FreeCAD/FreeCAD/pull/29142 Pull request #29142]
 * Draft angular dimensions now honor overshoot settings. [https://github.com/FreeCAD/FreeCAD/pull/29298 Pull request #29298]
-* Changing the [[Draft_Shape2DView|Shape2DView]] ''Auto Update'' property now updates its [[Tree_View|Tree View]] icon immediately. [https://github.com/FreeCAD/FreeCAD/pull/30063 Pull request #30063]
 
 === Further Draft improvements ===
 


### PR DESCRIPTION
## Summary
- document FreeCAD/FreeCAD#30063 in the Draft Workbench release notes
- note that changing Shape2DView's Auto Update property now refreshes the Tree View icon immediately

## Validation
- `git diff --check -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext`

Related to #30.