### PR TITLE
Document Part Attacher origin plane release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -284,6 +284,7 @@ ToDo (last check: 20260430, #29258):
 
 <!--T:41-->
 * A new method has been added to split a B-spline curve into two curves at a given parameter. [https://github.com/FreeCAD/FreeCAD/pull/26716 Pull request #26716]
+* The attachment system now correctly offers modes such as ''XY parallel to Plane'' when selecting origin datum planes through an Origin object. [https://github.com/FreeCAD/FreeCAD/pull/28958 Pull request #28958]
 
 == Part Design Workbench == <!--T:42-->
 


### PR DESCRIPTION
Adds a FreeCAD 1.2 release note entry for FreeCAD/FreeCAD#28958, which restored correct attachment-mode detection when selecting origin datum planes through an Origin object.

Updated both release-note copies:

- `wiki/Release_notes_1.2.wikitext`
- `wiki/en/Release_notes_1.2.wikitext`

Validation:

- `git diff --check`
- duplicate search for `FreeCAD/FreeCAD#28958`
- duplicate search for `Attacher hasPlacement`

Refs Reqrefusion/FreeCAD-Documentation-Project#30.
