### PR TITLE
Document Sketcher OVP keyboard behavior

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -372,6 +372,7 @@ ToDo (last check: 20260430, #29258):
 * Arc length dimensions are now positioned better for larger arc spans. [https://github.com/FreeCAD/FreeCAD/pull/29594 Pull request #29594]
 * Dimension labels are now oriented based on the view rotation so that they won't get displayed upside down anymore. [https://github.com/FreeCAD/FreeCAD/pull/29569 Pull request #29569]
 * A reworked [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|polyline]] tool was added with support for [[Sketcher_Workbench#On-View-Parameters|OVPs]]. [https://github.com/FreeCAD/FreeCAD/pull/29336 Pull request #29336]
+* [[Sketcher_Workbench#On-View-Parameters|On-View-Parameters]] now switch between value editing and view navigation based on the key pressed. Typing numbers, decimal separators, signs, deleting, backspacing, or pasting starts editing the parameter, while {{KEY|Enter}} or {{KEY|Tab}} confirms it and returns to camera controls. Holding {{KEY|Alt}} temporarily keeps camera controls available while editing. [https://github.com/FreeCAD/FreeCAD/pull/29477 Pull request #29477]
 * A new preference was added to control the font type (in addition to font size) for labels. [https://github.com/FreeCAD/FreeCAD/pull/26600 Pull request #26600]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -335,6 +335,7 @@ ToDo (last check: 20260430, #29258):
 * Arc length dimensions are now positioned better for larger arc spans. [https://github.com/FreeCAD/FreeCAD/pull/29594 Pull request #29594]
 * Dimension labels are now oriented based on the view rotation so that they won't get displayed upside down anymore. [https://github.com/FreeCAD/FreeCAD/pull/29569 Pull request #29569]
 * A reworked [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|polyline]] tool was added with support for [[Sketcher_Workbench#On-View-Parameters|OVPs]]. [https://github.com/FreeCAD/FreeCAD/pull/29336 Pull request #29336]
+* [[Sketcher_Workbench#On-View-Parameters|On-View-Parameters]] now switch between value editing and view navigation based on the key pressed. Typing numbers, decimal separators, signs, deleting, backspacing, or pasting starts editing the parameter, while {{KEY|Enter}} or {{KEY|Tab}} confirms it and returns to camera controls. Holding {{KEY|Alt}} temporarily keeps camera controls available while editing. [https://github.com/FreeCAD/FreeCAD/pull/29477 Pull request #29477]
 * A new preference was added to control the font type (in addition to font size) for labels. [https://github.com/FreeCAD/FreeCAD/pull/26600 Pull request #26600]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 


### PR DESCRIPTION
## Summary
- Add FreeCAD/FreeCAD#29477 to the FreeCAD 1.2 Sketcher release notes
- Document the updated On-View-Parameters keyboard behavior for value editing, confirmation, camera controls, and temporary Alt navigation
- Keep the change scoped to the root and English 1.2 release-note pages

## Verification
- git diff --check -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext

Related to #94.