### PR TITLE
Document recent 1.2 release-note additions

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -234,7 +234,6 @@ ToDo (last check: 20260430, #27222):
 * {{Incode|MachineState.G0F}}, and {{Incode|.ReturnMode}} were added for [[CAM_Drilling|Drilling]] commands. [https://github.com/FreeCAD/FreeCAD/pull/29892 Pull request #29892]
 * CAM drilling cycle expansion now uses MachineState for more accurate machine state tracking while expanding drilling cycles. [https://github.com/FreeCAD/FreeCAD/pull/30112 Pull request #30112]
 * The [[CAM_Profile|Profile]] and [[CAM_Pocket_Shape|Pocket]] linking options now include collision-avoidance strategies for using retract height, clearance height, line-of-sight checks, tool diameter, or tool shape. [https://github.com/FreeCAD/FreeCAD/pull/29983 Pull request #29983]
-* CAM comments with annotations now round-trip through save and load without adding an extra space to the command name. [https://github.com/FreeCAD/FreeCAD/pull/30317 Pull request #30317]
 
 == Draft Workbench == <!--T:27-->
 
@@ -250,7 +249,6 @@ ToDo (last check: 20260430, #29258):
 * [[Draft_PolarArray|Polar Array]] and [[Draft_CircularArray|Circular Array]] are now aware of the active working plane. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
 * SVG import can now approximate suitable curves to arcs and lines. [https://github.com/FreeCAD/FreeCAD/pull/29142 Pull request #29142]
 * Draft angular dimensions now honor overshoot settings. [https://github.com/FreeCAD/FreeCAD/pull/29298 Pull request #29298]
-* [[Draft_BSpline|B-spline]] creation no longer raises a missing {{incode|tangentAt}} attribute error after the curve-editing regression. [https://github.com/FreeCAD/FreeCAD/pull/29858 Pull request #29858]
 
 === Further Draft improvements === <!--T:28-->
 
@@ -446,7 +444,6 @@ ToDo (last check: 20260430, #29258):
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 * Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
-* Sketcher tool widget shortcuts such as {{KEY|U}} and {{KEY|J}} now continue to work after placing the first point in tools such as Rectangle. [https://github.com/FreeCAD/FreeCAD/pull/30348 Pull request #30348]
 
 == Spreadsheet Workbench == <!--T:53-->
 

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -104,6 +104,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Status_Bar#Quick_Measure|Quick Measure]] feature now shows the diameter of circular faces. [https://github.com/FreeCAD/FreeCAD/pull/29385 Pull request #29385]
 * [[Image:Part_SelectFilter.svg|24px]] [[Part_SelectFilter|Selection filters]] can now select other entities within the viewer pick radius instead of immediately showing the blocked-selection state. [https://github.com/FreeCAD/FreeCAD/pull/29705 Pull request #29705]
 * FreeCAD was adapted for OpenCascade 8 while keeping OpenCascade 7 compatibility, updating geometry, import/export, CAM, Sketcher, FEM mesh, and related code paths. [https://github.com/FreeCAD/FreeCAD/pull/25502 Pull request #25502]
+* On Unix-like systems, lock files now use owner-only permissions, and Coin image export avoids creating world-writable files. [https://github.com/FreeCAD/FreeCAD/pull/30239 Pull request #30239]
 
 === API === <!--T:15-->
 
@@ -232,6 +233,8 @@ ToDo (last check: 20260430, #27222):
 * The job creation and editing dialogs were improved. Job creation now includes a unit schema selector, template description was added to the json and there is a machine selector, as well as a button to create new machines on the General tab. Several other widgets within those panels were also enhanced. [https://github.com/FreeCAD/FreeCAD/pull/29861 Pull request #29861]
 * {{Incode|MachineState.G0F}}, and {{Incode|.ReturnMode}} were added for [[CAM_Drilling|Drilling]] commands. [https://github.com/FreeCAD/FreeCAD/pull/29892 Pull request #29892]
 * CAM drilling cycle expansion now uses MachineState for more accurate machine state tracking while expanding drilling cycles. [https://github.com/FreeCAD/FreeCAD/pull/30112 Pull request #30112]
+* The [[CAM_Profile|Profile]] and [[CAM_Pocket_Shape|Pocket]] linking options now include collision-avoidance strategies for using retract height, clearance height, line-of-sight checks, tool diameter, or tool shape. [https://github.com/FreeCAD/FreeCAD/pull/29983 Pull request #29983]
+* CAM comments with annotations now round-trip through save and load without adding an extra space to the command name. [https://github.com/FreeCAD/FreeCAD/pull/30317 Pull request #30317]
 
 == Draft Workbench == <!--T:27-->
 
@@ -247,6 +250,7 @@ ToDo (last check: 20260430, #29258):
 * [[Draft_PolarArray|Polar Array]] and [[Draft_CircularArray|Circular Array]] are now aware of the active working plane. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
 * SVG import can now approximate suitable curves to arcs and lines. [https://github.com/FreeCAD/FreeCAD/pull/29142 Pull request #29142]
 * Draft angular dimensions now honor overshoot settings. [https://github.com/FreeCAD/FreeCAD/pull/29298 Pull request #29298]
+* [[Draft_BSpline|B-spline]] creation no longer raises a missing {{incode|tangentAt}} attribute error after the curve-editing regression. [https://github.com/FreeCAD/FreeCAD/pull/29858 Pull request #29858]
 
 === Further Draft improvements === <!--T:28-->
 
@@ -442,6 +446,7 @@ ToDo (last check: 20260430, #29258):
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 * Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
+* Sketcher tool widget shortcuts such as {{KEY|U}} and {{KEY|J}} now continue to work after placing the first point in tools such as Rectangle. [https://github.com/FreeCAD/FreeCAD/pull/30348 Pull request #30348]
 
 == Spreadsheet Workbench == <!--T:53-->
 


### PR DESCRIPTION
## Summary
- add FreeCAD 1.2 release-note entries for two recently merged upstream additions that were not yet documented
- cover Core file-permission hardening and CAM linking strategy options
- keep the update limited to the root Release_notes_1.2 page

Refs #30

## Validation
- git diff --check HEAD~1..HEAD
