### PR TITLE
Document Part Loft regression fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -309,6 +309,7 @@ ToDo (last check: 20260430, #29258):
 * A new method has been added to split a B-spline curve into two curves at a given parameter. [https://github.com/FreeCAD/FreeCAD/pull/26716 Pull request #26716]
 * Extruding text sketches in the Part Workbench is now faster, especially for sketches that produce many wires. [https://github.com/FreeCAD/FreeCAD/pull/28344 Pull request #28344]
 * The attachment system now correctly offers modes such as ''XY parallel to Plane'' when selecting origin datum planes through an Origin object. [https://github.com/FreeCAD/FreeCAD/pull/28958 Pull request #28958]
+* Loft creation now allows valid profile combinations that share the same center of gravity while still guarding against the crash case fixed for duplicate profiles. [https://github.com/FreeCAD/FreeCAD/pull/29982 Pull request #29982]
 
 == Part Design Workbench == <!--T:42-->
 


### PR DESCRIPTION
Summary:
- Document the Part Loft regression fix from FreeCAD/FreeCAD#29982 in the FreeCAD 1.2 release notes.

Related bounty or issue:
- Part of #30.
- Upstream source: FreeCAD/FreeCAD#29982.
- Related upstream issue: FreeCAD/FreeCAD#5855.

What changed:
- Added one Part release-note bullet explaining that Loft creation again allows valid profile combinations sharing the same center of gravity while preserving the duplicate-profile crash guard.
- Kept the scope to the root release-note source page only; translation files are untouched.

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`
- Confirmed the new upstream PR reference appears once.
- Confirmed translate tag counts remain balanced.
