### PR TITLE
Document TechDraw page color fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -427,6 +427,7 @@ ToDo (last check: 20260430, #29258):
 * Rendered scene views now exclude viewer decorations such as the NaviCube from TechDraw scene captures. [https://github.com/FreeCAD/FreeCAD/pull/28943 Pull request #28943]
 * The [[TechDraw_ActiveView|Insert Active View]] task panel has been redesigned with improved spacing, a combobox for background style selection, and grouped crop settings that disable automatically when not in use. [https://github.com/FreeCAD/FreeCAD/pull/28085 Pull request #28085]
 * There is now a context menu option to toggle grid for the active page. [https://github.com/FreeCAD/FreeCAD/pull/29083 Pull request #29083]
+* The default TechDraw page color in the FreeCAD Light preference pack is now white, avoiding gray page backgrounds when printing. [https://github.com/FreeCAD/FreeCAD/pull/30129 Pull request #30129]
 * The task panel of the [[TechDraw_Balloon|Balloon Annotation]] tool was polished. [https://github.com/FreeCAD/FreeCAD/pull/28101 Pull request #28101]
 
 == Import and export == <!--T:59-->


### PR DESCRIPTION
Summary:
Adds a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#30129, which restored the FreeCAD Light preference pack default TechDraw page color to white to avoid gray page backgrounds when printing.

Related bounty or issue:
Contributes to #30.

What changed:
- Added one TechDraw release-note bullet to wiki/Release_notes_1.2.wikitext
- Kept translation files untouched
- Did not add manual T tags

Validation:
- git diff --check -- wiki/Release_notes_1.2.wikitext