### PR TITLE
docs: enhance Sketcher ConstrainGroup page with practical usage notes

### DIFF
--- a/wiki/Sketcher_ConstrainGroup.wikitext
+++ b/wiki/Sketcher_ConstrainGroup.wikitext
@@ -24,7 +24,10 @@
 ==Description== <!--T:3-->
 
 <!--T:4-->
-The [[Image:Sketcher_ConstrainGroup.svg|24px]] [[Sketcher_ConstrainGroup|Sketcher ConstrainGroup]] tool constrains selected geometry together as a single entity. The position and size of the grouped geometry can be defined by constraining the automatically generated construction line. 
+The [[Image:Sketcher_ConstrainGroup.svg|24px]] [[Sketcher_ConstrainGroup|Sketcher ConstrainGroup]] tool constrains selected geometry together as a single entity. The position and size of the grouped geometry can be defined by constraining the automatically generated construction line.
+
+<!--T:10-->
+The tool is especially useful when a sketch contains repeated motifs that should move and scale together, or when you want to position a set of geometries without applying individual constraints to each element.
 
 ==Usage== <!--T:5-->
 
@@ -40,6 +43,24 @@ The [[Image:Sketcher_ConstrainGroup.svg|24px]] [[Sketcher_ConstrainGroup|Sketche
 
 <!--T:9-->
 * Constraints applied to grouped edges are ignored as long as the group constraint is present.
+
+<!--T:11-->
+* '''Auto-generated construction line:''' When a group constraint is created, a blue construction line is automatically added. This line represents the group's reference frame. Constrain the endpoints of this construction line with dimensional or geometric constraints to control the position, rotation, and scale of the entire group.
+
+<!--T:12-->
+* '''Positioning a group:''' To move a group to a specific location, apply a [[Sketcher_ConstrainDistance|distance]] or [[Sketcher_ConstrainLock|lock]] constraint to one endpoint of the construction line. To rotate the group, constrain the angle of the construction line with an [[Sketcher_ConstrainAngle|angle constraint]].
+
+<!--T:13-->
+* '''Scaling a group:''' Apply a [[Sketcher_ConstrainDistance|distance constraint]] between the two endpoints of the construction line to set the group's size. All grouped geometry will scale proportionally as the distance changes.
+
+<!--T:14-->
+* '''Grouping and ungrouping:''' To remove a group constraint, select it in the [[Sketcher_Dialog|Sketcher Dialog]] and press {{KEY|Delete}}. The geometries remain in the sketch but are no longer grouped together.
+
+<!--T:15-->
+* '''Group vs. Block:''' Unlike the [[Sketcher_ConstrainBlock|Block constraint]], which completely freezes geometry, the Group constraint allows the grouped elements to be positioned, rotated, and scaled through its construction line. For rigidly fixed geometry, use [[Sketcher_ConstrainBlock|Block]]; for flexible, repositionable groups, use Group.
+
+<!--T:16-->
+* '''Text geometries and groups:''' The [[Sketcher_CreateText|Sketcher CreateText]] tool (also introduced in {{Version|1.2}}) uses a group constraint internally. When you create text geometry, the individual characters are grouped and controlled by the text's construction line.
 
 
 <!--T:8-->


### PR DESCRIPTION
## Summary

Enhance the Sketcher ConstrainGroup documentation page (introduced in FreeCAD 1.2) with practical usage information.

## Changes

- **Description:** Added context about when to use the Group constraint (repeated motifs, batch positioning)
- **Notes:** Expanded from 1 bullet to 7 detailed sections:
  - Auto-generated construction line and its role
  - How to position groups with distance/lock constraints
  - How to scale groups proportionally
  - How to remove/ungroup
  - Group vs. Block constraint comparison
  - Relationship with the CreateText tool (both introduced in the same PR)

## Related

- Contributes to #94 (Sketcher Workbench: Adding Missing Information)
- Documents features from FreeCAD/FreeCAD#22217 (AstoCAD Sketcher Text + Group contribution)

## Validation

- git diff --check -- wiki/Sketcher_ConstrainGroup.wikitext
- No existing PRs modify this page (0 competition)