### PR TITLE
Document notification unread count release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -43,6 +43,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 <!--T:63-->
 * The built-in text editor now supports line selection via clicking on the line number (and optionally also holding {{KEY|Shift}} for range selection). [https://github.com/FreeCAD/FreeCAD/pull/27677 Pull request #27677]
 * In the built-in text editor, the search field is now prefilled with the currently selected text. [https://github.com/FreeCAD/FreeCAD/pull/27674 Pull request #27674]
+* The notification area now initializes its unread count on startup. [https://github.com/FreeCAD/FreeCAD/pull/29391 Pull request #29391]
 * Double-clicking a face of the [[Navigation_Cube|navigation cube]] will now rotate to it, but also center the view. [https://github.com/FreeCAD/FreeCAD/pull/28608 Pull request #28608]
 * The ''Recompute Object'' [[Tree_View|Tree View]] context menu option (''Std_Recompute'' command) now has a keyboard shortcut {{KEY|Ctrl}}+{{KEY|Shift}}+{{KEY|R}}. [https://github.com/FreeCAD/FreeCAD/pull/27880 Pull request #27880]
 * There is now a [[Image:Std_ToggleBottomPanels.svg|16px]] Toggle Bottom Panels button and a shortcut {{KEY|Ctrl}} + {{KEY|O}} to toggle the bottom panels ([[Report_View|Report View]] and [[Python_Console|Python Console]]). [https://github.com/FreeCAD/FreeCAD/pull/28598 Pull request #28598]


### PR DESCRIPTION
## Summary

- Adds the merged FreeCAD/FreeCAD#29391 notification-area startup count change to the 1.2 release notes.
- Updates both the source release note page and the English mirror.

## Scope

FreeCAD/FreeCAD#29391 is a user-visible UI improvement: the notification area now initializes its unread count on startup.

## Related

- Tracks Reqrefusion/FreeCAD-Documentation-Project#30.
- Documents FreeCAD/FreeCAD#29391.
- Related upstream issue: FreeCAD/FreeCAD#26341.

## Duplicate check

- Checked the current release-note files for `29391`, `notification area`, and `unread count` before editing.
- Checked open documentation PRs for `FreeCAD/FreeCAD#29391` and `notification unread count`; no duplicates were found.

## Validation

- `git diff --check`
- Verified the new release-note entry appears once in each updated release-note file.
