### PR TITLE
Document TechDraw ANSIB template background fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -428,6 +428,7 @@ ToDo (last check: 20260430, #29258):
 * The [[TechDraw_ActiveView|Insert Active View]] task panel has been redesigned with improved spacing, a combobox for background style selection, and grouped crop settings that disable automatically when not in use. [https://github.com/FreeCAD/FreeCAD/pull/28085 Pull request #28085]
 * There is now a context menu option to toggle grid for the active page. [https://github.com/FreeCAD/FreeCAD/pull/29083 Pull request #29083]
 * The task panel of the [[TechDraw_Balloon|Balloon Annotation]] tool was polished. [https://github.com/FreeCAD/FreeCAD/pull/28101 Pull request #28101]
+* The ASME ANSIB TechDraw template now has a transparent background, matching the other drawing templates. [https://github.com/FreeCAD/FreeCAD/pull/30025 Pull request #30025]
 
 == Import and export == <!--T:59-->
 


### PR DESCRIPTION
Summary:
Documents the TechDraw ANSIB template background fix from FreeCAD/FreeCAD#30025 in the FreeCAD 1.2 release notes.

Related bounty or issue:
- Contributes to #30.
- Source change: FreeCAD/FreeCAD#30025.
- Fixed upstream issue: FreeCAD/FreeCAD#18793.

What changed:
- Added one TechDraw Workbench release-note bullet explaining that the ASME ANSIB template now has a transparent background, matching the other drawing templates.
- Limited the change to `wiki/Release_notes_1.2.wikitext`; translation files were not touched and no manual translation tags were added.

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`
