### PR TITLE
Document Mass Properties tools menu release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -80,6 +80,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 
 <!--T:14-->
 * The search bar in the [[Image:Std_DlgPreferences.svg|24px]] [[Std_DlgPreferences|Preferences]] is now able to search through tooltips, dropdown values, checkboxes and group titles. [https://github.com/FreeCAD/FreeCAD/pull/24283 Pull request #24283]
+* The [[Image:Std_MassProperties.svg|24px]] [[Std_MassProperties|Mass Properties]] command is now also available from the Tools menu. [https://github.com/FreeCAD/FreeCAD/pull/28864 Pull request #28864]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now has the option to display the measured result of circular elements as diameters instead of radii. [https://github.com/FreeCAD/FreeCAD/pull/24853 Pull request #24853]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now supports the measurement of the radius and diameter of cylindrical faces. [https://github.com/FreeCAD/FreeCAD/pull/27044 Pull request #27044]
 * On macOS the .FCStd files now support the native QuickLook extension to show a thumbnail of the file in the finder and the full preview. [https://github.com/FreeCAD/FreeCAD/pull/25239 Pull request #25239]


### PR DESCRIPTION
Adds a FreeCAD 1.2 release note entry for FreeCAD/FreeCAD#28864, which made the Mass Properties command available from the Tools menu.

Updated both release-note copies:

- `wiki/Release_notes_1.2.wikitext`
- `wiki/en/Release_notes_1.2.wikitext`

Validation:

- `git diff --check`
- duplicate search for `FreeCAD/FreeCAD#28864`
- duplicate search for `Mass Properties Tools menu`

Refs Reqrefusion/FreeCAD-Documentation-Project#30.
