### PR TITLE
Document BIM IfcOpenShell dependency behavior

### DIFF
--- a/wiki/BIM_Workbench.wikitext
+++ b/wiki/BIM_Workbench.wikitext
@@ -701,6 +701,8 @@ TBD
 <!--T:257-->
 The BIM workbench works natively with [https://en.wikipedia.org/wiki/Industry_Foundation_Classes Industry Foundation Classes] (IFC) files. Native means there is no more translation between the IFC contents and FreeCAD: The IFC contents are directly rendered in FreeCAD, and any change affects the IFC contents directly. Read more on [[Native_IFC|Native IFC]].
 
+Native IFC support requires [[IfcOpenShell|IfcOpenShell]]. If it is not available, FreeCAD reports that IFC support is disabled and the other BIM tools remain available. Use the [[IFC_UpdateIOS|IfcOpenShell Update]] tool to install or update the dependency.
+
 <!--T:258-->
 If you don't plan to work with others, and have no need for IFC, you can still use the BIM workbench tools and simply ignore anything related to IFC. You can still export your model to IFC anytime.
 


### PR DESCRIPTION
## Summary
- document that Native IFC support requires IfcOpenShell
- note that missing IfcOpenShell disables IFC support while other BIM tools remain available
- point users to the IfcOpenShell Update tool

## Source
- FreeCAD/FreeCAD#29192 added graceful missing-IfcOpenShell handling

## Validation
- `git diff --check upstream/main..HEAD`

Contributes to #26.