### PR TITLE
Document Sketcher arc angle selection

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -397,6 +397,7 @@ ToDo (last check: 20260430, #29258):
 * A new preference was added to control the font type (in addition to font size) for labels. [https://github.com/FreeCAD/FreeCAD/pull/26600 Pull request #26600]
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
+* Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
 
 == Spreadsheet Workbench == <!--T:53-->
 


### PR DESCRIPTION
Summary:
Documents FreeCAD/FreeCAD#29679 in the FreeCAD 1.2 release notes.

Related bounty or issue:
Contributes to #30.

What changed:
- Added a focused Sketcher release-note bullet explaining that arcs can now be selected directly while the Angle dimension tool is active.
- Linked the upstream FreeCAD PR reference.
- Limited the change to `wiki/Release_notes_1.2.wikitext`; translation files are untouched and no manual T tags were added.

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`

Notes:
No translation page updates were made, following the latest maintainer guidance.