### PR TITLE
Document Sketcher text font portability release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -374,6 +374,7 @@ ToDo (last check: 20260430, #29258):
 * Arc length dimensions are now positioned better for larger arc spans. [https://github.com/FreeCAD/FreeCAD/pull/29594 Pull request #29594]
 * Dimension labels are now oriented based on the view rotation so that they won't get displayed upside down anymore. [https://github.com/FreeCAD/FreeCAD/pull/29569 Pull request #29569]
 * A reworked [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|polyline]] tool was added with support for [[Sketcher_Workbench#On-View-Parameters|OVPs]]. [https://github.com/FreeCAD/FreeCAD/pull/29336 Pull request #29336]
+* The [[Image:Sketcher_CreateText.svg|24px]] [[Sketcher_CreateText|Text]] tool now stores only the font name in the document instead of an absolute local font path, improving file portability between systems. [https://github.com/FreeCAD/FreeCAD/pull/28418 Pull request #28418]
 * A new preference was added to control the font type (in addition to font size) for labels. [https://github.com/FreeCAD/FreeCAD/pull/26600 Pull request #26600]
 * Sketcher line style dropdowns now correctly list the available styles instead of appearing empty. [https://github.com/FreeCAD/FreeCAD/pull/30151 Pull request #30151]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]


### PR DESCRIPTION
Adds a FreeCAD 1.2 release note entry for FreeCAD/FreeCAD#28418, which made the Sketcher Text tool store the font name rather than an absolute local font path.

Updated both release-note copies:

- `wiki/Release_notes_1.2.wikitext`
- `wiki/en/Release_notes_1.2.wikitext`

Validation:

- `git diff --check`
- duplicate search for `FreeCAD/FreeCAD#28418`
- duplicate search for `Sketcher text font name`

Refs Reqrefusion/FreeCAD-Documentation-Project#30.
