### PR TITLE
Expand BIM Native IFC preferences documentation

### DIFF
--- a/wiki/en/BIM_Preferences.wikitext
+++ b/wiki/en/BIM_Preferences.wikitext
@@ -31,6 +31,50 @@ Some advanced preferences can only be changed in the [[Std_DlgParameter|Paramete
 
 [[Image:Preferences_BIM_Page_NativeIFC.png]]
 
+The Native IFC preferences control how IFC files are opened as Native IFC projects and how new Native IFC documents, projects and types are created. These settings are different from the older IFC import and export preferences, but the import dialog can store its choices here when the option dialog is disabled.
+
+=== Import ===
+
+The import group defines what FreeCAD creates when an IFC file is opened with the Native IFC workflow:
+
+* {{MenuCommand|Initial import}}: chooses how much of the IFC project tree is expanded immediately:
+** {{MenuCommand|Only root object (default)}}: creates the root IFC project object first and loads child objects on demand.
+** {{MenuCommand|Project structure (levels)}}: creates the project structure, such as levels, during the initial import.
+** {{MenuCommand|All individual IFC objects}}: creates all individual IFC objects immediately.
+* {{MenuCommand|Representation type}}: chooses how object geometry is loaded:
+** {{MenuCommand|Load full shape (slower)}}: loads the complete FreeCAD shape representation.
+** {{MenuCommand|Load 3D representation only, no shape (default)}}: loads the lightweight 3D representation only.
+** {{MenuCommand|No 3D representation}}: opens the model without loading 3D geometry.
+* {{MenuCommand|Switch to BIM workbench after import}}: switches to the BIM Workbench after importing an IFC file.
+* {{MenuCommand|Preload property sets}}, {{MenuCommand|Preload types}}, {{MenuCommand|Preload materials}} and {{MenuCommand|Preload layers}}: loads those IFC data groups automatically when the file is opened. Enabling these can make the model more complete immediately, but may increase opening time for large files.
+* {{MenuCommand|Keep original version of aggregated objects}}: keeps the original object when it is dropped onto an IFC project tree instead of deleting the original during aggregation.
+* {{MenuCommand|Show options dialog when importing}}: shows the Native IFC import options dialog each time. If disabled, the stored Native IFC preferences are applied automatically.
+
+=== Export ===
+
+* {{MenuCommand|Show warning when saving}}: shows a warning before saving Native IFC data back to disk.
+
+=== New Document ===
+
+* {{MenuCommand|Always lock new documents}}: creates new Native IFC documents in single-document mode.
+* {{MenuCommand|Ask every time}}: asks whether to use that mode whenever a new Native IFC document is created.
+
+=== New Project ===
+
+* {{MenuCommand|Create a default structure}}: creates a default project hierarchy when a new Native IFC project is created, adding a site, a building and a storey under the project.
+* {{MenuCommand|Ask every time}}: asks whether to create that default structure whenever a new Native IFC project is created.
+
+=== New Type ===
+
+* {{MenuCommand|Always keep original object when converting to type}}: keeps the original object when converting objects to IFC types.
+* {{MenuCommand|Show dialog when converting to type}}: shows a dialog each time objects are converted to IFC types.
+
+=== Related IFC import preference ===
+
+The separate {{MenuCommand|IFC Import}} preference page contains the {{MenuCommand|Number of cores to use (experimental)}} setting for the classic IFC importer. A value of {{incode|0}} disables multicore mode. Use {{incode|1}} to run the multicore importer in single-core mode, which can be safer if imports crash with multiple cores. For higher values, use at most the number of CPU cores minus one, for example {{incode|3}} on a 4-core CPU.
+
+Native IFC and IFC import/export support require [[IfcOpenShell]]. If IfcOpenShell is not installed, IFC support is disabled or import/export falls back to the available limited behavior depending on the command used.
+
 
 {{Docnav
 |[[BIM_Views|Views]]


### PR DESCRIPTION
## Summary

- Expands the English BIM Preferences wiki page with the currently missing Native IFC preference descriptions.
- Documents the Native IFC import, export, new document, new project, and new type option groups.
- Adds a related note for the classic IFC import multicore setting and the IfcOpenShell dependency.

## Bounty scope

This is a focused slice of #26 covering missing BIM Workbench preference documentation, based on the current BIM preference UI and recent IFC-related BIM updates.

Refs #26

## Validation

- Ran `git diff --check`.
- Checked the edited wikitext for balanced `{{ }}` templates and `[[ ]]` wikilinks.
