### PR TITLE
Document duplicate disabled addon notices

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -113,6 +113,10 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 
 == Addon Manager == <!--T:20-->
 
+=== Further Addon Manager improvements ===
+
+* Duplicate disabled addon notices are now suppressed when the same disabled addon is discovered from both the user {{FileName|Mod}} directory and an additional flat module path. [https://github.com/FreeCAD/FreeCAD/pull/29380 Pull request #29380]
+
 == Assembly Workbench == <!--T:21-->
 
 === Further Assembly improvements === <!--T:22-->


### PR DESCRIPTION
Summary:
Adds a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#29380, which suppresses duplicate disabled-addon notices when the same addon is found through both the user Mod directory and an additional flat module path.

Related bounty or issue:
Contributes to #30.

What changed:
- Added the entry to wiki/Release_notes_1.2.wikitext
- Kept translation files untouched after maintainer feedback
- Removed manually added T tags

Validation:
- git diff --check origin/main...HEAD -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext