### PR TITLE
Document Assembly link context crash fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -121,6 +121,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Solver messages (overconstraint reports) were added to the Assembly task panel. [https://github.com/FreeCAD/FreeCAD/pull/24623 Pull request #24623]
 * A new command has been added to select all joints associated with a chosen component. [https://github.com/FreeCAD/FreeCAD/pull/27530 Pull request #27530]
 * A button was added to rotate joint offsets by 90 degrees. [https://github.com/FreeCAD/FreeCAD/pull/29717 Pull request #29717]
+* Right-clicking an assembly link no longer crashes when the Assembly command has not been loaded yet. [https://github.com/FreeCAD/FreeCAD/pull/29887 Pull request #29887]
 
 == BIM Workbench == <!--T:23-->
 


### PR DESCRIPTION
Summary:
Adds a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#29887, which fixed a crash when right-clicking an assembly link before the Assembly command was loaded.

Related bounty or issue:
Contributes to #30.

What changed:
- Added one Assembly Workbench release-note bullet to wiki/Release_notes_1.2.wikitext
- Kept translation files untouched

Validation:
- git diff --check -- wiki/Release_notes_1.2.wikitext