### PR TITLE
Document CAM Slot operation improvements

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -195,6 +195,7 @@ ToDo (last check: 20260430, #27222):
 * The ''Zig Zag Angle'' property of the [[CAM_Pocket_Shape|Pocket]] operation was renamed to ''Angle''. It is now hidden if the selected pattern is ''Offset''. [https://github.com/FreeCAD/FreeCAD/pull/26842 Pull request #26842]
 * A new tool was added to allow mirroring dressups. [https://github.com/FreeCAD/FreeCAD/pull/21820 Pull request #21820]
 * A rapid move from ''Clearance Height'' to ''Safe Height'' was added at the beginning of the [[CAM_Slot|Slot]] operation's G-code. [https://github.com/FreeCAD/FreeCAD/pull/25845 Pull request #25845]
+* The [[CAM_Slot|Slot]] operation now handles perpendicular and start-to-end paths for multiple edges or faces more reliably, supports straight edges and non-horizontal arcs, and clears invalid paths when a slot cannot be created. [https://github.com/FreeCAD/FreeCAD/pull/25090 Pull request #25090]
 * The CAM context menu was improved. [https://github.com/FreeCAD/FreeCAD/pull/26492 Pull request #26492]
 * [[CAM_Engrave|Engraving]] has two new properties: ''Pattern'' (allows swapping the direction after step down to exclude retraction) and ''Reverse'' (forces direction change). [https://github.com/FreeCAD/FreeCAD/pull/22226 Pull request #22226]
 * Linking now considers the tool shape. [https://github.com/FreeCAD/FreeCAD/pull/28180 Pull request #28180]


### PR DESCRIPTION
## Summary
- Add a FreeCAD 1.2 CAM release-note entry for FreeCAD/FreeCAD#25090.
- Document that the Slot operation now handles perpendicular/start-to-end paths for multiple edges or faces more reliably, supports straight edges and non-horizontal arcs, and clears invalid paths when a slot cannot be created.
- Keep the change scoped to the source release-note page only.

## Source
- FreeCAD/FreeCAD#25090

## Validation
- git diff --check -- wiki/Release_notes_1.2.wikitext
- rg -n "25090|Slot.*perpendicular|non-horizontal arcs|invalid paths" wiki/Release_notes_1.2.wikitext

Refs #25
Refs #30