### PR TITLE
Document TechDraw cosmetic threads release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -404,6 +404,7 @@ ToDo (last check: 20260430, #29258):
 * Section line font, font size, and arrow size in [[TechDraw_SectionView|TechDraw Section Views]] are now configurable per view via view properties. [https://github.com/FreeCAD/FreeCAD/pull/27521 Pull request #27521]
 * [[TechDraw_Workbench|TechDraw]] angle dimensions now support displaying the supplementary angle (180° minus the measured angle) via a view property. [https://github.com/FreeCAD/FreeCAD/pull/27055 Pull request #27055]
 * Scene drawing is now significantly faster. [https://github.com/FreeCAD/FreeCAD/pull/25898 Pull request #25898] and [https://github.com/FreeCAD/FreeCAD/pull/28702 Pull request #28702]
+* Cosmetic thread views in [[TechDraw_Workbench|TechDraw]] now use improved ISO-style line weights and styles. [https://github.com/FreeCAD/FreeCAD/pull/28570 Pull request #28570]
 * The [[TechDraw_ActiveView|Insert Active View]] task panel has been redesigned with improved spacing, a combobox for background style selection, and grouped crop settings that disable automatically when not in use. [https://github.com/FreeCAD/FreeCAD/pull/28085 Pull request #28085]
 * There is now a context menu option to toggle grid for the active page. [https://github.com/FreeCAD/FreeCAD/pull/29083 Pull request #29083]
 * The task panel of the [[TechDraw_Balloon|Balloon Annotation]] tool was polished. [https://github.com/FreeCAD/FreeCAD/pull/28101 Pull request #28101]


### PR DESCRIPTION
## Summary

- Adds the merged FreeCAD/FreeCAD#28570 TechDraw cosmetic-thread styling improvement to the 1.2 release notes.
- Updates both the source release note page and the English mirror.

## Scope

FreeCAD/FreeCAD#28570 is a user-visible TechDraw improvement: cosmetic thread views now use improved ISO-style line weights and styles.

## Related

- Tracks Reqrefusion/FreeCAD-Documentation-Project#30.
- Documents FreeCAD/FreeCAD#28570.

## Duplicate check

- Checked the current release-note files for `28570`, cosmetic-thread wording, ISO styling wording, and TechDraw thread wording before editing.
- Checked open documentation PRs for `FreeCAD/FreeCAD#28570` and `TechDraw cosmetic threads ISO styling`; no duplicates were found.

## Validation

- `git diff --check`
- Verified the new release-note entry appears once in each updated release-note file.
