### PR TITLE
Document CAM invalid Base recovery

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -208,6 +208,7 @@ ToDo (last check: 20260430, #27222):
 * The ''Op Final Depth'' property of the [[CAM_Engrave|Engrave]] operation now has a better default value depending on stock and engraving shape. [https://github.com/FreeCAD/FreeCAD/pull/26543 Pull request #26543]
 * ''Start Point'' can now be set from the task panel for [[CAM_Profile|Profile]] and [[CAM_Pocket_Shape|Pocket]] operations. [https://github.com/FreeCAD/FreeCAD/pull/29502 Pull request #29502]
 * The Circular Hole Base feature used to select Base Geometry for some operations now shows position and blind state (for cylinder faces) in addition to face name and diameter. [https://github.com/FreeCAD/FreeCAD/pull/27869 Pull request #27869]
+* CAM operations now recover more gracefully when linked Base Geometry becomes invalid: the path is cleared, the operation is marked with an error state, and invalid Base entries can be removed from the task panel. [https://github.com/FreeCAD/FreeCAD/pull/27559 Pull request #27559]
 * The [[CAM_Helix|Helix]] operation now has the ''Helix Max Ramp Angle'' property while ''Helix Pitch'' was renamed to ''Helix Max Pitch''. [https://github.com/FreeCAD/FreeCAD/pull/29286 Pull request #29286]
 * The ''Zig Zag Angle'' property of the [[CAM_Pocket_Shape|Pocket]] operation was renamed to ''Angle''. It is now hidden if the selected pattern is ''Offset''. [https://github.com/FreeCAD/FreeCAD/pull/26842 Pull request #26842]
 * A new tool was added to allow mirroring dressups. [https://github.com/FreeCAD/FreeCAD/pull/21820 Pull request #21820]


### PR DESCRIPTION
Summary:
- Document the CAM ObjectOp recovery change from FreeCAD/FreeCAD#27559 in the FreeCAD 1.2 release notes.

Related bounty or issue:
- Part of #30.
- Upstream source: FreeCAD/FreeCAD#27559.
- Fixed upstream issues: FreeCAD/FreeCAD#17924 and FreeCAD/FreeCAD#30105.

What changed:
- Added one CAM release-note bullet explaining that operations now recover more gracefully when linked Base Geometry becomes invalid.
- Kept the scope to the root release-note source page only; translation files are untouched.

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`
- Confirmed the new upstream PR reference appears once.
- Confirmed translate tag counts remain balanced.
