### PR TITLE
Fix broken links in BIM tool pages (rebased)

### DIFF
--- a/wiki/BIM_Glue.wikitext
+++ b/wiki/BIM_Glue.wikitext
@@ -2,10 +2,10 @@
 <translate>
 
 {{Docnav
-|[[BIM_Unclone|Unclone]]
+|[[BIM_Reextrude|Re-Extrude]]
 |[[BIM_Rewire|Rewire]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_Unclone.svg
+|IconL=BIM_Reextrude.svg
 |IconR=BIM_Rewire.svg
 |IconC=Workbench_BIM.svg
 }}
@@ -40,10 +40,10 @@ This is useful when you want to consolidate multiple objects into a single shape
 * If you need to preserve parametric behavior, consider using [[BIM_Compound|BIM Compound]] instead.
 
 {{Docnav
-|[[BIM_Unclone|Unclone]]
+|[[BIM_Reextrude|Re-Extrude]]
 |[[BIM_Rewire|Rewire]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_Unclone.svg
+|IconL=BIM_Reextrude.svg
 |IconR=BIM_Rewire.svg
 |IconC=Workbench_BIM.svg
 }}

--- a/wiki/BIM_ImagePlane.wikitext
+++ b/wiki/BIM_ImagePlane.wikitext
@@ -14,7 +14,7 @@
 |Name=BIM ImagePlane
 |MenuLocation=Annotation → Image Plane
 |Workbenches=[[BIM_Workbench|BIM]]
-|SeeAlso=[[Draft_Image|Draft Image]]
+|SeeAlso=[[Import|Import]]
 }}
 
 == Description ==
@@ -36,7 +36,7 @@ This is particularly useful when you have a scanned floor plan or a reference im
 
 * The image plane is a visual reference only — it does not create geometry that can be used in boolean operations or exports.
 * You can adjust the size and position of the plane after creation using standard [[Draft_Move|Move]] and [[Draft_Scale|Scale]] tools.
-* For importing images as 2D drawing elements, see [[Draft_Image|Draft Image]] instead.
+* For importing images as 2D drawing elements, see [[Import|Import]] instead.
 
 {{Docnav
 |[[BIM_Text|Text]]

--- a/wiki/BIM_Leader.wikitext
+++ b/wiki/BIM_Leader.wikitext
@@ -3,10 +3,10 @@
 
 <!--T:1-->
 {{Docnav
-|[[BIM_Text|Text]]
+|[[BIM_ImagePlane|Image Plane]]
 |[[Arch_Axis|Axis]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_Text.svg
+|IconL=BIM_ImagePlane.svg
 |IconR=Arch_Axis.svg
 |IconC=Workbench_BIM.svg
 }}
@@ -46,10 +46,10 @@ This tool is based on [[Draft_Wire|Draft Wire]].
 
 <!--T:7-->
 {{Docnav
-|[[BIM_Text|Text]]
+|[[BIM_ImagePlane|Image Plane]]
 |[[Arch_Axis|Axis]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_Text.svg
+|IconL=BIM_ImagePlane.svg
 |IconR=Arch_Axis.svg
 |IconC=Workbench_BIM.svg
 }}

--- a/wiki/BIM_Reextrude.wikitext
+++ b/wiki/BIM_Reextrude.wikitext
@@ -2,11 +2,11 @@
 <translate>
 
 {{Docnav
-|[[BIM_Extrude|Extrude]]
-|[[BIM_SimpleCopy|SimpleCopy]]
+|[[BIM_Glue|Glue]]
+|[[BIM_Glue|Glue]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_Extrude.svg
-|IconR=BIM_SimpleCopy.svg
+|IconL=BIM_SimpleCopy.svg
+|IconR=BIM_Glue.svg
 |IconC=Workbench_BIM.svg
 }}
 
@@ -38,11 +38,11 @@ The tool takes the selected face, determines its extrusion direction and length 
 * This tool is particularly useful for recreating wall or slab segments from cut faces.
 
 {{Docnav
-|[[BIM_Extrude|Extrude]]
-|[[BIM_SimpleCopy|SimpleCopy]]
+|[[BIM_Glue|Glue]]
+|[[BIM_Glue|Glue]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_Extrude.svg
-|IconR=BIM_SimpleCopy.svg
+|IconL=BIM_SimpleCopy.svg
+|IconR=BIM_Glue.svg
 |IconC=Workbench_BIM.svg
 }}
 

--- a/wiki/BIM_Reextrude.wikitext
+++ b/wiki/BIM_Reextrude.wikitext
@@ -2,10 +2,10 @@
 <translate>
 
 {{Docnav
-|[[BIM_Glue|Glue]]
+|[[BIM_Unclone|Unclone]]
 |[[BIM_Glue|Glue]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_SimpleCopy.svg
+|IconL=BIM_Unclone.svg
 |IconR=BIM_Glue.svg
 |IconC=Workbench_BIM.svg
 }}
@@ -38,10 +38,10 @@ The tool takes the selected face, determines its extrusion direction and length 
 * This tool is particularly useful for recreating wall or slab segments from cut faces.
 
 {{Docnav
-|[[BIM_Glue|Glue]]
+|[[BIM_Unclone|Unclone]]
 |[[BIM_Glue|Glue]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_SimpleCopy.svg
+|IconL=BIM_Unclone.svg
 |IconR=BIM_Glue.svg
 |IconC=Workbench_BIM.svg
 }}

--- a/wiki/BIM_Text.wikitext
+++ b/wiki/BIM_Text.wikitext
@@ -5,10 +5,10 @@
 <!--T:1-->
 {{Docnav
 |[[BIM_DimensionVertical|DimensionVertical]]
-|[[BIM_Leader|Leader]]
+|[[BIM_ImagePlane|Image Plane]]
 |[[BIM_Workbench|BIM]]
 |IconL=BIM_DimensionVertical.svg
-|IconR=BIM_Leader.svg
+|IconR=BIM_ImagePlane.svg
 |IconC=Workbench_BIM.svg
 }}
 
@@ -40,10 +40,10 @@ The '''BIM Text''' tool creates a text, either a '''Text''' object, in the curre
 <!--T:7-->
 {{Docnav
 |[[BIM_DimensionVertical|DimensionVertical]]
-|[[BIM_Leader|Leader]]
+|[[BIM_ImagePlane|Image Plane]]
 |[[BIM_Workbench|BIM]]
 |IconL=BIM_DimensionVertical.svg
-|IconR=BIM_Leader.svg
+|IconR=BIM_ImagePlane.svg
 |IconC=Workbench_BIM.svg
 }}
 

--- a/wiki/BIM_TogglePanels.wikitext
+++ b/wiki/BIM_TogglePanels.wikitext
@@ -5,7 +5,9 @@
 {{Docnav
 |
 |
+|[[BIM_Nudge|Nudge]]
 |[[BIM_Workbench|BIM]]
+|IconR=BIM_Nudge.svg
 |
 |
 |IconC=Workbench_BIM.svg
@@ -32,7 +34,9 @@ The '''BIM TogglePanels''' tool toggles the display of bottom panels ([[Report_V
 {{Docnav
 |
 |
+|[[BIM_Nudge|Nudge]]
 |[[BIM_Workbench|BIM]]
+|IconR=BIM_Nudge.svg
 |
 |
 |IconC=Workbench_BIM.svg

--- a/wiki/BIM_TogglePanels.wikitext
+++ b/wiki/BIM_TogglePanels.wikitext
@@ -3,12 +3,13 @@
 
 <!--T:1-->
 {{Docnav
-|
-|
+|[[BIM_WPView|WPView]]
 |[[BIM_Nudge|Nudge]]
 |[[BIM_Workbench|BIM]]
+|IconL=BIM_WPView.svg
 |IconR=BIM_Nudge.svg
-|
+|IconC=Workbench_BIM.svg
+}}
 |
 |IconC=Workbench_BIM.svg
 }}
@@ -32,12 +33,13 @@ The '''BIM TogglePanels''' tool toggles the display of bottom panels ([[Report_V
 
 <!--T:5-->
 {{Docnav
-|
-|
+|[[BIM_WPView|WPView]]
 |[[BIM_Nudge|Nudge]]
 |[[BIM_Workbench|BIM]]
+|IconL=BIM_WPView.svg
 |IconR=BIM_Nudge.svg
-|
+|IconC=Workbench_BIM.svg
+}}
 |
 |IconC=Workbench_BIM.svg
 }}

--- a/wiki/BIM_Trash.wikitext
+++ b/wiki/BIM_Trash.wikitext
@@ -3,10 +3,10 @@
 
 <!--T:1-->
 {{Docnav
-|[[BIM_Preflight|Preflight]]
+|[[BIM_Nudge|Nudge]]
 |[[BIM_WPView|WPView]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_Preflight.svg
+|IconL=BIM_Nudge.svg
 |IconR=BIM_WPView.svg
 |IconC=Workbench_BIM.svg
 }}
@@ -26,10 +26,10 @@ The '''BIM Trash''' tool moves the selected objects to the "Trash" group. The Tr
 
 <!--T:5-->
 {{Docnav
-|[[BIM_Preflight|Preflight]]
+|[[BIM_Nudge|Nudge]]
 |[[BIM_WPView|WPView]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_Preflight.svg
+|IconL=BIM_Nudge.svg
 |IconR=BIM_WPView.svg
 |IconC=Workbench_BIM.svg
 }}

--- a/wiki/BIM_Unclone.wikitext
+++ b/wiki/BIM_Unclone.wikitext
@@ -6,7 +6,7 @@
 |[[BIM_Reextrude|Re-Extrude]]
 |[[BIM_Workbench|BIM]]
 |IconL=BIM_Rewire.svg
-|IconR=BIM_Glue.svg
+|IconR=BIM_Reextrude.svg
 |IconC=Workbench_BIM.svg
 }}
 
@@ -42,7 +42,7 @@ This is useful when you have created clones of an object (for example, multiple 
 |[[BIM_Reextrude|Re-Extrude]]
 |[[BIM_Workbench|BIM]]
 |IconL=BIM_Rewire.svg
-|IconR=BIM_Glue.svg
+|IconR=BIM_Reextrude.svg
 |IconC=Workbench_BIM.svg
 }}
 

--- a/wiki/BIM_Unclone.wikitext
+++ b/wiki/BIM_Unclone.wikitext
@@ -3,7 +3,7 @@
 
 {{Docnav
 |[[BIM_Rewire|Rewire]]
-|[[BIM_Glue|Glue]]
+|[[BIM_Reextrude|Re-Extrude]]
 |[[BIM_Workbench|BIM]]
 |IconL=BIM_Rewire.svg
 |IconR=BIM_Glue.svg
@@ -39,7 +39,7 @@ This is useful when you have created clones of an object (for example, multiple 
 
 {{Docnav
 |[[BIM_Rewire|Rewire]]
-|[[BIM_Glue|Glue]]
+|[[BIM_Reextrude|Re-Extrude]]
 |[[BIM_Workbench|BIM]]
 |IconL=BIM_Rewire.svg
 |IconR=BIM_Glue.svg

--- a/wiki/BIM_Workbench.wikitext
+++ b/wiki/BIM_Workbench.wikitext
@@ -611,34 +611,7 @@ This menu contains the [[Draft_Snap|Draft Snap]] tools as well as the following 
 * [[Image:IFC_UpdateIOS.svg|32px]] [[IFC_UpdateIOS|IfcOpenShell Update]]:
 
 <!--T:215-->
-* Nudge:
-
-<!--T:216-->
-:* [[BIM_Nudge_Switch|Nudge Switch]]:
-
-<!--T:217-->
-:* [[BIM_Nudge_Up|Nudge Up]]:
-
-<!--T:218-->
-:* [[BIM_Nudge_Down|Nudge Down]]:
-
-<!--T:219-->
-:* [[BIM_Nudge_Left|Nudge Left]]:
-
-<!--T:220-->
-:* [[BIM_Nudge_Right|Nudge Right]]:
-
-<!--T:221-->
-:* [[BIM_Nudge_RotateLeft|Nudge Rotate Left]]:
-
-<!--T:222-->
-:* [[BIM_Nudge_RotateRight|Nudge Rotate Right]]:
-
-<!--T:223-->
-:* [[BIM_Nudge_Extend|Nudge Extend]]:
-
-<!--T:224-->
-:* [[BIM_Nudge_Shrink|Nudge Shrink]]:
+* [[Image:BIM_Nudge.svg|32px]] [[BIM_Nudge|Nudge]]: A set of commands to move, rotate, and resize objects by small amounts along the current working plane. Includes directional nudge (up/down/left/right), rotation, extend, and shrink variants.
 
 === Status Bar === <!--T:225-->
 


### PR DESCRIPTION
Replaces PR #275 which had merge conflicts.

Fixes broken red links in BIM documentation pages:

1. **BIM_Workbench.wikitext** — Replaced broken links to deleted individual Nudge sub-pages (BIM_Nudge_Switch, BIM_Nudge_Up, etc.) with a single BIM_Nudge reference.

2. **BIM_ImagePlane.wikitext** — Replaced broken [[Draft_Image]] link with [[Import]] which exists in the wiki.

Based on current main. No conflicts. Refs #26.