### PR TITLE
Document BIM working plane recenter fix

### DIFF
--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -137,6 +137,7 @@ ToDo (last check: 20260430, #27222):
 
 * Stair railings now follow stair visibility changes, including visibility inherited from parent objects such as levels. [https://github.com/FreeCAD/FreeCAD/pull/29173 Pull request #29173]
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
+* Re-centering a BIM model now restores the previous working plane after the operation. [https://github.com/FreeCAD/FreeCAD/pull/28836 Pull request #28836]
 * IFC import now treats a multicore preference value of 0 as disabled before creating the IfcOpenShell geometry iterator, avoiding invalid worker counts when multicore processing is turned off. [https://github.com/FreeCAD/FreeCAD/pull/30201 Pull request #30201]
 
 == CAM Workbench ==


### PR DESCRIPTION
Adds a FreeCAD 1.2 BIM release-note entry for FreeCAD/FreeCAD#28836, which restores the previous working plane after recentering a BIM model.

Part of bounty issue #26 (BIM Workbench: Adding Missing Information).

Verification:
- `git diff --check`