### PR TITLE
Document XHTML X3D DEF release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -411,6 +411,7 @@ ToDo (last check: 20260430, #29258):
 == Import and export == <!--T:59-->
 
 * Importing STEP, IGES and glTF files now shows progress feedback during the transfer. [https://github.com/FreeCAD/FreeCAD/pull/27849 Pull request #27849]
+* XHTML/X3D export now uses more descriptive {{Incode|DEF}} attribute names. [https://github.com/FreeCAD/FreeCAD/pull/29980 Pull request #29980]
 
 </translate>
 [[Category:News{{#translation:}}]]


### PR DESCRIPTION
## Summary

- Adds the merged FreeCAD/FreeCAD#29980 XHTML/X3D export change to the 1.2 release notes.
- Updates both the source release note page and the English mirror.

## Scope

FreeCAD/FreeCAD#29980 is an import/export-facing improvement: XHTML/X3D export now uses more descriptive `DEF` attribute names.

## Related

- Tracks Reqrefusion/FreeCAD-Documentation-Project#30.
- Documents FreeCAD/FreeCAD#29980.
- Related upstream request: FreeCAD/FreeCAD#7268.

## Duplicate check

- Checked the current release-note files for `29980`, `DEF`, `XHTML`, and `X3D` before editing.
- Checked open documentation PRs for `FreeCAD/FreeCAD#29980` and `XHTML X3D DEF`; no duplicates were found.

## Validation

- `git diff --check`
- Verified the new release-note entry appears once in each updated release-note file.
