### PR TITLE
Document read-only document release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -43,6 +43,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 <!--T:63-->
 * The built-in text editor now supports line selection via clicking on the line number (and optionally also holding {{KEY|Shift}} for range selection). [https://github.com/FreeCAD/FreeCAD/pull/27677 Pull request #27677]
 * In the built-in text editor, the search field is now prefilled with the currently selected text. [https://github.com/FreeCAD/FreeCAD/pull/27674 Pull request #27674]
+* Documents whose files are not writable now show read-only overlays in the [[Tree_View|Tree View]], with tooltips explaining that changes cannot be saved directly. Links to read-only documents now use a red read-only link overlay. [https://github.com/FreeCAD/FreeCAD/pull/26702 Pull request #26702]
 * Double-clicking a face of the [[Navigation_Cube|navigation cube]] will now rotate to it, but also center the view. [https://github.com/FreeCAD/FreeCAD/pull/28608 Pull request #28608]
 * The ''Recompute Object'' [[Tree_View|Tree View]] context menu option (''Std_Recompute'' command) now has a keyboard shortcut {{KEY|Ctrl}}+{{KEY|Shift}}+{{KEY|R}}. [https://github.com/FreeCAD/FreeCAD/pull/27880 Pull request #27880]
 * There is now a [[Image:Std_ToggleBottomPanels.svg|16px]] Toggle Bottom Panels button and a shortcut {{KEY|Ctrl}} + {{KEY|O}} to toggle the bottom panels ([[Report_View|Report View]] and [[Python_Console|Python Console]]). [https://github.com/FreeCAD/FreeCAD/pull/28598 Pull request #28598]


### PR DESCRIPTION
## Summary

- Adds the merged FreeCAD/FreeCAD#26702 read-only document indicator to the 1.2 release notes.
- Updates both the source release note page and the English mirror.

## Scope

FreeCAD/FreeCAD#26702 is a user-visible UI change: documents backed by non-writable files now show read-only overlays in the Tree View, tooltips explain that the document cannot be saved directly, and links to read-only documents use a red read-only link overlay.

## Related

- Tracks Reqrefusion/FreeCAD-Documentation-Project#30.
- Documents FreeCAD/FreeCAD#26702.

## Duplicate check

- Checked the current release-note files for `26702`, `read-only`, `read only`, and related terms before editing.
- Checked open documentation PRs for `FreeCAD/FreeCAD#26702` and `document is read only indication`; no duplicates were found.

## Validation

- `git diff --check`
- Verified the new release-note entry appears once in each updated release-note file.
