### PR TITLE
Document Sketcher reduced solves release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -366,6 +366,7 @@ ToDo (last check: 20260430, #29258):
 * Double-clicking a geometric constraint now triggers its rename. [https://github.com/FreeCAD/FreeCAD/pull/27678 Pull request #27678]
 * Double-clicking selection now also works with external geometry. [https://github.com/FreeCAD/FreeCAD/pull/28105 Pull request #28105]
 * The Grid and Make Internals properties are now enabled by default for new sketches, and a grid transparency preference has been added. [https://github.com/FreeCAD/FreeCAD/pull/28771 Pull request #28771] and [https://github.com/FreeCAD/FreeCAD/pull/28791 Pull request #28791]
+* Sketcher now avoids unnecessary solves when dragging constraints, deleting sketch elements, and leaving dimension tools, improving responsiveness in these workflows. [https://github.com/FreeCAD/FreeCAD/pull/28652 Pull request #28652]
 * Selected distance constraints (point-line, circle-circle, and circle-line) now use orientation to prevent [[Sketcher_Workbench#Flipping|flipping]]. [https://github.com/FreeCAD/FreeCAD/pull/26518 Pull request #26518]
 * The ''Create symmetry constraints'' option of the [[Image:Sketcher_Symmetry.svg|24px]] [[Sketcher_Symmetry|Symmetry]] tool was improved to avoid overconstraints. It is now also enabled by default. [https://github.com/FreeCAD/FreeCAD/pull/28118 Pull request #28118] and [https://github.com/FreeCAD/FreeCAD/pull/28319 Pull request #28319]
 * There is now a ''Cancel'' button, making it possible to discard modifications in a sketch.  [https://github.com/FreeCAD/FreeCAD/pull/29337 Pull request #29337]


### PR DESCRIPTION
Adds a FreeCAD 1.2 release note entry for FreeCAD/FreeCAD#28652, which reduced unnecessary Sketcher solves while dragging constraints, deleting sketch elements, and leaving dimension tools.

Updated both release-note copies:

- `wiki/Release_notes_1.2.wikitext`
- `wiki/en/Release_notes_1.2.wikitext`

Validation:

- `git diff --check`
- duplicate search for `FreeCAD/FreeCAD#28652`
- duplicate search for `Sketcher superfluous solves`

Refs Reqrefusion/FreeCAD-Documentation-Project#30.
