### PR TITLE
Document remaining BIM release-note updates

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -138,22 +138,20 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 ToDo (last check: 20260430, #27222):
 * https://github.com/FreeCAD/FreeCAD/pull/24078
 * https://github.com/FreeCAD/FreeCAD/pull/24190
-* https://github.com/FreeCAD/FreeCAD/pull/24550
-* https://github.com/FreeCAD/FreeCAD/pull/24595
-* https://github.com/FreeCAD/FreeCAD/pull/25086
-* https://github.com/FreeCAD/FreeCAD/pull/25147
-* https://github.com/FreeCAD/FreeCAD/pull/26758
 * https://github.com/FreeCAD/FreeCAD/pull/27222
-* https://github.com/FreeCAD/FreeCAD/pull/27381
-* https://github.com/FreeCAD/FreeCAD/pull/27420
-* https://github.com/FreeCAD/FreeCAD/pull/27746
-* https://github.com/FreeCAD/FreeCAD/pull/28036
-* https://github.com/FreeCAD/FreeCAD/pull/28104
 * https://github.com/FreeCAD/FreeCAD/pull/28504
 <translate>
 <!--T:86-->
+* [[Arch_Wall|Walls]] can now be created without a base object by default, with the selected wall baseline mode remembered in preferences. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]
+* Removing a wall base now preserves the wall's placement and parametric dimensions for supported straight Draft or Sketch bases, and warns before removing unsupported complex bases. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
+* The BIM Project command was removed from the toolbar, moved to the Utils menu, renamed for IFC-project clarity, and the Setup Project dialog now defaults to non-IFC-native projects. [https://github.com/FreeCAD/FreeCAD/pull/25086 Pull request #25086]
+* The BIM toolbar layout was decluttered by grouping related commands, removing the Shape from Text and BIM Views entries from the default toolbar, and rearranging common drafting and copy tools. [https://github.com/FreeCAD/FreeCAD/pull/25147 Pull request #25147]
+* [[Arch_Wall|Walls]] now provide task-panel options for common wall properties, and the same quick-access task-box framework was extended to other BIM objects. [https://github.com/FreeCAD/FreeCAD/pull/26758 Pull request #26758] and [https://github.com/FreeCAD/FreeCAD/pull/27746 Pull request #27746]
 * [[BIM_Windows|BIM Windows]] now include a Sliding Door preset whose opening follows the {{incode|Opening}} property, and the Tree View context menu can invert the sliding direction. [https://github.com/FreeCAD/FreeCAD/pull/27375 Pull request #27375]
 * [[BIM_Windows|BIM Windows]] now provide a task-panel options box for editing common window properties with expression-aware fields and a cancel action. [https://github.com/FreeCAD/FreeCAD/pull/27381 Pull request #27381]
+* [[BIM_Windows|BIM Window]] types can now use LinkGroups, avoiding out-of-scope subvolume warnings while preserving unset base-object properties. [https://github.com/FreeCAD/FreeCAD/pull/27420 Pull request #27420]
+* BIM Nudge shortcuts now use {{KEY|Alt}} combinations to avoid conflicts with existing shortcuts. [https://github.com/FreeCAD/FreeCAD/pull/28036 Pull request #28036]
+* BIM link handling was refactored, and the new [[BIM_Link|Make Link]] command creates an {{incode|App::Link}} and immediately starts a move operation for BIM workflows. [https://github.com/FreeCAD/FreeCAD/pull/28104 Pull request #28104]
 
 === Further BIM improvements === <!--T:24-->
 


### PR DESCRIPTION
## Summary
- add FreeCAD 1.2 BIM release-note entries for upstream BIM changes that were still listed as TODO
- remove the now-covered upstream PRs from the BIM TODO list
- keep the change limited to the root release-notes page

Refs #26

## Validation
- git diff --check
