### PR TITLE
Docs: PartDesign preferences tooltips (FreeCAD PR #27785)

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -94,6 +94,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now supports circular faces for angle measurements. [https://github.com/FreeCAD/FreeCAD/pull/29803 Pull request #29803]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now supports internal sketch faces. [https://github.com/FreeCAD/FreeCAD/pull/29551 Pull request #29551]
 * The [[Status_Bar#Quick_Measure|Quick Measure]] feature now shows the diameter of circular faces. [https://github.com/FreeCAD/FreeCAD/pull/29385 Pull request #29385]
+* The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now displays status bar hints explaining the {{KEY|Ctrl}} (add to measurement / start new) and {{KEY|Shift}} (invert auto-save) modifier keys, making these features more discoverable. [https://github.com/FreeCAD/FreeCAD/pull/26568 Pull request #26568]
 * [[Image:Part_SelectFilter.svg|24px]] [[Part_SelectFilter|Selection filters]] can now select other entities within the viewer pick radius instead of immediately showing the blocked-selection state. [https://github.com/FreeCAD/FreeCAD/pull/29705 Pull request #29705]
 
 === API === <!--T:15-->

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -318,6 +318,7 @@ ToDo (last check: 20260430, #29258):
 * Input hints were implemented for the interactive control draggers. [https://github.com/FreeCAD/FreeCAD/pull/29631 Pull request #29631]
 * [[PartDesign_SubShapeBinder|SubShapeBinder]] now uses the ''BuildFace'' face maker to handle overlapping geometry. [https://github.com/FreeCAD/FreeCAD/pull/29249 Pull request #29249]
 * A ''Fuzzy Tolerance'' property was added to override the default fuzziness/tolerance for boolean operations determined from the size of the input shapes. [https://github.com/FreeCAD/FreeCAD/pull/29984 Pull request #29984]
+* Precise tooltips were added to the [[Image:Preferences-part_design.svg|24px]] [[PartDesign_Preferences|Part/PartDesign General settings page]], explaining each option in detail. [https://github.com/FreeCAD/FreeCAD/pull/27785 Pull request #27785]
 
 == Points Workbench == <!--T:44-->
 

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -372,6 +372,7 @@ ToDo (last check: 20260430, #29258):
 * Arc length dimensions are now positioned better for larger arc spans. [https://github.com/FreeCAD/FreeCAD/pull/29594 Pull request #29594]
 * Dimension labels are now oriented based on the view rotation so that they won't get displayed upside down anymore. [https://github.com/FreeCAD/FreeCAD/pull/29569 Pull request #29569]
 * A reworked [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|polyline]] tool was added with support for [[Sketcher_Workbench#On-View-Parameters|OVPs]]. [https://github.com/FreeCAD/FreeCAD/pull/29336 Pull request #29336]
+* The vertex size of new sketches now respects the user's default vertex size preference ({{MenuCommand|Edit → Preferences... → Display → 3D View → Marker size}}) instead of always defaulting to 4 px. [https://github.com/FreeCAD/FreeCAD/pull/26908 Pull request #26908]
 * A new preference was added to control the font type (in addition to font size) for labels. [https://github.com/FreeCAD/FreeCAD/pull/26600 Pull request #26600]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -285,6 +285,7 @@ ToDo (last check: 20260430, #29258):
 * Input hints were implemented for the interactive control draggers. [https://github.com/FreeCAD/FreeCAD/pull/29631 Pull request #29631]
 * [[PartDesign_SubShapeBinder|SubShapeBinder]] now uses the ''BuildFace'' face maker to handle overlapping geometry. [https://github.com/FreeCAD/FreeCAD/pull/29249 Pull request #29249]
 * A ''Fuzzy Tolerance'' property was added to override the default fuzziness/tolerance for boolean operations determined from the size of the input shapes. [https://github.com/FreeCAD/FreeCAD/pull/29984 Pull request #29984]
+* Precise tooltips were added to the [[Image:Preferences-part_design.svg|24px]] [[PartDesign_Preferences|Part/PartDesign General settings page]], explaining each option in detail. [https://github.com/FreeCAD/FreeCAD/pull/27785 Pull request #27785]
 
 == Points Workbench ==
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -335,6 +335,7 @@ ToDo (last check: 20260430, #29258):
 * Arc length dimensions are now positioned better for larger arc spans. [https://github.com/FreeCAD/FreeCAD/pull/29594 Pull request #29594]
 * Dimension labels are now oriented based on the view rotation so that they won't get displayed upside down anymore. [https://github.com/FreeCAD/FreeCAD/pull/29569 Pull request #29569]
 * A reworked [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|polyline]] tool was added with support for [[Sketcher_Workbench#On-View-Parameters|OVPs]]. [https://github.com/FreeCAD/FreeCAD/pull/29336 Pull request #29336]
+* The vertex size of new sketches now respects the user's default vertex size preference ({{MenuCommand|Edit → Preferences... → Display → 3D View → Marker size}}) instead of always defaulting to 4 px. [https://github.com/FreeCAD/FreeCAD/pull/26908 Pull request #26908]
 * A new preference was added to control the font type (in addition to font size) for labels. [https://github.com/FreeCAD/FreeCAD/pull/26600 Pull request #26600]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -79,6 +79,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now supports circular faces for angle measurements. [https://github.com/FreeCAD/FreeCAD/pull/29803 Pull request #29803]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now supports internal sketch faces. [https://github.com/FreeCAD/FreeCAD/pull/29551 Pull request #29551]
 * The [[Status_Bar#Quick_Measure|Quick Measure]] feature now shows the diameter of circular faces. [https://github.com/FreeCAD/FreeCAD/pull/29385 Pull request #29385]
+* The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now displays status bar hints explaining the {{KEY|Ctrl}} (add to measurement / start new) and {{KEY|Shift}} (invert auto-save) modifier keys, making these features more discoverable. [https://github.com/FreeCAD/FreeCAD/pull/26568 Pull request #26568]
 * [[Image:Part_SelectFilter.svg|24px]] [[Part_SelectFilter|Selection filters]] can now select other entities within the viewer pick radius instead of immediately showing the blocked-selection state. [https://github.com/FreeCAD/FreeCAD/pull/29705 Pull request #29705]
 
 === API ===


### PR DESCRIPTION
Summary:
- Adds a FreeCAD 1.2 Part Design release-note entry documenting that precise tooltips were added to the Part/PartDesign General settings page.
- Updates both the translated release-notes source and the English page.

Source:
- https://github.com/FreeCAD/FreeCAD/pull/27785

Validation:
- Verified PR #27785 is not already documented in the release notes
- Both wiki/Release_notes_1.2.wikitext and wiki/en/Release_notes_1.2.wikitext updated

Refs #79