### PR TITLE
Document TechDraw torus edge fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -437,6 +437,7 @@ ToDo (last check: 20260430, #29258):
 * Rendered scene views now exclude viewer decorations such as the NaviCube from TechDraw scene captures. [https://github.com/FreeCAD/FreeCAD/pull/28943 Pull request #28943]
 * The [[TechDraw_ActiveView|Insert Active View]] task panel has been redesigned with improved spacing, a combobox for background style selection, and grouped crop settings that disable automatically when not in use. [https://github.com/FreeCAD/FreeCAD/pull/28085 Pull request #28085]
 * There is now a context menu option to toggle grid for the active page. [https://github.com/FreeCAD/FreeCAD/pull/29083 Pull request #29083]
+* Projected views of tori and similar concentric-arc shapes now preserve legitimate outline arcs instead of deleting them during duplicate-edge cleanup. [https://github.com/FreeCAD/FreeCAD/pull/29637 Pull request #29637]
 * The default TechDraw page color in the FreeCAD Light preference pack is now white, avoiding gray page backgrounds when printing. [https://github.com/FreeCAD/FreeCAD/pull/30129 Pull request #30129]
 * The task panel of the [[TechDraw_Balloon|Balloon Annotation]] tool was polished. [https://github.com/FreeCAD/FreeCAD/pull/28101 Pull request #28101]
 * The ASME ANSIB TechDraw template now has a transparent background, matching the other drawing templates. [https://github.com/FreeCAD/FreeCAD/pull/30025 Pull request #30025]


### PR DESCRIPTION
Summary:
Documents FreeCAD/FreeCAD#29637 in the FreeCAD 1.2 release notes.

Related bounty or issue:
Contributes to #30.

What changed:
- Added a focused TechDraw release-note bullet explaining that projected views of tori and similar concentric-arc shapes now preserve legitimate outline arcs during duplicate-edge cleanup.
- Linked the upstream FreeCAD PR reference.
- Limited the change to `wiki/Release_notes_1.2.wikitext`; translation files are untouched and no manual T tags were added.

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`

Notes:
No translation page updates were made, following the latest maintainer guidance.