### PR TITLE
Document Assembly link double-click fix

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -131,6 +131,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * A new command has been added to select all joints associated with a chosen component. [https://github.com/FreeCAD/FreeCAD/pull/27530 Pull request #27530]
 * A button was added to rotate joint offsets by 90 degrees. [https://github.com/FreeCAD/FreeCAD/pull/29717 Pull request #29717]
 * Editing sketches from assemblies no longer briefly activates the sketch's source document or crashes when leaving the Assembly context. [https://github.com/FreeCAD/FreeCAD/pull/29271 Pull request #29271]
+* Double-clicking an assembly link now opens the linked object even when no 3D view is active. [https://github.com/FreeCAD/FreeCAD/pull/30177 Pull request #30177]
 
 == BIM Workbench == <!--T:23-->
 


### PR DESCRIPTION
Summary:
Adds a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#30177.

Related bounty or issue:
Refs #30.

What changed:
- Documented that double-clicking an assembly link now opens the linked object even when no 3D view is active.
- Kept the update limited to the root Release_notes_1.2 page.

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`
- Confirmed the upstream PR reference appears once.
- Confirmed translate tag counts remain balanced.

Notes:
- Translation files were intentionally not modified.
- This is a focused release-note addition and does not claim the broader release-notes issue is complete.