### PR TITLE
Document macro debugger guidance

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -91,6 +91,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now displays area units using unicode superscripts. [https://github.com/FreeCAD/FreeCAD/pull/28044 Pull request #28044]
 * Macros now support directories to collect the files associated with them. [https://github.com/FreeCAD/FreeCAD/pull/27005 Pull request #27005]
 * The macro dialog and the [[Std_OpenMacrosFolder|Open macros folder]] command now open the configured macro path instead of the default macro directory. [https://github.com/FreeCAD/FreeCAD/pull/29224 Pull request #29224]
+* The broken built-in macro debugging actions now show a message directing users to the remote debugger workflow instead of implying breakpoint debugging is available there. [https://github.com/FreeCAD/FreeCAD/pull/29889 Pull request #29889]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool can now report the radius and diameter for spheres and toruses. [https://github.com/FreeCAD/FreeCAD/pull/29369 Pull request #29369]
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now supports curved faces in ''Distance'' mode. [https://github.com/FreeCAD/FreeCAD/pull/29367 Pull request #29367]
 * The appearance and placement of the ''Angle'' [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measurement]] arrows was significantly improved. [https://github.com/FreeCAD/FreeCAD/pull/27135 Pull request #27135]


### PR DESCRIPTION
Summary:
Documents FreeCAD/FreeCAD#29889 in the FreeCAD 1.2 release notes.

Related bounty or issue:
Contributes to #30.

What changed:
- Added a focused Core release-note bullet explaining that broken built-in macro debugging actions now direct users to the remote debugger workflow.
- Linked the upstream FreeCAD PR reference.
- Limited the change to `wiki/Release_notes_1.2.wikitext`; translation files are untouched and no manual T tags were added.

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`

Notes:
No translation page updates were made, following the latest maintainer guidance.