### PR TITLE
Document BIM working plane restore fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -161,6 +161,7 @@ ToDo (last check: 20260430, #27222):
 
 <!--T:82-->
 * BIM Nudge shortcuts now use {{KEY|Alt}} combinations to avoid conflicts with existing shortcuts. [https://github.com/FreeCAD/FreeCAD/pull/28036 Pull request #28036]
+* BIM commands that temporarily move the [[Draft_SelectPlane|working plane]] now restore the previous working plane when the command finishes. [https://github.com/FreeCAD/FreeCAD/pull/28836 Pull request #28836]
 * Native IFC objects now expose the full active-schema class list for their object type in the {{incode|IfcClass}} property, including IFC2X3 type families. [https://github.com/FreeCAD/FreeCAD/pull/28994 Pull request #28994]
 * Stair railings now follow stair visibility changes, including visibility inherited from parent objects such as levels. [https://github.com/FreeCAD/FreeCAD/pull/29173 Pull request #29173]
 * [[BIM_DrawingView|DrawingView]] cut lines now use the default line width and cut areas line thickness ratio preferences for thicker cut-line output. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]


### PR DESCRIPTION
# Document BIM working plane restore fix

## Summary
- Add a FreeCAD 1.2 BIM release-note entry for FreeCAD/FreeCAD#28836.
- Keep translation files untouched; the PR now only updates the source release-note page.
- Keep the change scoped to release notes; no command pages or generated content are edited.

Contributes to #26.
Contributes to #30.

## Why this is low-risk
- Documentation-only change.
- Uses the same bullet and upstream pull-request link style already present in the file.
- Touches only `wiki/Release_notes_1.2.wikitext` after maintainer feedback.

## Files changed
- `wiki/Release_notes_1.2.wikitext` - modified: Adds the BIM working-plane restore release-note bullet.

## Coverage
- Checked this is not covered by an existing open documentation PR for PR #28836, recentering, or working-plane restore.

## Verification
- `git diff --check origin/main...HEAD` - passed

## Reviewer notes
- I removed the `wiki/en/Release_notes_1.2.wikitext` change in response to the translation-file guidance.

## Boundary note
No payment, account, secret, or private contact details are included in this PR.
