### PR TITLE
Document CAM comment round-trip save/load fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -205,6 +205,7 @@ ToDo (last check: 20260430, #27222):
 * The job creation and editing dialogs were improved. Job creation now includes a unit schema selector, template description was added to the json and there is a machine selector, as well as a button to create new machines on the General tab. Several other widgets within those panels were also enhanced. [https://github.com/FreeCAD/FreeCAD/pull/29861 Pull request #29861]
 * {{Incode|MachineState.G0F}}, and {{Incode|.ReturnMode}} were added for [[CAM_Drilling|Drilling]] commands. [https://github.com/FreeCAD/FreeCAD/pull/29892 Pull request #29892]
 * CAM drilling cycle expansion now uses MachineState for more accurate machine state tracking while expanding drilling cycles. [https://github.com/FreeCAD/FreeCAD/pull/30112 Pull request #30112]
+* CAM comments with annotations now round-trip through save/load without adding an extra trailing space before the annotation separator. [https://github.com/FreeCAD/FreeCAD/pull/30317 Pull request #30317]
 
 == Draft Workbench == <!--T:27-->
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -180,7 +180,6 @@ ToDo (last check: 20260430, #27222):
 * The job creation and editing dialogs were improved. Job creation now includes a unit schema selector, template description was added to the json and there is a machine selector, as well as a button to create new machines on the General tab. Several other widgets within those panels were also enhanced. [https://github.com/FreeCAD/FreeCAD/pull/29861 Pull request #29861]
 * {{Incode|MachineState.G0F}}, and {{Incode|.ReturnMode}} were added for [[CAM_Drilling|Drilling]] commands. [https://github.com/FreeCAD/FreeCAD/pull/29892 Pull request #29892]
 * CAM drilling cycle expansion now uses MachineState for more accurate machine state tracking while expanding drilling cycles. [https://github.com/FreeCAD/FreeCAD/pull/30112 Pull request #30112]
-* CAM comments with annotations now round-trip through save/load without adding an extra trailing space before the annotation separator. [https://github.com/FreeCAD/FreeCAD/pull/30317 Pull request #30317]
 
 == Draft Workbench ==
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -180,6 +180,7 @@ ToDo (last check: 20260430, #27222):
 * The job creation and editing dialogs were improved. Job creation now includes a unit schema selector, template description was added to the json and there is a machine selector, as well as a button to create new machines on the General tab. Several other widgets within those panels were also enhanced. [https://github.com/FreeCAD/FreeCAD/pull/29861 Pull request #29861]
 * {{Incode|MachineState.G0F}}, and {{Incode|.ReturnMode}} were added for [[CAM_Drilling|Drilling]] commands. [https://github.com/FreeCAD/FreeCAD/pull/29892 Pull request #29892]
 * CAM drilling cycle expansion now uses MachineState for more accurate machine state tracking while expanding drilling cycles. [https://github.com/FreeCAD/FreeCAD/pull/30112 Pull request #30112]
+* CAM comments with annotations now round-trip through save/load without adding an extra trailing space before the annotation separator. [https://github.com/FreeCAD/FreeCAD/pull/30317 Pull request #30317]
 
 == Draft Workbench ==
 


### PR DESCRIPTION
Updates the FreeCAD 1.2 release notes with the CAM comment round-trip save/load fix from FreeCAD/FreeCAD#30317, which fixed FreeCAD/FreeCAD#30140.

Scope:
- wiki/Release_notes_1.2.wikitext

Contributes to #30 and #25.

Verification:
- git diff origin/main...HEAD --name-only
- git diff --check
- rg -n "30317|round-trip|30140" wiki/Release_notes_1.2.wikitext

Maintainer note addressed: translation files are intentionally untouched; the earlier wiki/en change was removed.