### PR TITLE
Document Sketcher edit value menu text rename (#213)

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -398,6 +398,7 @@ ToDo (last check: 20260430, #29258):
 * A new preference was added to control the font type (in addition to font size) for labels. [https://github.com/FreeCAD/FreeCAD/pull/26600 Pull request #26600]
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
+* The task-panel action for editing constraint values was renamed from ''Change value'' to ''Edit value'' for consistency with the 3D View context menu. [https://github.com/FreeCAD/FreeCAD/pull/29556 Pull request #29556]
 
 == Spreadsheet Workbench == <!--T:53-->
 

--- a/wiki/Sketcher_Workbench.wikitext
+++ b/wiki/Sketcher_Workbench.wikitext
@@ -66,7 +66,7 @@ You can enter a numerical value or an [[Expressions|expression]], and it is poss
 To edit the value of an existing dimensional constraint do one of the following:
 * Double-click the constraint value in the [[3D_View|3D View]].
 * Double-click the constraint in the [[Sketcher_Dialog|Sketcher Dialog]].
-* Right-click the constraint in the Sketcher Dialog and select the {{MenuCommand|Change value}} option from the context menu.
+* Right-click the constraint in the Sketcher Dialog and select the {{MenuCommand|Edit value}} option from the context menu.
 
 === Reposition constraints === <!--T:206-->
 


### PR DESCRIPTION
## Summary

Closes #213.

Two changes:

1. **Sketcher Workbench page** (`Sketcher_Workbench.wikitext`): Updated the edit-constraints instructions to use the current `Edit value` context-menu label instead of the old `Change value`.

2. **Release notes 1.2** (`Release_notes_1.2.wikitext`): Added a bullet documenting that the task-panel action was renamed from "Change value" to "Edit value" for consistency with the 3D View context menu (FreeCAD/FreeCAD#29556).

Contributes to #30.