### PR TITLE
Document Mass Properties markers release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -86,6 +86,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measurement]] units can now be converted and viewed on the fly. [https://github.com/FreeCAD/FreeCAD/pull/27462 Pull request #27462]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool can now report the radius and diameter for circular faces in addition to the existing measurement types. [https://github.com/FreeCAD/FreeCAD/pull/27415 Pull request #27415]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now displays area units using unicode superscripts. [https://github.com/FreeCAD/FreeCAD/pull/28044 Pull request #28044]
+* [[Image:Std_MassProperties.svg|24px]] [[Std_MassProperties|Mass Properties]] results now use dedicated center of gravity and center of volume markers, and principal axes are labeled 1, 2 and 3. [https://github.com/FreeCAD/FreeCAD/pull/29288 Pull request #29288]
 * Macros now support directories to collect the files associated with them. [https://github.com/FreeCAD/FreeCAD/pull/27005 Pull request #27005]
 * The macro dialog and the [[Std_OpenMacrosFolder|Open macros folder]] command now open the configured macro path instead of the default macro directory. [https://github.com/FreeCAD/FreeCAD/pull/29224 Pull request #29224]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool can now report the radius and diameter for spheres and toruses. [https://github.com/FreeCAD/FreeCAD/pull/29369 Pull request #29369]


### PR DESCRIPTION
## Summary

- Adds the merged FreeCAD/FreeCAD#29288 Mass Properties marker update to the 1.2 release notes.
- Updates both the source release note page and the English mirror.

## Scope

FreeCAD/FreeCAD#29288 is a user-visible measurement improvement: Mass Properties results now use dedicated center of gravity and center of volume markers, and principal axes are labeled 1, 2 and 3.

## Related

- Tracks Reqrefusion/FreeCAD-Documentation-Project#30.
- Documents FreeCAD/FreeCAD#29288.
- Related upstream issues: FreeCAD/FreeCAD#28923 and FreeCAD/FreeCAD#28925.

## Duplicate check

- Checked the current release-note files for `29288`, center of gravity/volume marker wording, `COG`, `COV`, and numbered axes before editing.
- Checked open documentation PRs for `FreeCAD/FreeCAD#29288`, `center of gravity center of volume`, and `Mass Properties markers`; no duplicates were found.

## Validation

- `git diff --check`
- Verified the new release-note entry appears once in each updated release-note file.
