### PR TITLE
Document CAM Adaptive lead-in fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -186,6 +186,7 @@ ToDo (last check: 20260430, #27222):
 * Tolerance can now be set for [[CAM_DressupTag|Tag Dressup]], [[CAM_Engrave|Engrave]], and [[CAM_Deburr|Deburr]] operations to change the precision of segmentation of complex shapes while creating a path. [https://github.com/FreeCAD/FreeCAD/pull/26127 Pull request #26127] and [https://github.com/FreeCAD/FreeCAD/pull/26128 Pull request #26128]
 * The [[CAM_Engrave|Engrave]] operation can now use arc approximation for complex curves, reducing G-code command count and producing smoother G2/G3 output where applicable. [https://github.com/FreeCAD/FreeCAD/pull/29528 Pull request #29528]
 * [[CAM_Adaptive|Adaptive]] operation now automatically picks the diameter of the helix entrance. [https://github.com/FreeCAD/FreeCAD/pull/23980 Pull request #23980]
+* The [[CAM_Adaptive|Adaptive]] operation now rejects invalid lead-in start points more reliably, preventing short slotting moves near inside corners that could violate the configured step-over. [https://github.com/FreeCAD/FreeCAD/pull/29971 Pull request #29971]
 * CAM task panels now support selecting shapes from different objects. [https://github.com/FreeCAD/FreeCAD/pull/22304 Pull request #22304]
 * [[CAM_Vcarve|Vcarve]] routing is now improved using "virtual edge backtracking". [https://github.com/FreeCAD/FreeCAD/pull/25049 Pull request #25049]
 * It is now possible to postprocess only selected Operations from the Job and select operations inside Dressup. [https://github.com/FreeCAD/FreeCAD/pull/22764 Pull request #22764]


### PR DESCRIPTION
Summary:
Documents the CAM Adaptive lead-in fix from FreeCAD/FreeCAD#29971 in the FreeCAD 1.2 release notes.

Related bounty or issue:
- Contributes to #30.
- Source change: FreeCAD/FreeCAD#29971.
- Fixed upstream issue: FreeCAD/FreeCAD#29885.

What changed:
- Added one CAM Workbench release-note bullet explaining that Adaptive now rejects invalid lead-in start points more reliably, avoiding short slotting moves near inside corners that can violate the configured step-over.
- Limited the change to `wiki/Release_notes_1.2.wikitext`; translation files were not touched and no manual translation tags were added.

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`
