### PR TITLE
Document macro path release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -87,6 +87,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool can now report the radius and diameter for circular faces in addition to the existing measurement types. [https://github.com/FreeCAD/FreeCAD/pull/27415 Pull request #27415]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now displays area units using unicode superscripts. [https://github.com/FreeCAD/FreeCAD/pull/28044 Pull request #28044]
 * Macros now support directories to collect the files associated with them. [https://github.com/FreeCAD/FreeCAD/pull/27005 Pull request #27005]
+* The macro dialog and the [[Std_OpenMacrosFolder|Open macros folder]] command now open the configured macro path instead of the default macro directory. [https://github.com/FreeCAD/FreeCAD/pull/29224 Pull request #29224]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool can now report the radius and diameter for spheres and toruses. [https://github.com/FreeCAD/FreeCAD/pull/29369 Pull request #29369]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now supports curved faces in ''Distance'' mode. [https://github.com/FreeCAD/FreeCAD/pull/29367 Pull request #29367]
 * The appearance and placement of the ''Angle'' [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measurement]] arrows was significantly improved. [https://github.com/FreeCAD/FreeCAD/pull/27135 Pull request #27135]


### PR DESCRIPTION
## Summary

Adds a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#29224, which made the macro dialog and `Std_OpenMacrosFolder` command open the configured macro path instead of the default macro directory.

## Scope

- updates the root `wiki/Release_notes_1.2.wikitext`
- updates the English `wiki/en/Release_notes_1.2.wikitext`
- keeps the note near the existing macro release-note entry

## Related issues

Contributes to #30.

## Validation

- `git diff --check -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext`
- checked current open documentation PRs and found no visible reference to FreeCAD/FreeCAD#29224
