### PR TITLE
Document CAM ZCorrect probe warning release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -199,6 +199,7 @@ ToDo (last check: 20260430, #27222):
 * The HandleMultipleFeatures feature can now process more cases for the [[CAM_Area|Area]] operation. [https://github.com/FreeCAD/FreeCAD/pull/26867 Pull request #26867]
 * The [[CAM_DressupTag|DressupTag]] tool can now automatically place tags for several closed paths. [https://github.com/FreeCAD/FreeCAD/pull/22468 Pull request #22468]
 * The [[CAM_DressupTag|DressupTag]] tool now scales better with many edges. [https://github.com/FreeCAD/FreeCAD/pull/29094 Pull request #29094]
+* The [[CAM_DressupZCorrect|Z Depth Correction Dressup]] now shows a warning instead of an error when the path is outside the probe area. [https://github.com/FreeCAD/FreeCAD/pull/28582 Pull request #28582]
 * The [[CAM_Adaptive|Adaptive]] operation now uses helix generator to create a helix entry. Helix properties were moved to the ''Adaptive Helix Entry'' group. There are also new property names ''Helix Max Ramp Angle'' and ''Helix Max Pitch''. [https://github.com/FreeCAD/FreeCAD/pull/22357 Pull request #22357]
 * A new Rotary Surface operation was added for 4th axis surfacing. [https://github.com/FreeCAD/FreeCAD/pull/29751 Pull request #29751]
 * The job creation and editing dialogs were improved. Job creation now includes a unit schema selector, template description was added to the json and there is a machine selector, as well as a button to create new machines on the General tab. Several other widgets within those panels were also enhanced. [https://github.com/FreeCAD/FreeCAD/pull/29861 Pull request #29861]


### PR DESCRIPTION
Adds a FreeCAD 1.2 release note entry for FreeCAD/FreeCAD#28582, which makes the CAM Z Depth Correction Dressup show a warning instead of an error when the path is outside the probe area.

Updated both release-note copies:

- `wiki/Release_notes_1.2.wikitext`
- `wiki/en/Release_notes_1.2.wikitext`

Validation:

- `git diff --check`
- duplicate search for `FreeCAD/FreeCAD#28582`
- duplicate search for `DressupZCorrect probe area warning`

Refs Reqrefusion/FreeCAD-Documentation-Project#30.
