### PR TITLE
Document BIM axis bubble orientation behavior

### DIFF
--- a/wiki/Arch_Axis.wikitext
+++ b/wiki/Arch_Axis.wikitext
@@ -44,6 +44,7 @@ The [[Image:Arch Axis.svg|24px]] [[Arch_Axis|Arch Axis]] tool allows you to plac
 * Each axis in the series has its own distance and angle in relation to the previous axis. This allows to do very complex systems such as non-orthogonal systems, polar systems or any kind of non-uniform system.
 * Double-clicking the axis in the Tree View allows to edit the distances, angles and labels of each axis.
 * Axes length, size of the bubbles and numbering styles are customizable directly via the axes system's properties.
+* {{Version|1.2}} Bubble text keeps the correct orientation in the 3D View when an axis is rotated out of the global XY plane.
 * Each axis can also display a label, which is editable via the task panel dialog.
 
 ==Properties== <!--T:12-->

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -160,6 +160,7 @@ ToDo (last check: 20260430, #27222):
 
 <!--T:82-->
 * Stair railings now follow stair visibility changes, including visibility inherited from parent objects such as levels. [https://github.com/FreeCAD/FreeCAD/pull/29173 Pull request #29173]
+* [[Arch_Axis|Arch Axis]] bubble text now keeps the correct orientation in the 3D View when an axis is rotated out of the global XY plane. [https://github.com/FreeCAD/FreeCAD/pull/29676 Pull request #29676]
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
 * [[BIM_DrawingView|DrawingView]] cut lines now use the default line width and cut areas line thickness ratio preferences for thicker cut-line output. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]
 * IFC import now treats a multicore preference value of 0 as disabled before creating the IfcOpenShell geometry iterator, avoiding invalid worker counts when multicore processing is turned off. [https://github.com/FreeCAD/FreeCAD/pull/30201 Pull request #30201]


### PR DESCRIPTION
## Summary
- document the FreeCAD 1.2 Arch Axis bubble text orientation behavior in the 3D View
- add a matching Release_notes_1.2 entry
- tie the note to upstream FreeCAD/FreeCAD#29676, which fixes FreeCAD/FreeCAD#19618

Focused slice of #26.

## Verification
- docs-only change; checked the generated wikitext diff