### PR TITLE
Document Part text extrusion release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -288,6 +288,7 @@ ToDo (last check: 20260430, #29258):
 
 <!--T:41-->
 * A new method has been added to split a B-spline curve into two curves at a given parameter. [https://github.com/FreeCAD/FreeCAD/pull/26716 Pull request #26716]
+* Extruding text sketches in the Part Workbench is now faster, especially for sketches that produce many wires. [https://github.com/FreeCAD/FreeCAD/pull/28344 Pull request #28344]
 * The attachment system now correctly offers modes such as ''XY parallel to Plane'' when selecting origin datum planes through an Origin object. [https://github.com/FreeCAD/FreeCAD/pull/28958 Pull request #28958]
 
 == Part Design Workbench == <!--T:42-->


### PR DESCRIPTION
## Summary

- Adds the merged FreeCAD/FreeCAD#28344 Part Workbench performance improvement to the 1.2 release notes.
- Updates both the source release note page and the English mirror.

## Scope

FreeCAD/FreeCAD#28344 is a user-visible Part Workbench improvement: extruding text sketches is now faster, especially for sketches that produce many wires.

## Related

- Tracks Reqrefusion/FreeCAD-Documentation-Project#30.
- Documents FreeCAD/FreeCAD#28344.

## Duplicate check

- Checked the current release-note files for `28344`, text sketch wording, sketch extrusion wording, and related performance wording before editing.
- Checked open documentation PRs for `FreeCAD/FreeCAD#28344` and `text sketch extrusion`; no duplicates were found.

## Validation

- `git diff --check`
- Verified the new release-note entry appears once in each updated release-note file.
