### PR TITLE
Document import progress release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -407,6 +407,8 @@ ToDo (last check: 20260430, #29258):
 
 == Import and export == <!--T:59-->
 
+* Importing STEP, IGES and glTF files now shows progress feedback during the transfer. [https://github.com/FreeCAD/FreeCAD/pull/27849 Pull request #27849]
+
 </translate>
 [[Category:News{{#translation:}}]]
 [[Category:Documentation{{#translation:}}]]


### PR DESCRIPTION
## Summary

Adds a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#27849, which added progress feedback while importing STEP, IGES and glTF files.

## Scope

- updates the root `wiki/Release_notes_1.2.wikitext`
- updates the English `wiki/en/Release_notes_1.2.wikitext`
- keeps the note in the existing Import and export section

## Related issues

Contributes to #30.

## Validation

- `git diff --check -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext`
- checked current open documentation PRs and found no visible reference to FreeCAD/FreeCAD#27849
