### PR TITLE
Document Assembly simulation video release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -115,6 +115,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 
 <!--T:60-->
 * Solver messages (overconstraint reports) were added to the Assembly task panel. [https://github.com/FreeCAD/FreeCAD/pull/24623 Pull request #24623]
+* Assembly simulations can now be exported as videos. [https://github.com/FreeCAD/FreeCAD/pull/25307 Pull request #25307]
 * A new command has been added to select all joints associated with a chosen component. [https://github.com/FreeCAD/FreeCAD/pull/27530 Pull request #27530]
 * A button was added to rotate joint offsets by 90 degrees. [https://github.com/FreeCAD/FreeCAD/pull/29717 Pull request #29717]
 


### PR DESCRIPTION
## Summary

- Adds the merged FreeCAD/FreeCAD#25307 Assembly simulation video export change to the 1.2 release notes.
- Updates both the source release note page and the English mirror.

## Scope

FreeCAD/FreeCAD#25307 is a user-visible Assembly improvement: Assembly simulations can now be exported as videos.

## Related

- Tracks Reqrefusion/FreeCAD-Documentation-Project#30.
- Documents FreeCAD/FreeCAD#25307.
- Related upstream request: FreeCAD/FreeCAD#22531.

## Duplicate check

- Checked the current release-note files for `25307`, `video export`, and related wording before editing.
- Checked open documentation PRs for `FreeCAD/FreeCAD#25307` and `Assembly simulation video export`; no duplicates were found.

## Validation

- `git diff --check`
- Verified the new release-note entry appears once in each updated release-note file.
