### PR TITLE
Document CAM Slot CutPattern update

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -213,6 +213,7 @@ ToDo (last check: 20260430, #27222):
 * A new tool was added to allow mirroring dressups. [https://github.com/FreeCAD/FreeCAD/pull/21820 Pull request #21820]
 * A rapid move from ''Clearance Height'' to ''Safe Height'' was added at the beginning of the [[CAM_Slot|Slot]] operation's G-code. [https://github.com/FreeCAD/FreeCAD/pull/25845 Pull request #25845]
 * The [[CAM_Slot|Slot]] operation now handles perpendicular and start-to-end paths for multiple edges or faces more reliably, supports straight edges and non-horizontal arcs, and clears invalid paths when a slot cannot be created. [https://github.com/FreeCAD/FreeCAD/pull/25090 Pull request #25090]
+* The [[CAM_Slot|Slot]] operation task panel now includes the ''CutPattern'' option, whose values were renamed to ''Bidirectional'' and ''Directional''; the removed ''LayerMode'' behavior now matches other operations' step-down handling. [https://github.com/FreeCAD/FreeCAD/pull/25867 Pull request #25867]
 * The CAM context menu was improved. [https://github.com/FreeCAD/FreeCAD/pull/26492 Pull request #26492]
 * [[CAM_Engrave|Engraving]] has two new properties: ''Pattern'' (allows swapping the direction after step down to exclude retraction) and ''Reverse'' (forces direction change). [https://github.com/FreeCAD/FreeCAD/pull/22226 Pull request #22226]
 * Linking now considers the tool shape. [https://github.com/FreeCAD/FreeCAD/pull/28180 Pull request #28180]


### PR DESCRIPTION
Summary:
Adds a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#25867.

Related bounty or issue:
Refs #30.

What changed:
- Documented the CAM Slot task-panel CutPattern option and renamed CutPattern values.
- Noted that the removed LayerMode behavior now matches other operations' step-down handling.
- Kept the update limited to the root Release_notes_1.2 page.

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`

Notes:
- Translation files were intentionally not modified.
