### PR TITLE
Document Assembly Insert Component label fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -132,6 +132,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * A new command has been added to select all joints associated with a chosen component. [https://github.com/FreeCAD/FreeCAD/pull/27530 Pull request #27530]
 * A button was added to rotate joint offsets by 90 degrees. [https://github.com/FreeCAD/FreeCAD/pull/29717 Pull request #29717]
 * Editing sketches from assemblies no longer briefly activates the sketch's source document or crashes when leaving the Assembly context. [https://github.com/FreeCAD/FreeCAD/pull/29271 Pull request #29271]
+* The Assembly Insert Component command now uses the same label in the menu as in the toolbar and task panel. [https://github.com/FreeCAD/FreeCAD/pull/30024 Pull request #30024]
 * [[Assembly_CreateSimulation|Simulations]] now offer export to video format. [https://github.com/FreeCAD/FreeCAD/pull/25307 Pull request #25307]
 * [[Assembly_CreateView|Exploded View]] can now be created temporarily. [https://github.com/FreeCAD/FreeCAD/pull/25456 Pull request #25456]
 


### PR DESCRIPTION
Summary:
Documents the Assembly Insert Component label fix from FreeCAD/FreeCAD#30024 in the FreeCAD 1.2 release notes.

Related bounty or issue:
- Contributes to #30.
- Source change: FreeCAD/FreeCAD#30024.
- Fixed upstream issue: FreeCAD/FreeCAD#29674.

What changed:
- Added one Assembly Workbench release-note bullet explaining that the Insert Component command now uses the same label in the menu as in the toolbar and task panel.
- Limited the change to `wiki/Release_notes_1.2.wikitext`; translation files were not touched and no manual translation tags were added.

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`
