### PR TITLE
Document Raytracing tutorial version limits

### DIFF
--- a/wiki/Raytracing_tutorial.wikitext
+++ b/wiki/Raytracing_tutorial.wikitext
@@ -4,7 +4,7 @@
 ==Raytracing Workbench== <!--T:20-->
 
 <!--T:19-->
-{{VeryImportantMessage|The [[Raytracing_Workbench|Raytracing workbench]] is being superseded by the new [https://github.com/FreeCAD/FreeCAD-render Render Workbench], which is intended as its replacement. The Render Workbench can be installed through the [[Std_AddonMgr|Addon Manager]]. The information here is provided because by default FreeCAD is still shipped (as of 0.19-24276) with the Raytracing Workbench, and because the new module should basically work in the same way}}
+{{VeryImportantMessage|The [[Raytracing_Workbench|Raytracing Workbench]] is no longer included after version 0.20. For current FreeCAD versions, use the external [https://github.com/FreeCAD/FreeCAD-render Render Workbench], which can be installed through the [[Std_AddonMgr|Addon Manager]]. This tutorial is kept for users of FreeCAD 0.16 through 0.20 and as a legacy workflow reference.}}
 
 <!--T:1-->
 {{TutorialInfo
@@ -12,14 +12,14 @@
 |Level=Beginner
 |Time=10 minutes + Render time
 |Author=[https://wiki.freecad.org/index.php?title=User:Drei Drei]
-|FCVersion=0.16 or above
+|FCVersion=0.16 to 0.20
 |Files=
 }}
 
 == Introduction == <!--T:21-->
 
 <!--T:2-->
-This tutorial is meant to introduce the reader to the basic workflow of the Raytracing Workbench, as well as most of the tools that are available to create a rendered image. '''Note''' that the Raytracing workbench is progressively being obsoleted in favor of the newer [https://github.com/FreeCAD/FreeCAD-render Render Workbench], available via the [[Std_AddonMgr|Addons Manager]]
+This tutorial is meant to introduce the reader to the basic workflow of the Raytracing Workbench, as well as most of the tools that are available to create a rendered image. '''Note''' that the Raytracing Workbench is obsolete and no longer bundled with FreeCAD after version 0.20. For current FreeCAD versions, use the newer [https://github.com/FreeCAD/FreeCAD-render Render Workbench], available via the [[Std_AddonMgr|Addon Manager]].
 
 </translate>
 [[Image:Raytracing_tutorial_result.png|480px]]
@@ -28,7 +28,7 @@ This tutorial is meant to introduce the reader to the basic workflow of the Rayt
 == Requirements == <!--T:22-->
 
 <!--T:4-->
-* FreeCAD version 0.16 or above
+* FreeCAD version 0.16 to 0.20 with the Raytracing Workbench available
 * [https://www.povray.org/ POV-Ray] and/or [https://luxcorerender.org/ LuxRender] is installed on the system
 * In the case of POV-Ray, it's not enough to have just the binary executable in place, but it also '''''requires''''' the installation of '''''supporting files'''''. In Ubuntu, these are provided by the Recommends-flagged package [https://packages.ubuntu.com/search?keywords=povray-includes povray-includes]. Potential issues have also been seen with Linux installations requiring local configuration files to be manually created in a user's home folder, as discussed [https://forum.freecad.org/viewtopic.php?f=3&t=27548&start=10#p224576 here].
 * In the case of POV-Ray, installation of [https://github.com/psicofil/Macros_FreeCAD psicofil's macro] is recommended

--- a/wiki/en/Raytracing_tutorial.wikitext
+++ b/wiki/en/Raytracing_tutorial.wikitext
@@ -2,26 +2,26 @@
 
 ==Raytracing Workbench==
 
-{{VeryImportantMessage|The [[Raytracing_Workbench|Raytracing workbench]] is being superseded by the new [https://github.com/FreeCAD/FreeCAD-render Render Workbench], which is intended as its replacement. The Render Workbench can be installed through the [[Std_AddonMgr|Addon Manager]]. The information here is provided because by default FreeCAD is still shipped (as of 0.19-24276) with the Raytracing Workbench, and because the new module should basically work in the same way}}
+{{VeryImportantMessage|The [[Raytracing_Workbench|Raytracing Workbench]] is no longer included after version 0.20. For current FreeCAD versions, use the external [https://github.com/FreeCAD/FreeCAD-render Render Workbench], which can be installed through the [[Std_AddonMgr|Addon Manager]]. This tutorial is kept for users of FreeCAD 0.16 through 0.20 and as a legacy workflow reference.}}
 
 {{TutorialInfo
 |Topic=Raytracing
 |Level=Beginner
 |Time=10 minutes + Render time
 |Author=[https://wiki.freecad.org/index.php?title=User:Drei Drei]
-|FCVersion=0.16 or above
+|FCVersion=0.16 to 0.20
 |Files=
 }}
 
 == Introduction ==
 
-This tutorial is meant to introduce the reader to the basic workflow of the Raytracing Workbench, as well as most of the tools that are available to create a rendered image. '''Note''' that the Raytracing workbench is progressively being obsoleted in favor of the newer [https://github.com/FreeCAD/FreeCAD-render Render Workbench], available via the [[Std_AddonMgr|Addons Manager]]
+This tutorial is meant to introduce the reader to the basic workflow of the Raytracing Workbench, as well as most of the tools that are available to create a rendered image. '''Note''' that the Raytracing Workbench is obsolete and no longer bundled with FreeCAD after version 0.20. For current FreeCAD versions, use the newer [https://github.com/FreeCAD/FreeCAD-render Render Workbench], available via the [[Std_AddonMgr|Addon Manager]].
 
 [[Image:Raytracing_tutorial_result.png|480px]]
 
 == Requirements ==
 
-* FreeCAD version 0.16 or above
+* FreeCAD version 0.16 to 0.20 with the Raytracing Workbench available
 * [https://www.povray.org/ POV-Ray] and/or [https://luxcorerender.org/ LuxRender] is installed on the system
 * In the case of POV-Ray, it's not enough to have just the binary executable in place, but it also '''''requires''''' the installation of '''''supporting files'''''. In Ubuntu, these are provided by the Recommends-flagged package [https://packages.ubuntu.com/search?keywords=povray-includes povray-includes]. Potential issues have also been seen with Linux installations requiring local configuration files to be manually created in a user's home folder, as discussed [https://forum.freecad.org/viewtopic.php?f=3&t=27548&start=10#p224576 here].
 * In the case of POV-Ray, installation of [https://github.com/psicofil/Macros_FreeCAD psicofil's macro] is recommended

--- a/wiki/en/Raytracing_tutorial.wikitext
+++ b/wiki/en/Raytracing_tutorial.wikitext
@@ -2,26 +2,26 @@
 
 ==Raytracing Workbench==
 
-{{VeryImportantMessage|The [[Raytracing_Workbench|Raytracing Workbench]] is no longer included after version 0.20. For current FreeCAD versions, use the external [https://github.com/FreeCAD/FreeCAD-render Render Workbench], which can be installed through the [[Std_AddonMgr|Addon Manager]]. This tutorial is kept for users of FreeCAD 0.16 through 0.20 and as a legacy workflow reference.}}
+{{VeryImportantMessage|The [[Raytracing_Workbench|Raytracing workbench]] is being superseded by the new [https://github.com/FreeCAD/FreeCAD-render Render Workbench], which is intended as its replacement. The Render Workbench can be installed through the [[Std_AddonMgr|Addon Manager]]. The information here is provided because by default FreeCAD is still shipped (as of 0.19-24276) with the Raytracing Workbench, and because the new module should basically work in the same way}}
 
 {{TutorialInfo
 |Topic=Raytracing
 |Level=Beginner
 |Time=10 minutes + Render time
 |Author=[https://wiki.freecad.org/index.php?title=User:Drei Drei]
-|FCVersion=0.16 to 0.20
+|FCVersion=0.16 or above
 |Files=
 }}
 
 == Introduction ==
 
-This tutorial is meant to introduce the reader to the basic workflow of the Raytracing Workbench, as well as most of the tools that are available to create a rendered image. '''Note''' that the Raytracing Workbench is obsolete and no longer bundled with FreeCAD after version 0.20. For current FreeCAD versions, use the newer [https://github.com/FreeCAD/FreeCAD-render Render Workbench], available via the [[Std_AddonMgr|Addon Manager]].
+This tutorial is meant to introduce the reader to the basic workflow of the Raytracing Workbench, as well as most of the tools that are available to create a rendered image. '''Note''' that the Raytracing workbench is progressively being obsoleted in favor of the newer [https://github.com/FreeCAD/FreeCAD-render Render Workbench], available via the [[Std_AddonMgr|Addons Manager]]
 
 [[Image:Raytracing_tutorial_result.png|480px]]
 
 == Requirements ==
 
-* FreeCAD version 0.16 to 0.20 with the Raytracing Workbench available
+* FreeCAD version 0.16 or above
 * [https://www.povray.org/ POV-Ray] and/or [https://luxcorerender.org/ LuxRender] is installed on the system
 * In the case of POV-Ray, it's not enough to have just the binary executable in place, but it also '''''requires''''' the installation of '''''supporting files'''''. In Ubuntu, these are provided by the Recommends-flagged package [https://packages.ubuntu.com/search?keywords=povray-includes povray-includes]. Potential issues have also been seen with Linux installations requiring local configuration files to be manually created in a user's home folder, as discussed [https://forum.freecad.org/viewtopic.php?f=3&t=27548&start=10#p224576 here].
 * In the case of POV-Ray, installation of [https://github.com/psicofil/Macros_FreeCAD psicofil's macro] is recommended


### PR DESCRIPTION
Refs #29.

Summary:
Updates the Basic Raytracing tutorial so it no longer tells readers that FreeCAD 0.16 or later ships with the Raytracing Workbench.

What changed:
- Marks the tutorial as applicable to FreeCAD 0.16 through 0.20.
- Points current FreeCAD users to the external Render Workbench via the Addon Manager.
- Keeps the root tutorial page and English mirror aligned.

Validation:
- Compared against the current Raytracing Workbench page, which states the Raytracing Workbench is no longer included after version 0.20.
- Ran git diff --check -- wiki/Raytracing_tutorial.wikitext wiki/en/Raytracing_tutorial.wikitext.