### PR TITLE
Document FCBak date format release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -28,6 +28,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 <!--T:67-->
 * Multiple documents can now be edited simultaneously with independent tasks and undo/redo stacks, for example, having two Sketches open at the same time (GSoC project). [https://github.com/FreeCAD/FreeCAD/pull/21978 Pull request #21978]
 * {{FileName|.FCBak}} backup files can now be opened directly from the File → Open dialog without renaming them to {{FileName|.FCStd}} first. Saving such a file triggers [[Std_SaveAs|Save As…]] to prevent accidentally overwriting the backup. [https://github.com/FreeCAD/FreeCAD/pull/28454 Pull request #28454]
+* The {{FileName|.FCBak}} backup date format preference now validates invalid filename characters and replaces invalid timestamp characters when creating backups. [https://github.com/FreeCAD/FreeCAD/pull/25985 Pull request #25985]
 
 == User interface == <!--T:8-->
 


### PR DESCRIPTION
## Summary

- Adds the merged FreeCAD/FreeCAD#25985 backup date-format validation change to the 1.2 release notes.
- Updates both the source release note page and the English mirror.

## Scope

FreeCAD/FreeCAD#25985 is a user-visible general improvement: the `.FCBak` backup date format preference now validates invalid filename characters, and invalid timestamp characters are replaced when backups are created.

## Related

- Tracks Reqrefusion/FreeCAD-Documentation-Project#30.
- Documents FreeCAD/FreeCAD#25985.
- Related upstream issue: FreeCAD/FreeCAD#25752.

## Duplicate check

- Checked the current release-note files for `25985`, `.FCBak`, `backup date`, `invalid characters`, and related timestamp wording before editing.
- Checked open documentation PRs for `FreeCAD/FreeCAD#25985`, `backup date format`, and `FCBak date format`; no duplicates were found.

## Validation

- `git diff --check`
- Verified the new release-note entry appears once in each updated release-note file.
