### PR TITLE
Document Python console output method fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -94,6 +94,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now supports curved faces in ''Distance'' mode. [https://github.com/FreeCAD/FreeCAD/pull/29367 Pull request #29367]
 * The appearance and placement of the ''Angle'' [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measurement]] arrows was significantly improved. [https://github.com/FreeCAD/FreeCAD/pull/27135 Pull request #27135]
 * [[Image:Std_BoxElementSelection.svg|24px]] [[Std_BoxElementSelection|Box Element Selection]] now takes into account the [[Image:Part_SelectFilter.svg|24px]] [[Part_SelectFilter|selection filters]]. [https://github.com/FreeCAD/FreeCAD/pull/28982 Pull request #28982]
+* The [[Python_Console|Python Console]] and Python debugger now expose their expected output methods again, fixing errors such as {{Incode|'OutputStdout' object has no attribute 'write'}}. [https://github.com/FreeCAD/FreeCAD/pull/30261 Pull request #30261]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now supports circular faces for angle measurements. [https://github.com/FreeCAD/FreeCAD/pull/29803 Pull request #29803]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now supports internal sketch faces. [https://github.com/FreeCAD/FreeCAD/pull/29551 Pull request #29551]
 * The [[Status_Bar#Quick_Measure|Quick Measure]] feature now shows the diameter of circular faces. [https://github.com/FreeCAD/FreeCAD/pull/29385 Pull request #29385]


### PR DESCRIPTION
## Summary
- document FreeCAD/FreeCAD#30261 in the 1.2 release notes
- mention the restored Python Console/debugger output methods and the resolved OutputStdout write error

## Validation
- git diff --check -- wiki/Release_notes_1.2.wikitext
- rg -n "30261|OutputStdout|Python Console|Python debugger" wiki/Release_notes_1.2.wikitext
