### PR TITLE
Document CAM RampEntry LeadInOut release note

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -164,6 +164,7 @@ ToDo (last check: 20260430, #27222):
 * Tapping was removed as an experimental feature and consolidated into [[CAM_Drilling|Drilling]] as a new strategy. [https://github.com/FreeCAD/FreeCAD/pull/27506 Pull request #27506]
 * Circular Hole operation was significantly improved, including a new C++ 2-Opt TSP solver with Python bindings for improved hole sorting performance as well as new sorting modes and manual reordering in the GUI. [https://github.com/FreeCAD/FreeCAD/pull/23093 Pull request #23093]
 * New style ''LineZFollow'' was added to the [[CAM_DressupLeadInOut|LeadInOut]] operation. It can be used as a replacement for ''ArcZFollow'', as simpler and requiring less computation. [https://github.com/FreeCAD/FreeCAD/pull/27986 Pull request #27986]
+* The [[CAM_DressupRampEntry|RampEntry]] dressup can now be applied to operations that already use a [[CAM_DressupLeadInOut|LeadInOut]] dressup. [https://github.com/FreeCAD/FreeCAD/pull/28496 Pull request #28496]
 * It is now possible to manually set ''RetractThreshold'' in [[CAM_Profile|Profile]] and [[CAM_Pocket_Shape|Pocket]] operations. [https://github.com/FreeCAD/FreeCAD/pull/21738 Pull request #21738]
 * Manual selection of faces or edges for [[CAM_Drilling|Drilling]] or Helix Drilling operations is now possible. [https://github.com/FreeCAD/FreeCAD/pull/27494 Pull request #27494]
 * Helix operation, helix and spiral generators were improved to provide better results and allow more control. [https://github.com/FreeCAD/FreeCAD/pull/21971 Pull request #21971]


### PR DESCRIPTION
Adds a FreeCAD 1.2 release note entry for FreeCAD/FreeCAD#28496, which allows the CAM RampEntry dressup to be applied to operations that already use a LeadInOut dressup.

Updated both release-note copies:

- `wiki/Release_notes_1.2.wikitext`
- `wiki/en/Release_notes_1.2.wikitext`

Validation:

- `git diff --check`
- duplicate search for `FreeCAD/FreeCAD#28496`
- duplicate search for `RampEntryDressup LeadInOutDressup`

Refs Reqrefusion/FreeCAD-Documentation-Project#30.
