### PR TITLE
Document Sketcher arc angle selection (#229) and line group preference fix (#214)

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -398,6 +398,8 @@ ToDo (last check: 20260430, #29258):
 * A new preference was added to control the font type (in addition to font size) for labels. [https://github.com/FreeCAD/FreeCAD/pull/26600 Pull request #26600]
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
+* Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making angle dimensioning more efficient. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
+* The ''Group the polyline and line commands'' preference now correctly shows its saved state after restarting FreeCAD. [https://github.com/FreeCAD/FreeCAD/pull/28673 Pull request #28673]
 
 == Spreadsheet Workbench == <!--T:53-->
 


### PR DESCRIPTION
## Summary

Documents two Sketcher improvements for the FreeCAD 1.2 release notes:

1. **Arc angle selection** (closes #229): Arcs can now be selected directly while the Angle dimension tool is active (FreeCAD/FreeCAD#29679).

2. **Line group preference fix** (closes #214): The "Group the polyline and line commands" preference now correctly shows its saved state after restarting FreeCAD (FreeCAD/FreeCAD#28673).

Both additions are in the **Further Sketcher improvements** section of `Release_notes_1.2.wikitext`.

Contributes to #30.