### PR TITLE
Document BIM DrawingView cut line width

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -160,6 +160,7 @@ ToDo (last check: 20260430, #27222):
 <!--T:82-->
 * Stair railings now follow stair visibility changes, including visibility inherited from parent objects such as levels. [https://github.com/FreeCAD/FreeCAD/pull/29173 Pull request #29173]
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
+* [[BIM_DrawingView|DrawingView]] cut lines now use the default line width and cut areas line thickness ratio preferences for thicker cut-line output. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]
 * IFC import now treats a multicore preference value of 0 as disabled before creating the IfcOpenShell geometry iterator, avoiding invalid worker counts when multicore processing is turned off. [https://github.com/FreeCAD/FreeCAD/pull/30201 Pull request #30201]
 
 == CAM Workbench == <!--T:25-->


### PR DESCRIPTION
Summary:
Adds a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#30149.

Related bounty or issue:
Refs #30.

What changed:
- Documented that BIM DrawingView cut lines now use the default line width and cut areas line thickness ratio preferences for thicker cut-line output.
- Kept the update limited to the root Release_notes_1.2 page.

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`
- Confirmed the upstream PR reference appears once.
- Confirmed translate tag counts remain balanced.

Notes:
- Translation files were intentionally not modified.
- This is a focused release-note addition and does not claim the broader release-notes issue is complete.