### PR TITLE
Document older version save warning preference

### DIFF
--- a/wiki/Preferences_Editor.wikitext
+++ b/wiki/Preferences_Editor.wikitext
@@ -180,6 +180,9 @@ On this page you can specify the following:
 | If checked, backup files will get the extension {{FileName|.FCbak}} and their file names get a date suffix according to the specified {{MenuCommand|Date format}}. For a description of the date format see [https://devhints.io/datetime Date & time formats cheatsheet].
 With the default settings a backup file will for example get this name {{FileName|TD-Cube.20200315-215654.FCBak}} (original filename is {{FileName|TD-Cube.FCStd}}).
 |-
+| {{MenuCommand|Suppress older version warning on save}} {{Version|1.1}}
+| If checked, FreeCAD will not show the warning that appears when saving a file created with an older FreeCAD version. That warning allows choosing {{Button|Save}}, {{Button|Save As…}} or {{Button|Cancel}} because saving can upgrade the file format.
+|-
 | {{MenuCommand|Allow duplicate object labels in one document}}
 | If checked, objects can have the same label.
 |-

--- a/wiki/en/Preferences_Editor.wikitext
+++ b/wiki/en/Preferences_Editor.wikitext
@@ -153,9 +153,6 @@ On this page you can specify the following:
 | If checked, backup files will get the extension {{FileName|.FCbak}} and their file names get a date suffix according to the specified {{MenuCommand|Date format}}. For a description of the date format see [https://devhints.io/datetime Date & time formats cheatsheet].
 With the default settings a backup file will for example get this name {{FileName|TD-Cube.20200315-215654.FCBak}} (original filename is {{FileName|TD-Cube.FCStd}}).
 |-
-| {{MenuCommand|Suppress older version warning on save}} {{Version|1.1}}
-| If checked, FreeCAD will not show the warning that appears when saving a file created with an older FreeCAD version. That warning allows choosing {{Button|Save}}, {{Button|Save As…}} or {{Button|Cancel}} because saving can upgrade the file format.
-|-
 | {{MenuCommand|Allow duplicate object labels in one document}}
 | If checked, objects can have the same label.
 |-

--- a/wiki/en/Preferences_Editor.wikitext
+++ b/wiki/en/Preferences_Editor.wikitext
@@ -153,6 +153,9 @@ On this page you can specify the following:
 | If checked, backup files will get the extension {{FileName|.FCbak}} and their file names get a date suffix according to the specified {{MenuCommand|Date format}}. For a description of the date format see [https://devhints.io/datetime Date & time formats cheatsheet].
 With the default settings a backup file will for example get this name {{FileName|TD-Cube.20200315-215654.FCBak}} (original filename is {{FileName|TD-Cube.FCStd}}).
 |-
+| {{MenuCommand|Suppress older version warning on save}} {{Version|1.1}}
+| If checked, FreeCAD will not show the warning that appears when saving a file created with an older FreeCAD version. That warning allows choosing {{Button|Save}}, {{Button|Save As…}} or {{Button|Cancel}} because saving can upgrade the file format.
+|-
 | {{MenuCommand|Allow duplicate object labels in one document}}
 | If checked, objects can have the same label.
 |-


### PR DESCRIPTION
Summary:
- documents the Document preferences option added by FreeCAD/FreeCAD#28389 and backported in FreeCAD/FreeCAD#30276

Related bounty or issue:
- Contributes to #28
- Source change: FreeCAD/FreeCAD#28389
- Backport/source verification: FreeCAD/FreeCAD#30276

What changed:
- adds the `Suppress older version warning on save` option to the Document page of the Preferences Editor
- keeps the update limited to the root `wiki/Preferences_Editor.wikitext` page

Validation:
- `git diff --check -- wiki/Preferences_Editor.wikitext`

Notes:
- Translation files were intentionally not modified.
