### PR TITLE
Document TechDraw scene capture release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -413,6 +413,7 @@ ToDo (last check: 20260430, #29258):
 * Section line font, font size, and arrow size in [[TechDraw_SectionView|TechDraw Section Views]] are now configurable per view via view properties. [https://github.com/FreeCAD/FreeCAD/pull/27521 Pull request #27521]
 * [[TechDraw_Workbench|TechDraw]] angle dimensions now support displaying the supplementary angle (180° minus the measured angle) via a view property. [https://github.com/FreeCAD/FreeCAD/pull/27055 Pull request #27055]
 * Scene drawing is now significantly faster. [https://github.com/FreeCAD/FreeCAD/pull/25898 Pull request #25898] and [https://github.com/FreeCAD/FreeCAD/pull/28702 Pull request #28702]
+* Rendered scene views now exclude viewer decorations such as the NaviCube from TechDraw scene captures. [https://github.com/FreeCAD/FreeCAD/pull/28943 Pull request #28943]
 * Cosmetic thread views in [[TechDraw_Workbench|TechDraw]] now use improved ISO-style line weights and styles. [https://github.com/FreeCAD/FreeCAD/pull/28570 Pull request #28570]
 * The [[TechDraw_ActiveView|Insert Active View]] task panel has been redesigned with improved spacing, a combobox for background style selection, and grouped crop settings that disable automatically when not in use. [https://github.com/FreeCAD/FreeCAD/pull/28085 Pull request #28085]
 * There is now a context menu option to toggle grid for the active page. [https://github.com/FreeCAD/FreeCAD/pull/29083 Pull request #29083]


### PR DESCRIPTION
## Summary

- Adds the merged FreeCAD/FreeCAD#28943 TechDraw scene capture behavior to the 1.2 release notes.
- Updates both the source release note page and the English mirror.

## Scope

FreeCAD/FreeCAD#28943 is a user-visible TechDraw/Core improvement: rendered scene views now exclude viewer decorations such as the NaviCube from TechDraw scene captures.

## Related

- Tracks Reqrefusion/FreeCAD-Documentation-Project#30.
- Documents FreeCAD/FreeCAD#28943.

## Duplicate check

- Checked the current release-note files for `28943`, scene-capture wording, viewer decoration wording, NaviCube wording, and screenshot/capture wording before editing.
- Checked open documentation PRs for `FreeCAD/FreeCAD#28943` and `viewer decorations scene captures`; no duplicates were found.

## Validation

- `git diff --check`
- Verified the new release-note entry appears once in each updated release-note file.
