### PR TITLE
Document Material symlink release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -269,6 +269,7 @@ ToDo (last check: 20260430, #29258):
 <!--T:62-->
 * The Material-Metals database has been extended with additional copper and copper-alloy materials. [https://github.com/FreeCAD/FreeCAD/pull/25832 Pull request #25832]
 * Material assignment via [[Std_SetMaterial|Std SetMaterial]] now wraps changes in a transaction, replacing the "Close" button with "OK" and "Cancel" to enable proper undo support. [https://github.com/FreeCAD/FreeCAD/pull/27910 Pull request #27910]
+* Material library paths using symbolic links are now handled correctly by the Materials Editor and material-loading API calls. [https://github.com/FreeCAD/FreeCAD/pull/28500 Pull request #28500]
 
 == Mesh Workbench == <!--T:36-->
 


### PR DESCRIPTION
## Summary

- Adds the merged FreeCAD/FreeCAD#28500 Material Workbench symbolic-link handling improvement to the 1.2 release notes.
- Updates both the source release note page and the English mirror.

## Scope

FreeCAD/FreeCAD#28500 is a user-visible Material Workbench/API improvement: material library paths using symbolic links are now handled correctly by the Materials Editor and material-loading API calls.

## Related

- Tracks Reqrefusion/FreeCAD-Documentation-Project#30.
- Documents FreeCAD/FreeCAD#28500.

## Duplicate check

- Checked the current release-note files for `28500`, symbolic-link wording, symlink wording, and Material library path wording before editing.
- Checked open documentation PRs for `FreeCAD/FreeCAD#28500` and `Material symbolic links`; no duplicates were found.

## Validation

- `git diff --check`
- Verified the new release-note entry appears once in each updated release-note file.
