### PR TITLE
Document OpenCascade 8 compatibility

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -101,6 +101,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Image:Std_Measure.svg|24px]] [[Std_Measure|Measure]] tool now supports internal sketch faces. [https://github.com/FreeCAD/FreeCAD/pull/29551 Pull request #29551]
 * The [[Status_Bar#Quick_Measure|Quick Measure]] feature now shows the diameter of circular faces. [https://github.com/FreeCAD/FreeCAD/pull/29385 Pull request #29385]
 * [[Image:Part_SelectFilter.svg|24px]] [[Part_SelectFilter|Selection filters]] can now select other entities within the viewer pick radius instead of immediately showing the blocked-selection state. [https://github.com/FreeCAD/FreeCAD/pull/29705 Pull request #29705]
+* FreeCAD was adapted for OpenCascade 8 while keeping OpenCascade 7 compatibility, updating geometry, import/export, CAM, Sketcher, FEM mesh, and related code paths. [https://github.com/FreeCAD/FreeCAD/pull/25502 Pull request #25502]
 
 === API === <!--T:15-->
 


### PR DESCRIPTION
Summary:
Adds a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#25502.

Related bounty or issue:
Refs #30.

What changed:
- Documented that FreeCAD was adapted for OpenCascade 8 while keeping OpenCascade 7 compatibility across geometry, import/export, CAM, Sketcher, FEM mesh, and related code paths.
- Kept the update limited to the root Release_notes_1.2 page.

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`

Notes:
- Translation files were intentionally not modified.
- This is a focused release-note addition and does not claim the broader release-notes issue is complete.