### PR TITLE
Document BIM classification download source updates

### DIFF
--- a/wiki/BIM_Classification.wikitext
+++ b/wiki/BIM_Classification.wikitext
@@ -45,7 +45,7 @@ Several classification systems are available in XML or IFC form (both are suppor
 If both an IFC and XML file are available, the BIM Classification tool will prefer the IFC one.
 
 <!--T:12-->
-There is a [[Macro_Download_Classifications|convenience macro]] that can download all systems available from https://github.com/Moult/IfcClassification and place them directly in the right folder. After running the macro, everything is ready to use this tool. Note that classification system downloaded from this source may not be up to date.
+There is a [[Macro_Download_Classifications|convenience macro]] that can install a prepared batch of classification systems in the right folder automatically. This is useful for a quick setup, but the downloaded package may lag behind the newer classification files linked above. If you need the most up-to-date data, prefer downloading the current XML or IFC files from the IfcOpenShell classification folder or the original publishers.
 
 
 <!--T:8-->

--- a/wiki/Macro_Download_Classifications.wikitext
+++ b/wiki/Macro_Download_Classifications.wikitext
@@ -14,7 +14,7 @@
 ==Description== <!--T:2-->
 
 <!--T:3-->
-This macro downloads a series of BIM classification systems from https://github.com/Moult/IfcClassification and places them in the appropriate folder on your computer so they are found by the [[BIM_Classification|BIM Classification]] tool.
+This macro downloads a prepared set of BIM classification systems from https://github.com/Moult/IfcClassification and places them in the appropriate folder on your computer so they are found by the [[BIM_Classification|BIM Classification]] tool. This is convenient for a quick setup, but the downloaded package may lag behind newer classification files available from the IfcOpenShell classification folder or the original publishers described on the [[BIM_Classification|BIM Classification]] page.
 
 ==Usage== <!--T:4-->
 


### PR DESCRIPTION
## Summary
- update `BIM_Classification` so the classification download guidance points readers to the current sources for the newest files
- clarify in `Macro_Download_Classifications` that the convenience macro can lag behind newer published classification data
- keep the change limited to root `wiki/` pages, without touching translation files

## Validation
- updated only root wiki pages
- kept existing `<translate>` structure intact
- based the wording on the newer BIM classification source change from `FreeCAD/FreeCAD#30247`

Refs #26