### PR TITLE
Document file dialog filter release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -43,6 +43,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 <!--T:63-->
 * The built-in text editor now supports line selection via clicking on the line number (and optionally also holding {{KEY|Shift}} for range selection). [https://github.com/FreeCAD/FreeCAD/pull/27677 Pull request #27677]
 * In the built-in text editor, the search field is now prefilled with the currently selected text. [https://github.com/FreeCAD/FreeCAD/pull/27674 Pull request #27674]
+* Long file type filters in file dialogs are now collapsed and deduplicated, making Open, Import, Save and Export dialogs easier to read. [https://github.com/FreeCAD/FreeCAD/pull/23209 Pull request #23209]
 * Double-clicking a face of the [[Navigation_Cube|navigation cube]] will now rotate to it, but also center the view. [https://github.com/FreeCAD/FreeCAD/pull/28608 Pull request #28608]
 * The ''Recompute Object'' [[Tree_View|Tree View]] context menu option (''Std_Recompute'' command) now has a keyboard shortcut {{KEY|Ctrl}}+{{KEY|Shift}}+{{KEY|R}}. [https://github.com/FreeCAD/FreeCAD/pull/27880 Pull request #27880]
 * There is now a [[Image:Std_ToggleBottomPanels.svg|16px]] Toggle Bottom Panels button and a shortcut {{KEY|Ctrl}} + {{KEY|O}} to toggle the bottom panels ([[Report_View|Report View]] and [[Python_Console|Python Console]]). [https://github.com/FreeCAD/FreeCAD/pull/28598 Pull request #28598]


### PR DESCRIPTION
## Summary

Adds a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#23209, which made long file-dialog type filters easier to read by collapsing and deduplicating them.

## Scope

- updates the root `wiki/Release_notes_1.2.wikitext`
- updates the English `wiki/en/Release_notes_1.2.wikitext`
- keeps the note in the existing further user interface improvements list

## Related issues

Contributes to #30.

## Validation

- `git diff --check origin/main...HEAD -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext`
- checked current open documentation PRs and found no visible reference to FreeCAD/FreeCAD#23209 or the file-dialog filter wording
