### PR TITLE
Document Draft cursor key fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -249,6 +249,7 @@ ToDo (last check: 20260430, #29258):
 === Further Draft improvements === <!--T:28-->
 
 * [[Draft_Trimex|Trimex]] now reports unsupported sketch selections before opening the task panel, avoiding a misleading no-op workflow. [https://github.com/FreeCAD/FreeCAD/pull/29845 Pull request #29845]
+* Draft command input fields now keep handling cursor-key events correctly when localized in-command shortcuts are enabled. [https://github.com/FreeCAD/FreeCAD/pull/30061 Pull request #30061]
 
 == FEM Workbench == <!--T:29-->
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -205,6 +205,8 @@ ToDo (last check: 20260430, #29258):
 
 === Further Draft improvements ===
 
+* Draft command input fields now keep handling cursor-key events correctly when localized in-command shortcuts are enabled. [https://github.com/FreeCAD/FreeCAD/pull/30061 Pull request #30061]
+
 == FEM Workbench ==
 
 {| cellpadding=5


### PR DESCRIPTION
Documents FreeCAD/FreeCAD#30061 in the 1.2 release notes.

The upstream fix keeps Draft command input fields from swallowing cursor-key events when localized in-command shortcuts are enabled.

Validation: inspected the release-note diff and confirmed no translation tags were added manually.
