### PR TITLE
Document CAM SelectLoop all-edges release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -181,6 +181,7 @@ ToDo (last check: 20260430, #27222):
 * [[CAM_Vcarve|Vcarve]] routing is now improved using "virtual edge backtracking". [https://github.com/FreeCAD/FreeCAD/pull/25049 Pull request #25049]
 * It is now possible to postprocess only selected Operations from the Job and select operations inside Dressup. [https://github.com/FreeCAD/FreeCAD/pull/22764 Pull request #22764]
 * The [[CAM_SelectLoop|loop selection]] tool was improved and now returns the wire if edge(s) selected and other methods failed. [https://github.com/FreeCAD/FreeCAD/pull/24185 Pull request #24185]
+* The [[CAM_SelectLoop|loop selection]] tool can now select all edges from a selected shape when no subelements are selected. [https://github.com/FreeCAD/FreeCAD/pull/29523 Pull request #29523]
 * A cooling feature was added to the Kinetic postprocessor. [https://github.com/FreeCAD/FreeCAD/pull/25022 Pull request #25022]
 * The ''Units'' (Metric/Imperial) property was added to ToolBits. [https://github.com/FreeCAD/FreeCAD/pull/25783 Pull request #25783]
 * The [[CAM_SimulatorGL|new CAM simulator]] now uses the same ortho/perspective view mode and navigation style as the [[3D_View|3D View]]. [https://github.com/FreeCAD/FreeCAD/pull/23073 Pull request #23073]


### PR DESCRIPTION
Adds a FreeCAD 1.2 release note entry for FreeCAD/FreeCAD#29523, which lets the CAM loop selection tool select all edges from a selected shape when no subelements are selected.

Updated both release-note copies:

- `wiki/Release_notes_1.2.wikitext`
- `wiki/en/Release_notes_1.2.wikitext`

Validation:

- `git diff --check`
- duplicate search for `FreeCAD/FreeCAD#29523`
- duplicate search for `CAM SelectLoop all edges`

Refs Reqrefusion/FreeCAD-Documentation-Project#30.
