### PR TITLE
Document BIM hybrid IFC relative paths

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -135,7 +135,6 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 </translate>
 ToDo (last check: 20260430, #27222):
 * https://github.com/FreeCAD/FreeCAD/pull/24078
-* https://github.com/FreeCAD/FreeCAD/pull/24190
 * https://github.com/FreeCAD/FreeCAD/pull/24550
 * https://github.com/FreeCAD/FreeCAD/pull/24595
 * https://github.com/FreeCAD/FreeCAD/pull/25086
@@ -155,6 +154,7 @@ ToDo (last check: 20260430, #27222):
 
 <!--T:82-->
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
+* Hybrid IFC files now store their linked IFC file path relative to the FreeCAD document when possible, making projects easier to move between folders or computers. [https://github.com/FreeCAD/FreeCAD/pull/24190 Pull request #24190]
 * [[BIM_Windows|BIM Windows]] now include a Sliding Door preset whose opening follows the {{incode|Opening}} property, and the Tree View context menu can invert the sliding direction. [https://github.com/FreeCAD/FreeCAD/pull/27375 Pull request #27375]
 * [[BIM_Windows|BIM Windows]] now provide a task-panel options box for editing common window properties with expression-aware fields and a cancel action. [https://github.com/FreeCAD/FreeCAD/pull/27381 Pull request #27381]
 * Stair railings now follow stair visibility changes, including visibility inherited from parent objects such as levels. [https://github.com/FreeCAD/FreeCAD/pull/29173 Pull request #29173]


### PR DESCRIPTION
## Summary
- add a FreeCAD 1.2 BIM release-note entry for FreeCAD/FreeCAD#24190
- document that hybrid IFC files now store linked IFC paths relative to the FreeCAD document when possible
- remove FreeCAD/FreeCAD#24190 from the BIM release-note TODO list

## Related bounty / issue
- Contributes to #26
- Source change: FreeCAD/FreeCAD#24190

## Validation
- `git diff --check -- wiki/Release_notes_1.2.wikitext`
- confirmed `<translate>` and `</translate>` tag counts remain balanced
