### PR TITLE
Document CAM SelectLoop several wires support

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -183,6 +183,7 @@ ToDo (last check: 20260430, #27222):
 * [[CAM_Vcarve|Vcarve]] routing is now improved using "virtual edge backtracking". [https://github.com/FreeCAD/FreeCAD/pull/25049 Pull request #25049]
 * It is now possible to postprocess only selected Operations from the Job and select operations inside Dressup. [https://github.com/FreeCAD/FreeCAD/pull/22764 Pull request #22764]
 * The [[CAM_SelectLoop|loop selection]] tool was improved and now returns the wire if edge(s) selected and other methods failed. [https://github.com/FreeCAD/FreeCAD/pull/24185 Pull request #24185]
+* The [[CAM_SelectLoop|loop selection]] tool can now find several horizontal wires when two or more selected edges do not belong to the same wire. [https://github.com/FreeCAD/FreeCAD/pull/27497 Pull request #27497]
 * The [[CAM_SelectLoop|loop selection]] tool can now select all edges from a selected shape when no subelements are selected. [https://github.com/FreeCAD/FreeCAD/pull/29523 Pull request #29523]
 * A cooling feature was added to the Kinetic postprocessor. [https://github.com/FreeCAD/FreeCAD/pull/25022 Pull request #25022]
 * The ''Units'' (Metric/Imperial) property was added to ToolBits. [https://github.com/FreeCAD/FreeCAD/pull/25783 Pull request #25783]


### PR DESCRIPTION
## Summary
- Add a FreeCAD 1.2 CAM release-note entry for FreeCAD/FreeCAD#27497.
- Document that SelectLoop can now find several horizontal wires when selected edges do not belong to the same wire.
- Keep the change scoped to the source release-note page only.

## Source
- FreeCAD/FreeCAD#27497

## Validation
- git diff --check -- wiki/Release_notes_1.2.wikitext
- rg -n "27497|several horizontal wires|selected edges" wiki/Release_notes_1.2.wikitext

Refs #25
Refs #30