### PR TITLE
Document Sketcher toolbar state persistence

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -392,6 +392,7 @@ ToDo (last check: 20260430, #29258):
 * A new preference was added to control the font type (in addition to font size) for labels. [https://github.com/FreeCAD/FreeCAD/pull/26600 Pull request #26600]
 * Sketcher line style dropdowns now correctly list the available styles instead of appearing empty. [https://github.com/FreeCAD/FreeCAD/pull/30151 Pull request #30151]
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
+* Sketcher toolbar visibility and layout changes are now preserved when switching workbenches. [https://github.com/FreeCAD/FreeCAD/pull/28674 Pull request #28674]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 
 == Spreadsheet Workbench == <!--T:53-->


### PR DESCRIPTION
Summary:
- Adds a FreeCAD 1.2 Sketcher release-note entry for preserving toolbar visibility/layout across workbench switches.
- Updates both the translated release-notes source and the English page.

Source:
- https://github.com/FreeCAD/FreeCAD/pull/28674

Validation:
- git diff --check -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext

Refs #94