### PR TITLE
Sync additional English 1.2 release notes

### DIFF
--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -69,9 +69,11 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now supports the measurement of the radius and diameter of cylindrical faces. [https://github.com/FreeCAD/FreeCAD/pull/27044 Pull request #27044]
 * On macOS the .FCStd files now support the native QuickLook extension to show a thumbnail of the file in the finder and the full preview. [https://github.com/FreeCAD/FreeCAD/pull/25239 Pull request #25239]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measurement]] units can now be converted and viewed on the fly. [https://github.com/FreeCAD/FreeCAD/pull/27462 Pull request #27462]
+* The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now keeps the selected display unit with the measurement object, so changing units updates the task panel result and 3D label immediately. [https://github.com/FreeCAD/FreeCAD/pull/29157 Pull request #29157]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool can now report the radius and diameter for circular faces in addition to the existing measurement types. [https://github.com/FreeCAD/FreeCAD/pull/27415 Pull request #27415]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now displays area units using unicode superscripts. [https://github.com/FreeCAD/FreeCAD/pull/28044 Pull request #28044]
 * Macros now support directories to collect the files associated with them. [https://github.com/FreeCAD/FreeCAD/pull/27005 Pull request #27005]
+* The macro dialog and the [[Std_OpenMacrosFolder|Open macros folder]] command now open the configured macro path instead of the default macro directory. [https://github.com/FreeCAD/FreeCAD/pull/29224 Pull request #29224]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool can now report the radius and diameter for spheres and toruses. [https://github.com/FreeCAD/FreeCAD/pull/29369 Pull request #29369]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now supports curved faces in ''Distance'' mode. [https://github.com/FreeCAD/FreeCAD/pull/29367 Pull request #29367]
 * The appearance and placement of the ''Angle'' [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measurement]] arrows was significantly improved. [https://github.com/FreeCAD/FreeCAD/pull/27135 Pull request #27135]
@@ -142,6 +144,7 @@ ToDo (last check: 20260430, #27222):
 * Tapping was removed as an experimental feature and consolidated into [[CAM_Drilling|Drilling]] as a new strategy. [https://github.com/FreeCAD/FreeCAD/pull/27506 Pull request #27506]
 * Circular Hole operation was significantly improved, including a new C++ 2-Opt TSP solver with Python bindings for improved hole sorting performance as well as new sorting modes and manual reordering in the GUI. [https://github.com/FreeCAD/FreeCAD/pull/23093 Pull request #23093]
 * New style ''LineZFollow'' was added to the [[CAM_DressupLeadInOut|LeadInOut]] operation. It can be used as a replacement for ''ArcZFollow'', as simpler and requiring less computation. [https://github.com/FreeCAD/FreeCAD/pull/27986 Pull request #27986]
+* The [[CAM_DressupRampEntry|RampEntry]] dressup can now be applied to operations that already use a [[CAM_DressupLeadInOut|LeadInOut]] dressup. [https://github.com/FreeCAD/FreeCAD/pull/28496 Pull request #28496]
 * It is now possible to manually set ''RetractThreshold'' in [[CAM_Profile|Profile]] and [[CAM_Pocket_Shape|Pocket]] operations. [https://github.com/FreeCAD/FreeCAD/pull/21738 Pull request #21738]
 * Manual selection of faces or edges for [[CAM_Drilling|Drilling]] or Helix Drilling operations is now possible. [https://github.com/FreeCAD/FreeCAD/pull/27494 Pull request #27494]
 * Helix operation, helix and spiral generators were improved to provide better results and allow more control. [https://github.com/FreeCAD/FreeCAD/pull/21971 Pull request #21971]
@@ -157,6 +160,7 @@ ToDo (last check: 20260430, #27222):
 * [[CAM_Vcarve|Vcarve]] routing is now improved using "virtual edge backtracking". [https://github.com/FreeCAD/FreeCAD/pull/25049 Pull request #25049]
 * It is now possible to postprocess only selected Operations from the Job and select operations inside Dressup. [https://github.com/FreeCAD/FreeCAD/pull/22764 Pull request #22764]
 * The [[CAM_SelectLoop|loop selection]] tool was improved and now returns the wire if edge(s) selected and other methods failed. [https://github.com/FreeCAD/FreeCAD/pull/24185 Pull request #24185]
+* The [[CAM_SelectLoop|loop selection]] tool can now select all edges from a selected shape when no subelements are selected. [https://github.com/FreeCAD/FreeCAD/pull/29523 Pull request #29523]
 * A cooling feature was added to the Kinetic postprocessor. [https://github.com/FreeCAD/FreeCAD/pull/25022 Pull request #25022]
 * The ''Units'' (Metric/Imperial) property was added to ToolBits. [https://github.com/FreeCAD/FreeCAD/pull/25783 Pull request #25783]
 * The [[CAM_SimulatorGL|new CAM simulator]] now uses the same ortho/perspective view mode and navigation style as the [[3D_View|3D View]]. [https://github.com/FreeCAD/FreeCAD/pull/23073 Pull request #23073]
@@ -175,6 +179,7 @@ ToDo (last check: 20260430, #27222):
 * The HandleMultipleFeatures feature can now process more cases for the [[CAM_Area|Area]] operation. [https://github.com/FreeCAD/FreeCAD/pull/26867 Pull request #26867]
 * The [[CAM_DressupTag|DressupTag]] tool can now automatically place tags for several closed paths. [https://github.com/FreeCAD/FreeCAD/pull/22468 Pull request #22468]
 * The [[CAM_DressupTag|DressupTag]] tool now scales better with many edges. [https://github.com/FreeCAD/FreeCAD/pull/29094 Pull request #29094]
+* The [[CAM_DressupZCorrect|Z Depth Correction Dressup]] now shows a warning instead of an error when the path is outside the probe area. [https://github.com/FreeCAD/FreeCAD/pull/28582 Pull request #28582]
 * The [[CAM_Adaptive|Adaptive]] operation now uses helix generator to create a helix entry. Helix properties were moved to the ''Adaptive Helix Entry'' group. There are also new property names ''Helix Max Ramp Angle'' and ''Helix Max Pitch''. [https://github.com/FreeCAD/FreeCAD/pull/22357 Pull request #22357]
 * A new Rotary Surface operation was added for 4th axis surfacing. [https://github.com/FreeCAD/FreeCAD/pull/29751 Pull request #29751]
 * The job creation and editing dialogs were improved. Job creation now includes a unit schema selector, template description was added to the json and there is a machine selector, as well as a button to create new machines on the General tab. Several other widgets within those panels were also enhanced. [https://github.com/FreeCAD/FreeCAD/pull/29861 Pull request #29861]
@@ -366,6 +371,8 @@ ToDo (last check: 20260430, #29258):
 * The task panel of the [[TechDraw_Balloon|Balloon Annotation]] tool was polished. [https://github.com/FreeCAD/FreeCAD/pull/28101 Pull request #28101]
 
 == Import and export ==
+
+* Importing STEP, IGES and glTF files now shows progress feedback during the transfer. [https://github.com/FreeCAD/FreeCAD/pull/27849 Pull request #27849]
 
 [[Category:News{{#translation:}}]]
 [[Category:Documentation{{#translation:}}]]


### PR DESCRIPTION
## Summary
- sync six existing 1.2 release-note entries from the main release notes into `wiki/en/Release_notes_1.2.wikitext`
- covers FreeCAD/FreeCAD#27849, #28496, #28582, #29157, #29224, and #29523
- leaves FreeCAD/FreeCAD#30151 and #30247 untouched because they are covered by existing open PRs

## Validation
- `git diff --check -- wiki/en/Release_notes_1.2.wikitext`

Contributes to #30.