### PR TITLE
Document Draft cursor key input fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -220,6 +220,7 @@ ToDo (last check: 20260430, #29258):
 <!--T:81-->
 * Draft snapping now supports B-spline knots. [https://github.com/FreeCAD/FreeCAD/pull/26571 Pull request #26571]
 * Draft in-command shortcut preferences can now contain multiple characters, making localized single-character shortcuts possible. [https://github.com/FreeCAD/FreeCAD/pull/26950 Pull request #26950]
+* Draft command input fields now keep cursor-key navigation working when key press events do not contain typed text. [https://github.com/FreeCAD/FreeCAD/pull/30061 Pull request #30061]
 * The [[Draft_SelectPlane|Working Plane]] command now moves the working plane origin to a pre-selected vertex without changing its orientation. [https://github.com/FreeCAD/FreeCAD/pull/27979 Pull request #27979]
 * Draft angular dimensions now create extension lines. [https://github.com/FreeCAD/FreeCAD/pull/27987 Pull request #27987]
 * [[Draft_PolarArray|Polar Array]] and [[Draft_CircularArray|Circular Array]] are now aware of the active working plane. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]


### PR DESCRIPTION
## Summary
- Add a FreeCAD 1.2 Draft release-note entry for FreeCAD/FreeCAD#30061.
- Document that Draft command input fields keep cursor-key navigation working when key press events contain no typed text.
- Keep the change scoped to the source release-note page only.

## Source
- FreeCAD/FreeCAD#30061

## Duplicate check
- Exact PR search for `30061` in this repository returned no existing docs PR.
- Open PR search for `30061`, `input cursor`, `cursor key`, `DraftGui`, and `26950` only found unrelated Sketcher cursor coverage.

## Validation
- `git diff --check -- wiki/Release_notes_1.2.wikitext`
- `rg -n "30061|cursor-key|key press|typed text" wiki/Release_notes_1.2.wikitext`

Refs #27
Refs #30
