### PR TITLE
Document CAM Engrave approximation release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -176,6 +176,7 @@ ToDo (last check: 20260430, #27222):
 * The [[CAM_OpActiveToggle|Toggle Operation]] tool now supports Job and Operations groups. [https://github.com/FreeCAD/FreeCAD/pull/24872 Pull request #24872]
 * It is now possible to cancel G-code export. [https://github.com/FreeCAD/FreeCAD/pull/25273 Pull request #25273]
 * Tolerance can now be set for [[CAM_DressupTag|Tag Dressup]], [[CAM_Engrave|Engrave]], and [[CAM_Deburr|Deburr]] operations to change the precision of segmentation of complex shapes while creating a path. [https://github.com/FreeCAD/FreeCAD/pull/26127 Pull request #26127] and [https://github.com/FreeCAD/FreeCAD/pull/26128 Pull request #26128]
+* The [[CAM_Engrave|Engrave]] operation can now use arc approximation for complex curves, reducing G-code command count and producing smoother G2/G3 output where applicable. [https://github.com/FreeCAD/FreeCAD/pull/29528 Pull request #29528]
 * [[CAM_Adaptive|Adaptive]] operation now automatically picks the diameter of the helix entrance. [https://github.com/FreeCAD/FreeCAD/pull/23980 Pull request #23980]
 * CAM task panels now support selecting shapes from different objects. [https://github.com/FreeCAD/FreeCAD/pull/22304 Pull request #22304]
 * [[CAM_Vcarve|Vcarve]] routing is now improved using "virtual edge backtracking". [https://github.com/FreeCAD/FreeCAD/pull/25049 Pull request #25049]


### PR DESCRIPTION
## Summary

- Adds the merged FreeCAD/FreeCAD#29528 CAM Engrave approximation change to the 1.2 release notes.
- Updates both the source release note page and the English mirror.

## Scope

FreeCAD/FreeCAD#29528 is a user-visible CAM improvement: the Engrave operation can now use arc approximation for complex curves, which can reduce generated G-code command count and produce smoother G2/G3 output where applicable.

## Related

- Tracks Reqrefusion/FreeCAD-Documentation-Project#30.
- Documents FreeCAD/FreeCAD#29528.

## Duplicate check

- Checked the current release-note files for `29528`, `Engrave`, `Approximation`, and related wording before editing.
- Checked open documentation PRs for `FreeCAD/FreeCAD#29528` and `Engrave approximation`; no duplicates were found.

## Validation

- `git diff --check`
- Verified the new release-note entry appears once in each updated release-note file.
