### PR TITLE
Document Draft Trimex sketch rejection

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -247,6 +247,8 @@ ToDo (last check: 20260430, #29258):
 
 === Further Draft improvements === <!--T:28-->
 
+* [[Draft_Trimex|Trimex]] now reports unsupported sketch selections before opening the task panel, avoiding a misleading no-op workflow. [https://github.com/FreeCAD/FreeCAD/pull/29845 Pull request #29845]
+
 == FEM Workbench == <!--T:29-->
 
 <!--T:75-->


### PR DESCRIPTION
Summary:
- Add a FreeCAD 1.2 release-note entry for Draft Trimex rejecting unsupported sketch selections.

Related bounty or issue:
- Refs #30
- Upstream fix: FreeCAD/FreeCAD#29845
- Upstream issue: FreeCAD/FreeCAD#23681

What changed:
- Added one bullet under Further Draft improvements describing the user-visible behavior change.

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`
- Verified FreeCAD PR #29845 is merged and linked to closed issue #23681.
- Confirmed `<translate>` and `</translate>` tag counts remain balanced.