### PR TITLE
Document Sketcher internal face fixes

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -398,6 +398,7 @@ ToDo (last check: 20260430, #29258):
 * The constraint list now displays the type of the constraint in the name. [https://github.com/FreeCAD/FreeCAD/pull/26797 Pull request #26797]
 * A new selection mode was added to [[Image:Sketcher_ConstrainSymmetric.svg|24px]] [[Sketcher_ConstrainSymmetric|Symmetric constraint]]. Now it is also possible to select an element (line, arc, or open B-spline) and a symmetry line. [https://github.com/FreeCAD/FreeCAD/pull/25525 Pull request #25525]
 * Internal faces are now visible from both sides of the sketch plane, and multi-selection highlighting with {{KEY|Ctrl}}+click now correctly highlights all selected faces. [https://github.com/FreeCAD/FreeCAD/pull/28655 Pull request #28655] and [https://github.com/FreeCAD/FreeCAD/pull/28651 Pull request #28651]
+* Internal face generation now handles self-intersecting B-splines and dangling edges, while keeping stable mapped names for split edge fragments. [https://github.com/FreeCAD/FreeCAD/pull/28964 Pull request #28964]
 * Double-clicking a geometric constraint now triggers its rename. [https://github.com/FreeCAD/FreeCAD/pull/27678 Pull request #27678]
 * Double-clicking selection now also works with external geometry. [https://github.com/FreeCAD/FreeCAD/pull/28105 Pull request #28105]
 * The Grid and Make Internals properties are now enabled by default for new sketches, and a grid transparency preference has been added. [https://github.com/FreeCAD/FreeCAD/pull/28771 Pull request #28771] and [https://github.com/FreeCAD/FreeCAD/pull/28791 Pull request #28791]


### PR DESCRIPTION
Summary:
Adds a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#28964.

Related bounty or issue:
Refs #94.

What changed:
- Documented that Sketcher internal face generation now handles self-intersecting B-splines and dangling edges.
- Mentioned that split edge fragments keep stable mapped names.
- Kept the update limited to the root Release_notes_1.2 page.

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`
- Confirmed the upstream `pull/28964` link appears once.
- Confirmed translate tag counts remain balanced.

Notes:
- Translation files were intentionally not modified.
- This is a focused release-note addition and does not claim the broader Sketcher documentation issue is complete.
