### PR TITLE
Document recent files prompt release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -51,6 +51,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * SpaceMouse rotations now honor the active navigation rotation center mode, including ''Object center'' and ''Drag at cursor'' modes. [https://github.com/FreeCAD/FreeCAD/pull/29998 Pull request #29998]
 * The VarSet ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 * There is now a warning when saving files created in older versions. A preference was added to allow disabling it. [https://github.com/FreeCAD/FreeCAD/pull/28389 Pull request #28389]
+* Clearing the recent files list now asks for confirmation before the list is removed. [https://github.com/FreeCAD/FreeCAD/pull/27274 Pull request #27274]
 
 == Core system and API == <!--T:10-->
 


### PR DESCRIPTION
## Summary

Adds a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#27274, which added a confirmation prompt before clearing the recent files list.

## Scope

- updates the root `wiki/Release_notes_1.2.wikitext`
- updates the English `wiki/en/Release_notes_1.2.wikitext`
- keeps the note in the existing further user interface improvements list

## Related issues

Contributes to #30.

## Validation

- `git diff --check -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext`
- checked current open documentation PRs and found no visible reference to FreeCAD/FreeCAD#27274
