### PR TITLE
Document macOS SpaceMouse release fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -50,6 +50,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Image:Std_AlignToSelection.svg|24px]] [[Std_AlignToSelection|Align to Selection]] command now supports multi-selection. [https://github.com/FreeCAD/FreeCAD/pull/29182 Pull request #29182]
 * Double-clicking on an expression field now clears the expression and keeps the current value. If no change is made, the expression is restored after losing focus. [https://github.com/FreeCAD/FreeCAD/pull/29414 Pull request #29414]
 * SpaceMouse rotations now honor the active navigation rotation center mode, including ''Object center'' and ''Drag at cursor'' modes. [https://github.com/FreeCAD/FreeCAD/pull/29998 Pull request #29998]
+* On macOS release builds, 3Dconnexion SpaceMouse devices now initialize correctly instead of reporting that the Navigation Framework is running outside an application bundle. [https://github.com/FreeCAD/FreeCAD/pull/29465 Pull request #29465]
 * The [[Std_VarSet|VarSet]] ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 * There is now a warning when saving files created in older versions. A preference was added to allow disabling it. [https://github.com/FreeCAD/FreeCAD/pull/28389 Pull request #28389]
 * Clearing the recent files list now asks for confirmation before the list is removed. [https://github.com/FreeCAD/FreeCAD/pull/27274 Pull request #27274]


### PR DESCRIPTION
Summary:
Adds a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#29465, which fixed the macOS release-build regression where 3Dconnexion SpaceMouse devices failed to initialize because the Navigation Framework detected the process outside an application bundle.

Related bounty or issue:
Contributes to #30.

What changed:
- Added one user-interface release-note bullet to wiki/Release_notes_1.2.wikitext
- Kept translation files untouched
- Did not add manual T tags

Validation:
- git diff --check -- wiki/Release_notes_1.2.wikitext