### PR TITLE
Document DXF import unicode path fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -431,6 +431,8 @@ ToDo (last check: 20260430, #29258):
 * Importing STEP, IGES and glTF files now shows progress feedback during the transfer. [https://github.com/FreeCAD/FreeCAD/pull/27849 Pull request #27849]
 * XHTML/X3D export now uses more descriptive {{Incode|DEF}} attribute names. [https://github.com/FreeCAD/FreeCAD/pull/29980 Pull request #29980]
 
+* On Windows, DXF import now works when the file is in a folder whose path contains non-English characters. [https://github.com/FreeCAD/FreeCAD/pull/30125 Pull request #30125]
+
 </translate>
 [[Category:News{{#translation:}}]]
 [[Category:Documentation{{#translation:}}]]


### PR DESCRIPTION
Summary:
Adds a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#30125, which fixed DXF import on Windows when the file path contains non-English characters.

Related bounty or issue:
Contributes to #30.

What changed:
- Added the entry to wiki/Release_notes_1.2.wikitext
- Kept translation files untouched after maintainer feedback
- Removed the manually added T tag

Validation:
- git diff --check origin/main...HEAD -- wiki/Release_notes_1.2.wikitext wiki/en/Release_notes_1.2.wikitext