### PR TITLE
Document Sketcher Python copy precision

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -369,6 +369,7 @@ ToDo (last check: 20260430, #29258):
 * The Grid and Make Internals properties are now enabled by default for new sketches, and a grid transparency preference has been added. [https://github.com/FreeCAD/FreeCAD/pull/28771 Pull request #28771] and [https://github.com/FreeCAD/FreeCAD/pull/28791 Pull request #28791]
 * Selected distance constraints (point-line, circle-circle, and circle-line) now use orientation to prevent [[Sketcher_Workbench#Flipping|flipping]]. [https://github.com/FreeCAD/FreeCAD/pull/26518 Pull request #26518]
 * The ''Create symmetry constraints'' option of the [[Image:Sketcher_Symmetry.svg|24px]] [[Sketcher_Symmetry|Symmetry]] tool was improved to avoid overconstraints. It is now also enabled by default. [https://github.com/FreeCAD/FreeCAD/pull/28118 Pull request #28118] and [https://github.com/FreeCAD/FreeCAD/pull/28319 Pull request #28319]
+* Copying Sketcher geometry as Python code now keeps more coordinate precision, reducing broken closed profiles after copy and paste. [https://github.com/FreeCAD/FreeCAD/pull/29211 Pull request #29211]
 * There is now a ''Cancel'' button, making it possible to discard modifications in a sketch.  [https://github.com/FreeCAD/FreeCAD/pull/29337 Pull request #29337]
 * [[Image:Sketcher_ConstrainDistanceX.svg|24px]] [[Sketcher_ConstrainDistanceX|Horizontal Dimension]],[[Image:Sketcher_ConstrainDistanceY.svg|24px]] [[Sketcher_ConstrainDistanceY|Vertical Dimension]], and [[Image:Sketcher_ConstrainDistance.svg|24px]] [[Sketcher_ConstrainDistance|Distance Dimension]] are now positioned better by default to avoid overlap with the lines being constrained. [https://github.com/FreeCAD/FreeCAD/pull/29538 Pull request #29538]
 * [[Sketcher_Workbench#3D_View_box_selection|Sketcher box selection]] now takes into account the [[Image:Part_SelectFilter.svg|24px]] [[Part_SelectFilter|selection filters]]. [https://github.com/FreeCAD/FreeCAD/pull/28982 Pull request #28982]
@@ -377,6 +378,7 @@ ToDo (last check: 20260430, #29258):
 * A reworked [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|polyline]] tool was added with support for [[Sketcher_Workbench#On-View-Parameters|OVPs]]. [https://github.com/FreeCAD/FreeCAD/pull/29336 Pull request #29336]
 * A new preference was added to control the font type (in addition to font size) for labels. [https://github.com/FreeCAD/FreeCAD/pull/26600 Pull request #26600]
 * Sketcher line style dropdowns now correctly list the available styles instead of appearing empty. [https://github.com/FreeCAD/FreeCAD/pull/30151 Pull request #30151]
+* Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 
 == Spreadsheet Workbench == <!--T:53-->


### PR DESCRIPTION
Adds two small Sketcher release notes for FreeCAD 1.2, covering FreeCAD/FreeCAD#29211 and FreeCAD/FreeCAD#29812.

Changes:
1. Copying Sketcher geometry as Python code keeps more coordinate precision.
2. Sketcher geometry updates correctly after removing part of a constraint from a fully constrained sketch.

Related to #94.

<!-- 

    🚨 𝗡𝗼𝘁𝗶𝗰𝗲
    Please be aware that translations 
    cannot be changed via pull requests.

    Head over to the wiki at:
    https://wiki.freecad.org
 
-->
