### PR TITLE
Document BIM window release-note updates

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -145,6 +145,8 @@ ToDo (last check: 20260430, #27222):
 
 <!--T:82-->
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
+* [[BIM_Windows|BIM Windows]] now include a Sliding Door preset whose opening follows the {{incode|Opening}} property, and the Tree View context menu can invert the sliding direction. [https://github.com/FreeCAD/FreeCAD/pull/27375 Pull request #27375]
+* [[BIM_Windows|BIM Windows]] now provide a task-panel options box for editing common window properties with expression-aware fields and a cancel action. [https://github.com/FreeCAD/FreeCAD/pull/27381 Pull request #27381]
 
 == CAM Workbench == <!--T:25-->
 


### PR DESCRIPTION
Supersedes #148 and follows maintainer feedback.

## Summary
- add the two BIM Windows release-note items for PR #27375 and PR #27381
- update only `wiki/Release_notes_1.2.wikitext` in the wiki root directory
- avoid editing `wiki/en/...` translation files and avoid adding new `T` tags manually

## Verification
- checked against current `upstream/main` so the added BIM items are not already present in `wiki/Release_notes_1.2.wikitext`