### PR TITLE
Document Sketcher tool hints

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -393,6 +393,7 @@ ToDo (last check: 20260430, #29258):
 <!--T:52-->
 * It is now possible to import Bézier and Offset curves as [[Image:Sketcher_Projection.svg|24px]] [[Sketcher_Projection|External geometry]]. [https://github.com/FreeCAD/FreeCAD/pull/25144 Pull request #25144]
 * The Merge Sketches command now imports external geometry when possible, remaps constraints that reference external geometry, and creates the merged sketch inside the shared Body when all source sketches belong to one. [https://github.com/FreeCAD/FreeCAD/pull/29497 Pull request #29497]
+* Sketcher geometry creation tools now show context-sensitive input hints for each step of the drawing workflow, such as selecting points, finishing multi-step tools, and switching tool modes. [https://github.com/FreeCAD/FreeCAD/pull/21632 Pull request #21632]
 * [[Sketcher_Workbench#Copy,_cut_and_paste|Copy, cut and paste]] now support text geometry and [[Image:Sketcher_ConstrainGroup.svg|24px]] [[Sketcher_ConstrainGroup|Group constraints]]. [https://github.com/FreeCAD/FreeCAD/pull/28728 Pull request #28728]
 * When creating or editing circular dimensions, it is now possible to switch between the radius and diameter type. [https://github.com/FreeCAD/FreeCAD/pull/26794 Pull request #26794]
 * The constraint list now displays the type of the constraint in the name. [https://github.com/FreeCAD/FreeCAD/pull/26797 Pull request #26797]


### PR DESCRIPTION
Summary:
Adds a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#21632.

Related bounty or issue:
Refs #94.

What changed:
- Documented that Sketcher geometry creation tools now show context-sensitive input hints for drawing workflow steps.
- Kept the update limited to the root Release_notes_1.2 page.

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`
- Confirmed the upstream PR reference appears once.
- Confirmed translate tag counts remain balanced.

Notes:
- Translation files were intentionally not modified.
- This is a focused release-note addition and does not claim the broader Sketcher documentation issue is complete.