### PR TITLE
Document Python typing stubs release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -105,6 +105,8 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 
 ==== New Python API ==== <!--T:18-->
 
+* A Python typing stub generator was added for FreeCAD's C++/PyCXX API surface, using source-adjacent .pyi inputs and smoke checks to keep generated stubs valid. [https://github.com/FreeCAD/FreeCAD/pull/29334 Pull request #29334]
+
 == Start == <!--T:19-->
 
 == Addon Manager == <!--T:20-->


### PR DESCRIPTION
## Summary

- Adds the merged FreeCAD/FreeCAD#29334 Python typing stubs generator to the 1.2 release notes.
- Updates both the source release note page and the English mirror.

## Scope

FreeCAD/FreeCAD#29334 is a developer-facing API/tooling improvement: it adds a Python typing stub generator for FreeCAD's C++/PyCXX API surface, with source-adjacent `.pyi` inputs and smoke checks for generated stubs.

## Related

- Tracks Reqrefusion/FreeCAD-Documentation-Project#30.
- Documents FreeCAD/FreeCAD#29334.

## Duplicate check

- Checked the current release-note files for `29334`, typing-stub wording, Python typing wording, and stubs generator wording before editing.
- Checked open documentation PRs for `FreeCAD/FreeCAD#29334` and `Python typing stubs generator`; no duplicates were found.

## Validation

- `git diff --check`
- Verified the new release-note entry appears once in each updated release-note file.
