### PR TITLE
Document BIM covering and report updates

### DIFF
--- a/wiki/BIM_Workbench.wikitext
+++ b/wiki/BIM_Workbench.wikitext
@@ -162,6 +162,9 @@ The BIM workbench also adds a series of items in the '''Status Bar''' of FreeCAD
 <!--T:77-->
 * [[Image:Arch_CurtainWall.svg|32px]] [[Arch_CurtainWall|Curtain Wall]]: Creates a curtain wall from scratch or using a selected object as a base.
 
+<!--T:286-->
+* [[Image:BIM_Covering.svg|32px]] [[BIM_Covering|Covering]]: Creates a parametric surface finish such as flooring, wall cladding, ceiling finish or roofing. {{Version|1.2}}
+
 <!--T:78-->
 * [[Image:BIM_Column.svg|32px]] [[BIM_Column|Column]]: Creates a vertical [[Arch_Structure|structural]] element at a given point, optionally using a selected object as a profile.
 

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -134,14 +134,12 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 
 </translate>
 ToDo (last check: 20260430, #27222):
-* https://github.com/FreeCAD/FreeCAD/pull/24078
 * https://github.com/FreeCAD/FreeCAD/pull/24190
 * https://github.com/FreeCAD/FreeCAD/pull/24550
 * https://github.com/FreeCAD/FreeCAD/pull/24595
 * https://github.com/FreeCAD/FreeCAD/pull/25086
 * https://github.com/FreeCAD/FreeCAD/pull/25147
 * https://github.com/FreeCAD/FreeCAD/pull/26758
-* https://github.com/FreeCAD/FreeCAD/pull/27222
 * https://github.com/FreeCAD/FreeCAD/pull/27375
 * https://github.com/FreeCAD/FreeCAD/pull/27381
 * https://github.com/FreeCAD/FreeCAD/pull/27420
@@ -155,6 +153,8 @@ ToDo (last check: 20260430, #27222):
 
 <!--T:82-->
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
+* The new [[BIM_Report|BIM Report]] command can query model data with SQL-like statements, pipeline query results, use report and query presets, and write the resulting schedules to a spreadsheet. [https://github.com/FreeCAD/FreeCAD/pull/24078 Pull request #24078]
+* The new [[BIM_Covering|BIM Covering]] command creates parametric surface finishes such as floor tiling, wall cladding and ceiling finishes, with tiled, monolithic and hatch-style representations plus quantity take-off data. [https://github.com/FreeCAD/FreeCAD/pull/27222 Pull request #27222]
 * [[BIM_Windows|BIM Windows]] now include a Sliding Door preset whose opening follows the {{incode|Opening}} property, and the Tree View context menu can invert the sliding direction. [https://github.com/FreeCAD/FreeCAD/pull/27375 Pull request #27375]
 * [[BIM_Windows|BIM Windows]] now provide a task-panel options box for editing common window properties with expression-aware fields and a cancel action. [https://github.com/FreeCAD/FreeCAD/pull/27381 Pull request #27381]
 * Stair railings now follow stair visibility changes, including visibility inherited from parent objects such as levels. [https://github.com/FreeCAD/FreeCAD/pull/29173 Pull request #29173]


### PR DESCRIPTION
## Summary
- add FreeCAD/FreeCAD#24078 and FreeCAD/FreeCAD#27222 to the FreeCAD 1.2 BIM release notes
- remove those two upstream PRs from the BIM release-note TODO list now that they have entries
- add the BIM Covering command to the BIM Workbench 3D/BIM tool list

## Source PRs
- FreeCAD/FreeCAD#24078 introduced the BIM Report command
- FreeCAD/FreeCAD#27222 introduced the BIM Covering object and command

## Validation
- `git diff --check -- wiki/Release_notes_1.2.wikitext wiki/BIM_Workbench.wikitext`

Part of #26.