### PR TITLE
Document PartDesign Chamfer selection fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -312,6 +312,7 @@ ToDo (last check: 20260430, #29258):
 * Interactive dragger was added to the [[Image:PartDesign_Draft.svg|24px]] [[PartDesign_Draft|Draft]] tool. [https://github.com/FreeCAD/FreeCAD/pull/27111 Pull request #27111]
 * Interactive draggers were added to the Sphere, Box and Cylinder primitive tools. [https://github.com/FreeCAD/FreeCAD/pull/23700 Pull request #23700]
 * Multi-selection is now supported for the [[PartDesign_AdditivePipe|Additive]] and [[PartDesign_SubtractivePipe|Subtractive Pipe]] path edges list. [https://github.com/FreeCAD/FreeCAD/pull/27962 Pull request #27962]
+* The [[Image:PartDesign_Chamfer.svg|24px]] [[PartDesign_Chamfer|Chamfer]] tool now starts in selection mode again. [https://github.com/FreeCAD/FreeCAD/pull/29313 Pull request #29313]
 * Now unhiding a Body with no visible features also unhides its tip. [https://github.com/FreeCAD/FreeCAD/pull/24887 Pull request #24887]
 * Pressing {{KEY|Space}} on an element selected from the 3D view (e.g. from selecting a face) now toggles the visibility of the entire [[PartDesign_Body|PartDesign Body]] instead of the last feature, making it easier to show or hide bodies in assemblies or files with multiple bodies. Selection in the Tree view still toggles the selected object. [https://github.com/FreeCAD/FreeCAD/pull/29110 Pull request #29110] and [https://github.com/FreeCAD/FreeCAD/pull/30231 Pull request #30231]
 * Input hints were implemented for the interactive control draggers. [https://github.com/FreeCAD/FreeCAD/pull/29631 Pull request #29631]


### PR DESCRIPTION
Summary:
- Adds a FreeCAD 1.2 Part Design release-note entry for the Chamfer tool starting in selection mode again.
- Updates both the translated release-notes source and the English page.

Source:
- https://github.com/FreeCAD/FreeCAD/pull/29313

Validation:
- git diff --check -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext

Refs #79