### PR TITLE
Document BIM stair railings release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -148,6 +148,7 @@ ToDo (last check: 20260430, #27222):
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
 * [[BIM_Windows|BIM Windows]] now include a Sliding Door preset whose opening follows the {{incode|Opening}} property, and the Tree View context menu can invert the sliding direction. [https://github.com/FreeCAD/FreeCAD/pull/27375 Pull request #27375]
 * [[BIM_Windows|BIM Windows]] now provide a task-panel options box for editing common window properties with expression-aware fields and a cancel action. [https://github.com/FreeCAD/FreeCAD/pull/27381 Pull request #27381]
+* Stair railings now follow stair visibility changes, including visibility inherited from parent objects such as levels. [https://github.com/FreeCAD/FreeCAD/pull/29173 Pull request #29173]
 
 == CAM Workbench == <!--T:25-->
 


### PR DESCRIPTION
## Summary

- Adds the merged FreeCAD/FreeCAD#29173 BIM stair railing visibility change to the 1.2 release notes.
- Updates both the source release note page and the English mirror.

## Scope

FreeCAD/FreeCAD#29173 is a user-visible BIM improvement: stair railings now follow stair visibility changes, including visibility inherited from parent objects such as levels.

## Related

- Tracks Reqrefusion/FreeCAD-Documentation-Project#30.
- Documents FreeCAD/FreeCAD#29173.
- Related upstream issue: FreeCAD/FreeCAD#28911.

## Duplicate check

- Checked the current release-note files for `29173`, `stair railings`, and related visibility wording before editing.
- Checked open documentation PRs for `FreeCAD/FreeCAD#29173` and `stair railings visibility`; no duplicates were found.

## Validation

- `git diff --check`
- Verified the new release-note entry appears once in each updated release-note file.
