### PR TITLE
Document BIM IFC multicore preference behavior

### DIFF
--- a/wiki/BIM_Preferences.wikitext
+++ b/wiki/BIM_Preferences.wikitext
@@ -44,7 +44,6 @@ Some advanced preferences can only be changed in the [[Std_DlgParameter|Paramete
 [[Image:Preferences_BIM_Page_NativeIFC.png]]
 <translate>
 
-<!--T:19-->
 The Native IFC page includes the IFC multicore geometry processing preference. Set this value to 0 to disable multicore processing; FreeCAD still creates the IfcOpenShell geometry iterator with one worker so the import can proceed safely. Values above 0 request multiple workers and are clamped before import. This behavior is available in FreeCAD 1.2 and later. See [https://github.com/FreeCAD/FreeCAD/pull/30201 PR #30201].
 
 

--- a/wiki/BIM_Preferences.wikitext
+++ b/wiki/BIM_Preferences.wikitext
@@ -44,6 +44,9 @@ Some advanced preferences can only be changed in the [[Std_DlgParameter|Paramete
 [[Image:Preferences_BIM_Page_NativeIFC.png]]
 <translate>
 
+<!--T:19-->
+The Native IFC page includes the IFC multicore geometry processing preference. Set this value to 0 to disable multicore processing; FreeCAD still creates the IfcOpenShell geometry iterator with one worker so the import can proceed safely. Values above 0 request multiple workers and are clamped before import. This behavior is available in FreeCAD 1.2 and later. See [https://github.com/FreeCAD/FreeCAD/pull/30201 PR #30201].
+
 
 <!--T:11-->
 {{Docnav


### PR DESCRIPTION
## Summary
- document how the Native IFC page treats IFC multicore value `0` as disabled
- link the preference behavior to FreeCAD/FreeCAD#30201
- remove the manually added translation marker after maintainer feedback

Focused slice of #26.

## Verification
- docs-only change; checked the generated wikitext diff