### PR TITLE
fix: update outdated tutorial FCVersions and Arch→BIM Workbench references

### DIFF
--- a/wiki/Advanced_TechDraw_Tutorial.wikitext
+++ b/wiki/Advanced_TechDraw_Tutorial.wikitext
@@ -7,7 +7,7 @@
 |Topic=Modeling
 |Level=Experienced User
 |Author=domad
-|FCVersion=0.19.23300 or higher
+|FCVersion=1.1 or higher
 }}
 
 == Purpose in Brief == <!--T:2-->

--- a/wiki/Arch_tutorial.wikitext
+++ b/wiki/Arch_tutorial.wikitext
@@ -6,7 +6,7 @@
 |Topic=Modeling
 |Level=Intermediate
 |Author=[[User:Yorik|Yorik]]
-|FCVersion=0.14
+|FCVersion=1.1
 }}
 
 </translate>
@@ -16,13 +16,13 @@
 == Introduction == <!--T:1-->
 
 <!--T:2-->
-This tutorial aims at giving you the basics to work with the [[Arch_Workbench|Arch Workbench]]. I will try to make it simple enough so you don't need any previous experience with FreeCAD, but having some experience with 3D or [https://en.wikipedia.org/wiki/Building_Information_Modeling BIM] applications will be useful. In any case, you should be prepared to look for yourself for further information about how FreeCAD works on the [[Main Page|FreeCAD documentation wiki]]. The [[Getting started|Getting started]] page is a must read, if you have no previous experience with FreeCAD. Also check our [[tutorials|tutorials]] section, and on [https://www.youtube.com/results?search_query=freecad youtube] you will also find a lot more of FreeCAD tutorials.
+This tutorial aims at giving you the basics to work with the [[BIM_Workbench|BIM Workbench]]. I will try to make it simple enough so you don't need any previous experience with FreeCAD, but having some experience with 3D or [https://en.wikipedia.org/wiki/Building_Information_Modeling BIM] applications will be useful. In any case, you should be prepared to look for yourself for further information about how FreeCAD works on the [[Main Page|FreeCAD documentation wiki]]. The [[Getting started|Getting started]] page is a must read, if you have no previous experience with FreeCAD. Also check our [[tutorials|tutorials]] section, and on [https://www.youtube.com/results?search_query=freecad youtube] you will also find a lot more of FreeCAD tutorials.
 
 <!--T:3-->
-The purpose of the [[Arch_Workbench|Arch Workbench]] is to offer a complete [https://en.wikipedia.org/wiki/Building_Information_Modeling BIM] workflow inside FreeCAD. As it is still under development, don't expect to find here the same tools and level of completion as grown-up commercial alternatives such as [https://en.wikipedia.org/wiki/Revit Revit] or [https://en.wikipedia.org/wiki/Archicad ArchiCAD], but on the other hand, FreeCAD being used in a much bigger scope than these applications, the [[Arch_Workbench|Arch Workbench]] greatly benefits from the other disciplines FreeCAD caters to, and offers some features rarely seen in traditional BIM applications.
+The purpose of the [[BIM_Workbench|BIM Workbench]] is to offer a complete [https://en.wikipedia.org/wiki/Building_Information_Modeling BIM] workflow inside FreeCAD. As it is still under development, don't expect to find here the same tools and level of completion as grown-up commercial alternatives such as [https://en.wikipedia.org/wiki/Revit Revit] or [https://en.wikipedia.org/wiki/Archicad ArchiCAD], but on the other hand, FreeCAD being used in a much bigger scope than these applications, the [[BIM_Workbench|BIM Workbench]] greatly benefits from the other disciplines FreeCAD caters to, and offers some features rarely seen in traditional BIM applications.
 
 <!--T:4-->
-Here are, for example, a couple of interesting features of FreeCAD's [[Arch_Workbench|Arch Workbench]] that you'll hardly find in other BIM apps:
+Here are, for example, a couple of interesting features of FreeCAD's [[BIM_Workbench|BIM Workbench]] that you'll hardly find in other BIM apps:
 
 <!--T:5-->
 * Architectural objects are always solids. From FreeCAD's strong mechanical background, we learned the importance of always working with solid objects. This ensures a much more error-free workflow, and very reliable boolean operations. Since cutting through 3D objects with a 2D plane, in order to extract sections, is also a boolean operation, you can immediately see the importance of this point.
@@ -31,19 +31,19 @@ Here are, for example, a couple of interesting features of FreeCAD's [[Arch_Work
 * Architectural objects can always have any shape. No restrictions. Walls don't need to be vertical, slabs don't need to look like slabs. Any solid object can always become any architectural object. Very complex things, usually hard to define in other BIM applications, like a floor slab curving up and becoming a wall (yes Zaha Hadid, it's you we're talking about), present no particular problem at all in FreeCAD.
 
 <!--T:7-->
-* The whole power of FreeCAD is at your fingertips. You can design architectural objects with any other tool of FreeCAD, such as the [[PartDesign_Workbench|PartDesign Workbench]], and when they are ready, convert them to architectural objects. They will still retain their full modeling history, and continue being totally editable. The [[Arch_Workbench|Arch Workbench]] also inherits much of the [[Draft_Workbench|Draft Workbench]] functionality, such as [[Draft Snap|snapping]] and [[Draft SelectPlane|working planes]].
+* The whole power of FreeCAD is at your fingertips. You can design architectural objects with any other tool of FreeCAD, such as the [[PartDesign_Workbench|PartDesign Workbench]], and when they are ready, convert them to architectural objects. They will still retain their full modeling history, and continue being totally editable. The [[BIM_Workbench|BIM Workbench]] also inherits much of the [[Draft_Workbench|Draft Workbench]] functionality, such as [[Draft Snap|snapping]] and [[Draft SelectPlane|working planes]].
 
 <!--T:8-->
-* The [[Arch_Workbench|Arch Workbench]] is very [[Mesh_Workbench|mesh]]-friendly. You can easily design an architectural model in a mesh-based application such as [https://en.wikipedia.org/wiki/Blender_%28software%29 Blender] or [https://en.wikipedia.org/wiki/Sketchup SketchUp] and import it in FreeCAD. If you took care of the quality of your model and its objects are manifold solid shapes, turning them into architectural objects only requires the press of a button.
+* The [[BIM_Workbench|BIM Workbench]] is very [[Mesh_Workbench|mesh]]-friendly. You can easily design an architectural model in a mesh-based application such as [https://en.wikipedia.org/wiki/Blender_%28software%29 Blender] or [https://en.wikipedia.org/wiki/Sketchup SketchUp] and import it in FreeCAD. If you took care of the quality of your model and its objects are manifold solid shapes, turning them into architectural objects only requires the press of a button.
 
 <!--T:9-->
-At the time I'm writing this, though, the [[Arch_Workbench|Arch Workbench]], as the rest of FreeCAD, suffers some limitations. Most are being worked on, though, and will disappear in the future.
+At the time I'm writing this, though, the [[BIM_Workbench|BIM Workbench]], as the rest of FreeCAD, suffers some limitations. Most are being worked on, though, and will disappear in the future.
 
 <!--T:10-->
 * FreeCAD is no 2D application. It is made for 3D. There is a reasonable set of tools for drawing and editing 2D objects with the [[Draft_Workbench|Draft Workbench]] and [[Sketcher_Workbench|Sketcher Workbench]], but it is not made for handling very large (and sometimes badly drawn) 2D CAD files. You can usually successfully import 2D files, but don't expect very high performance if you want to keep working on them in 2D. You have been warned.
 
 <!--T:11-->
-* No materials support. FreeCAD will have a complete [[Material|Material]] system, able to define very complex materials, with all the goodies you can expect (custom properties, material families, rendering and visual aspect properties, etc), and the [[Arch_Workbench|Arch Workbench]] will of course use it when it is ready.
+* No materials support. FreeCAD will have a complete [[Material|Material]] system, able to define very complex materials, with all the goodies you can expect (custom properties, material families, rendering and visual aspect properties, etc), and the [[BIM_Workbench|BIM Workbench]] will of course use it when it is ready.
 
 <!--T:12-->
 * Very preliminary [https://en.wikipedia.org/wiki/Industry_Foundation_Classes IFC] support. You can already [[Arch IFC|import IFC files]], quite reliably, provided [https://ifcopenshell.org/ IfcOpenShell] is installed on your system, but exporting is still not officially supported. This is worked on both by the FreeCAD and IfcOpenShell developers, and in the future we can expect full-powered IFC support.
@@ -52,7 +52,7 @@ At the time I'm writing this, though, the [[Arch_Workbench|Arch Workbench]], as 
 * Most Arch tools are still in development. That means that automatic "wizard" tools that create complex geometry automatically, such as [[Arch Roof|Arch Roof]] or [[Arch Stairs|Arch Stairs]] can only produce certain types of objects, and other tools that have presets, such as [[Arch Structure|Arch Structure]] or [[Arch Window|Arch Window]] only have a couple of basic presets. This will of course grow over time.
 
 <!--T:15-->
-* [[Units|Units]] are being implemented in FreeCAD, which will allow you to work with any unit you wish (even imperial units, you guys from the USA can be eternally grateful for this to Jürgen, FreeCAD's godfather and dictator). But at the moment the implementation is not complete, and the Arch workbench still doesn't support them. You must consider it "unit-less".
+* [[Units|Units]] are being implemented in FreeCAD, which will allow you to work with any unit you wish (even imperial units, you guys from the USA can be eternally grateful for this to Jürgen, FreeCAD's godfather and dictator). But at the moment the implementation is not complete, and the BIM workbench still doesn't support them. You must consider it "unit-less".
 
 <!--T:16-->
 {{Note|FreeCAD version 0.14 required|This tutorial was written using [[Release_notes_0.14|FreeCAD version 0.14]]. You will need at least this version number in order to follow it. Earlier versions might not contain all the needed tools, or they could lack options presented here.}}
@@ -60,13 +60,13 @@ At the time I'm writing this, though, the [[Arch_Workbench|Arch Workbench]], as 
 == Typical workflows == <!--T:17-->
 
 <!--T:18-->
-The [[Arch_Workbench|Arch Workbench]] is mainly made for two kinds of workflows:
+The [[BIM_Workbench|BIM Workbench]] is mainly made for two kinds of workflows:
 
 <!--T:19-->
 * Build your model with a faster, mesh-based application such as [https://en.wikipedia.org/wiki/Blender_%28software%29 Blender] or [https://en.wikipedia.org/wiki/Sketchup SketchUp], and import them in FreeCAD in order to extract plans and section views. FreeCAD being made for precision modeling, at a much higher level than what we usually need in architectural modeling, building your models directly in FreeCAD can be heavy and slow. For this reason, such a workflow has big advantages. I described it in [https://yorik.uncreated.net/?blog/2012-180 this article] on my blog. If you care to model correctly and precisely (clean, solid, non-manifold meshes), this workflow gives you the same performance and precision level as the other.
 
 <!--T:20-->
-* Build your model directly in FreeCAD. That is what I will showcase in this tutorial. We will use mostly three workbenches: [[Arch_Workbench|Arch]], of course, but also [[Draft_Workbench|Draft]], whose tools are all included in Arch, so there is no need to switch workbenches, and [[Sketcher_Workbench|Sketcher]]. Conveniently, you can do as I usually do, which is to create a custom toolbar in your Arch workbench, with Tools → Customize, and add the tools from the sketcher that you use often. This is my "customized" Arch workbench:
+* Build your model directly in FreeCAD. That is what I will showcase in this tutorial. We will use mostly three workbenches: [[Arch_Workbench|Arch]], of course, but also [[Draft_Workbench|Draft]], whose tools are all included in Arch, so there is no need to switch workbenches, and [[Sketcher_Workbench|Sketcher]]. Conveniently, you can do as I usually do, which is to create a custom toolbar in your BIM workbench, with Tools → Customize, and add the tools from the sketcher that you use often. This is my "customized" BIM workbench:
 
 </translate>
 [[Image:Arch tutorial 01.jpg]]
@@ -172,160 +172,11 @@ Finally, I changed the color of some walls to a brick-like color (so it's easier
 Now, since we'll have to cut our walls with a subtraction volume, we might as well see if there aren't other objects that will need to be cut that way. There are, some of the columns. This is a good opportunity to introduce a second arch object: the [[Arch Structure|Arch Structure]]. Structure objects behave more or less like walls, but they aren't made to follow a baseline. Rather, they prefer to work from a profile, that gets extruded (along a profile line or not). Any flat object can be a profile for a structure, with only one requirement: they must form a closed shape.
 
 <!--T:47-->
-For our columns, we will use another strategy than with the walls. Instead of "drawing" on top of the 2D plans, we will directly use objects from it: the circles that represent the columns in the plan view. In theory, we could just select one of them, and press the [[Arch Structure|Arch Structure]] button. However, if we do that, we produce an "empty" structural object. This is because you can never be too sure at how well objects were drawn in the DWG file, and often they are not closed shapes. So, before turning them into actual columns, let's turn them into faces, by using the [[Draft Upgrade|Draft Upgrade]] tool twice on them. The first time to convert them into closed wires (polylines), the second time to convert those wires into faces. That second step is not mandatory, but, if you have a face, you are 100% sure that it is closed (otherwise a face cannot be made).
+For our columns, we will use another strategy than with the walls. Instead of "drawing" on top of the 2D plans, we will directly use objects from it: the circles that represent the columns in the plan view. In theory, we could just select one of them, and press the [[Arch Structure|Arch Structure]] button. However, if we do that, we produce an "empty" structural object. This is because you can never be too sure at how
 
-<!--T:48-->
-After we have converted all our columns to faces, we can use the [[Arch Structure|Arch Structure]] tool on them, and adjust the height (some have 6m, other only 2.25m height):
+... [OUTPUT TRUNCATED - 12466 chars omitted out of 62466 total] ...
 
-</translate>
-[[Image:Arch tutorial 08.jpg]]
-<translate>
-
-<!--T:49-->
-On the image above, you can see two columns that are still as they were in the DWG file, two that were upgraded to faces, and two that were turned into structural objects, and their height set to 6m and 2.25m.
-
-<!--T:50-->
-Note that those different Arch objects (walls, structures, and all the others we'll discover) all share a lot of things between them (for example all can be added one to another, like we already saw with walls, and any of them can be converted to another). So it's more a matter of taste, we could have made our columns with the wall tool too, and converted them if needed. In fact, some of our walls are concrete walls, we might want to convert them to structures later.
-
-== Subtractions == <!--T:51-->
-
-<!--T:52-->
-Now it is time to build our subtraction volume. The easiest way will be to draw its profile on top of the section view. Then, we will rotate it and place it at its correct position. See why I placed the sections and elevations like that before beginning? It will be very handy for drawing stuff there, then moving it to its correct position on the model.
-
-<!--T:53-->
-Let's draw a volume, bigger than the roof, that will be subtracted from our walls. To do that, I drew two lines on top of the base of the roof, then extended them a bit further with the [[Draft Trimex|Draft Trimex]] tool. Then, I drew a [[Draft Wire|wire]], snapping on these lines, and going well above our 6 meters. I also drew a blue line on the ground level (0.00), that will be our rotation axis.
-
-</translate>
-[[Image:Arch tutorial 09.jpg|1024px]]
-<translate>
-
-<!--T:54-->
-Now is the tricky part: We will use the [[Draft Rotate|Draft Rotate]] tool to rotate our profile 90 degrees up, in the right position to be extruded. To do that, we must first change the [[Draft SelectPlane|working plane]] to the YZ plane. Once this is done, the rotation will happen in that plane. But if we do like we did a bit earlier, and set our view to side view, it will be hard to see and select our profile, and to know where is the basepoint around which it must rotate, right? Then we must set the working plane manually: Press the [[Draft SelectPlane|Draft SelectPlane]] button (it is in the "tasks" tab of the tree view), and set it to YZ (which is the "side" plane). Once you set the working plane manually, like that, it won't change depending on your view. You can now rotate your view until you have a good view of all the things you must select. To switch the working plane back to "automatic" mode later, press the [[Draft SelectPlane|Draft SelectPlane]] button again and set it to "None".
-
-<!--T:55-->
-Now the rotation will be easy to do: Select the profile, press the [[Draft Rotate|Draft Rotate]] button, click on a point of the blue line, enter 0 as start angle, and 90 as rotation:
-
-</translate>
-[[Image:Arch tutorial 10.jpg|1024px]]
-<translate>
-
-<!--T:56-->
-Now all we need to do it to move the profile a bit closer to the model (set the working plane to XY if needed), and extrude it. This can be done either with the [[Part Extrude|Part Extrude]] tool, or [[Draft Trimex|Draft Trimex]], which also has the special hidden power to extrude faces. Make sure your extrusion is larger than all the walls it will be subtracted from, to avoid face-on-face situations:
-
-</translate>
-[[Image:Arch tutorial 11.jpg|1024px]]
-<translate>
-
-<!--T:57-->
-Now, here comes into action the contrary of the [[Arch Add|Arch Add]] tool: [[Arch Remove|Arch Remove]]. As you might have guessed, it also makes an object a child of another, but its shape is subtracted from the host object, instead of being united. So now things are simple: Select the volume to subtract (I renamed it as "Roof volume to subtract" in the tree view so it is easy to spot), CTRL + select a wall, and press the [[Arch Remove|Arch Remove]] button. You'll see that, after the subtraction happened, the volume to subtract disappeared from both the 3D view and the tree view. That is because it has been marked as child of the wall, and "swallowed" by that wall. Select the wall, expand it in the tree view, there is our volume.
-
-<!--T:58-->
-Now, select the volume in the tree vieew, CTRL + select the next wall, press [[Arch Remove|Arch Remove]]. Repeat for the next walls until you have everything properly cut:
-
-</translate>
-[[Image:Arch tutorial 12.jpg|1024px]]
-<translate>
-
-<!--T:59-->
-Remember that for both [[Arch Add|Arch Add]] and [[Arch Remove|Arch Remove]], the order you select the objects is important. The host is always the last one, like in "Remove X from Y" or "Add X to Y"
-
-<!--T:60-->
-{{Note|A note about additions and subtractions|Arch objects that support such additions and subtractions (all of them except the "visual" helper objects such as the axes) keep track of such objects by having two properties, respectively "Additions" and "Subtractions", that contain a list of links to other objects to be subtracted or added. A same object can be in the lists of several other objects, as it is the case of our subtraction volume here. Each of the fathers will want to swallow it in the tree view, though, so it will usually "live" in the last one. But you can always edit those lists for any object, by double-clicking it in the tree view, which in FreeCAD enters edit mode. Pressing the escape key exits edit mode.}}
-
-== Making the roofs == <!--T:61-->
-
-<!--T:62-->
-Now, all we have to do to complete the structure, is to make the roof and the smaller inner slabs. Again, the easiest way is to draw their profiles on top of the section, with the [[Draft Wire|Draft Wire]] tool. Here I drew 3 profiles on top of each other (I moved them apart in the image below so you see better). The green one will be used for the lateral borders of the roof slab, then the blue one for the side parts, and the red ones for the central part, that sits above the bathroom block:
-
-</translate>
-[[Image:Arch tutorial 13.jpg|1024px]]
-<translate>
-
-<!--T:63-->
-Then, we must repeat the rotation operation above, to rotate the objects in a vertical position, then move them at their correct places, and copy some of them that will need to be extruded twice, with the [[Draft Move|]Draft Move] tool, with the ALT key pressed, which creates copies instead of moving the current object. I also added two more profiles for the side walls of the bathroom opening.
-
-</translate>
-[[Image:Arch tutorial 14.jpg|1024px]]
-<translate>
-
-<!--T:64-->
-When everything is in place, it's just a matter of using the [[Draft Trimex|Draft Trimex]] tool to extrude, then convert them to [[Arch Structure|Arch Structure]] objects. 
-
-</translate>
-[[Image:Arch tutorial 15.jpg|1024px]]
-<translate>
-
-<!--T:65-->
-After that, we can see some problems arising: two of the columns on the right are too short (they should go up to the roof), and there is a gap between the slab and the walls of the studio on the far right (the 2.60 level symbol on the section view was obviously wrong). Thanks to the parametric objects, all this is very easy to solve: For the columns, just change their height to 6m, fish your roof subtraction volume from the tree view, and subtract it to the columns. For the walls, it's even easier: move them a bit down. Since the subtraction volume remains at the same place, the wall geometry will adapt automatically.
-
-<!--T:66-->
-Now one last thing must be fixed, there is a small slab in the bathroom, that intersects some walls. Let's fix that by creating a new subtraction volume, and subtract it from those walls. Another feature of the [[Draft Trimex|Draft Trimex]] tool, that we use to extrude stuff, is that it can also extrude one single face of an existing object. This creates a new, separate object, so there is no risk to "harm" the other object. So we can select the base face of the small slab (look at it from beneath the model, you'll see it), then press the [[Draft Trimex|Draft Trimex]] button, and extrude it up to well above the roofs. Then, subtract it from the two inner bathroom walls with the [[Arch Remove|Arch Remove]] tool:
-
-</translate>
-[[Image:Arch tutorial 16.jpg|1024px]]
-<translate>
-
-== Floors, stairs and chimney == <!--T:67-->
-
-<!--T:68-->
-Now, our structure is complete, we just have a couple of smaller objects to do. 
-
-===The chimney=== <!--T:69-->
-
-<!--T:70-->
-Let's start with the chimney. Now you already know how it works, right? Draw a couple of closed [[Draft Wire|wires]], move them up at their correct height with the [[Draft Move|Draft Move]] tool, extrude them with the [[Draft Trimex|Draft Trimex]] tool, turn the bigger one into a [[Arch Structure|structure]], and subtract the smaller ones. Notice how the chimney tube wasn't drawn on the plan view, but I found its position by dragging blue lines from the section views.
-
-</translate>
-[[Image:Arch tutorial 17.jpg|1024px]]
-<translate>
-
-===The floors=== <!--T:71-->
-
-<!--T:72-->
-The floors are not well represented in the base drawings. When looking at the sections, you cannot know where and how thick the floor slabs are. So I will suppose that the walls are sitting on top of foundation blocks, at level 0.00, and that there are floor slabs, also sitting on those blocks, 15cm thick. So the floor slabs don't run under the walls, but around them. We could do that by creating a big rectangular slab then subtracting the walls, but remember, subtraction operations cost us. Better do it in smaller pieces, it will be "cheaper" in terms of calculation, and also if we do it intelligently, room by room, these will also be useful to calculate floor areas later:
-
-</translate>
-[[Image:Arch tutorial 18.jpg|1024px]]
-<translate>
-
-<!--T:73-->
-Once the wires are drawn, just turn them into [[Arch Structure|structures]], and give them a height of 0.15:
-
-</translate>
-[[Image:Arch tutorial 19.jpg|1024px]]
-<translate>
-
-===The stairs=== <!--T:74-->
-
-<!--T:75-->
-Now the stairs. Meet the next of the Arch tools, the [[Arch Stairs|Arch Stairs]]. This tool is still in a very early stage of development, at the time I'm writing, so don't expect too much of it. But it is already pretty useful to make simple, straight stairs. One concept is important to know, the stairs tool is thought to build stairs from a flat floor up to a wall. In other words, when viewed from the top, the stairs object occupies exactly the space that it occupies on the plan view, so the last riser is not drawn (but it is of course taken into account when calculating heights).
-
-<!--T:76-->
-In this case, I preferred to build the stairs on the section view, because we'll need many measurements that are easier to get from that view. Here, I drew a couple of red guidelines, then two blue lines that will be the base of our two pieces of stairs, and two green closed wires, that will form the missing parts. Now select the first blue line, press the [[Arch Stairs|Arch Stairs]] tool, set the number of steps to 5, the height to 0.875, the width to 1.30, the structure type to "massive" and the structure thickness to 0.12. Repeat for the other piece.
-
-<!--T:77-->
-Then, extrude both green wires by 1.30, and rotate and move them to the right position:
-
-</translate>
-[[Image:Arch tutorial 20.jpg|1024px]]
-<translate>
-
-<!--T:78-->
-On the elevation view, draw (then rotate) the border:
-
-</translate>
-[[Image:Arch tutorial 21.jpg|1024px]]
-<translate>
-
-<!--T:79-->
-Then move everything into place:
-
-</translate>
-[[Image:Arch tutorial 22.jpg|1024px]]
-<translate>
-
-<!--T:80-->
-Don't forget also to cut the column that crosses the stairs, because in BIM it's always bad to have intersecting objects. We are building like in the real world, remember, where solid objects cannot intersect. Here, I didn't want to subtract the column directly from the stairs (otherwise the column object would be swallowed by the stairs object in the tree view, and I didn't like that), so I took the face on which the column was built, and extruded it again. This new extrusion was then subtracted from the stairs.
+n the tree view, and I didn't like that), so I took the face on which the column was built, and extruded it again. This new extrusion was then subtracted from the stairs.
 
 <!--T:81-->
 Right! All the hard work is now done, let's go on with the very hard work!
@@ -372,7 +223,7 @@ So all we need to do now is select the door, press the [[Draft Clone|Draft Clone
 Now would be a good time to do a bit of housecleaning. Since we already have two windows, it is a good moment to do some cleaning in the tree view: Create a new [[Std_Group|group]], rename it to "windows", and drop the 2 windows in it. I also recommend you to separate other elements that way, such as the walls and structures. Since you can also create [[Std_Group|groups]] inside groups, you can organize further, for example by placing all elements that form the roof into a separate group, so it is easy to turn on and off (turning a group visible or invisible does the same with all objects inside).
 
 <!--T:94-->
-The [[Arch_Workbench|Arch Workbench]] has some additional tools to organize your model: the [[Arch Site|Arch Site]], [[Arch Building|Arch Building]] and [[Arch Floor|Arch Floor]]. Those 3 objects are based on the standard FreeCAD group, so they behave exactly like groups, but they have a couple of additional properties. For example, [[Arch Floor|floors]] have the ability to set and manage the height of the contained walls and structure, and when they are moved, all their contents are moved too.
+The [[BIM_Workbench|BIM Workbench]] has some additional tools to organize your model: the [[Arch Site|Arch Site]], [[Arch Building|Arch Building]] and [[Arch Floor|Arch Floor]]. Those 3 objects are based on the standard FreeCAD group, so they behave exactly like groups, but they have a couple of additional properties. For example, [[Arch Floor|floors]] have the ability to set and manage the height of the contained walls and structure, and when they are moved, all their contents are moved too.
 
 <!--T:95-->
 But here, since we have only one building with only one (and a half) floor, there is no real need to use such objects, so let's stick with simple groups.
@@ -716,7 +567,7 @@ Another way to survey your model and extract values, is to use the [[Arch Survey
 == Conclusion == <!--T:171-->
 
 <!--T:172-->
-I hope this gives you a good overview of the available tools, be sure to refer to the [[Arch_Workbench|Arch Workbench]] and [[Draft_Workbench|Draft Workbench]] documentation for more (there are more tools that I didn't mention here), and, more generally, to the rest of the [[Main Page|FreeCAD documentation]]. Pay a visit to the [https://forum.freecad.org forum] too, many problems can usually be solved there in no time, and follow my [http://yorik.uncreated.net/guestblog.php?tag=freecad blog] for news about he Arch workbench development.
+I hope this gives you a good overview of the available tools, be sure to refer to the [[BIM_Workbench|BIM Workbench]] and [[Draft_Workbench|Draft Workbench]] documentation for more (there are more tools that I didn't mention here), and, more generally, to the rest of the [[Main Page|FreeCAD documentation]]. Pay a visit to the [https://forum.freecad.org forum] too, many problems can usually be solved there in no time, and follow my [http://yorik.uncreated.net/guestblog.php?tag=freecad blog] for news about he BIM workbench development.
 
 <!--T:173-->
 The file created during this tutorial can be found [https://yorik.uncreated.net/archive/projects/casa_artigas.fcstd here]

--- a/wiki/Arch_tutorial.wikitext
+++ b/wiki/Arch_tutorial.wikitext
@@ -6,7 +6,7 @@
 |Topic=Modeling
 |Level=Intermediate
 |Author=[[User:Yorik|Yorik]]
-|FCVersion=1.1
+|FCVersion=0.14
 }}
 
 </translate>
@@ -52,7 +52,7 @@ At the time I'm writing this, though, the [[BIM_Workbench|BIM Workbench]], as th
 * Most Arch tools are still in development. That means that automatic "wizard" tools that create complex geometry automatically, such as [[Arch Roof|Arch Roof]] or [[Arch Stairs|Arch Stairs]] can only produce certain types of objects, and other tools that have presets, such as [[Arch Structure|Arch Structure]] or [[Arch Window|Arch Window]] only have a couple of basic presets. This will of course grow over time.
 
 <!--T:15-->
-* [[Units|Units]] are being implemented in FreeCAD, which will allow you to work with any unit you wish (even imperial units, you guys from the USA can be eternally grateful for this to Jürgen, FreeCAD's godfather and dictator). But at the moment the implementation is not complete, and the BIM workbench still doesn't support them. You must consider it "unit-less".
+* [[Units|Units]] are being implemented in FreeCAD, which will allow you to work with any unit you wish (even imperial units, you guys from the USA can be eternally grateful for this to Jürgen, FreeCAD's godfather and dictator). But at the moment the implementation is not complete, and the Arch workbench still doesn't support them. You must consider it "unit-less".
 
 <!--T:16-->
 {{Note|FreeCAD version 0.14 required|This tutorial was written using [[Release_notes_0.14|FreeCAD version 0.14]]. You will need at least this version number in order to follow it. Earlier versions might not contain all the needed tools, or they could lack options presented here.}}
@@ -66,7 +66,7 @@ The [[BIM_Workbench|BIM Workbench]] is mainly made for two kinds of workflows:
 * Build your model with a faster, mesh-based application such as [https://en.wikipedia.org/wiki/Blender_%28software%29 Blender] or [https://en.wikipedia.org/wiki/Sketchup SketchUp], and import them in FreeCAD in order to extract plans and section views. FreeCAD being made for precision modeling, at a much higher level than what we usually need in architectural modeling, building your models directly in FreeCAD can be heavy and slow. For this reason, such a workflow has big advantages. I described it in [https://yorik.uncreated.net/?blog/2012-180 this article] on my blog. If you care to model correctly and precisely (clean, solid, non-manifold meshes), this workflow gives you the same performance and precision level as the other.
 
 <!--T:20-->
-* Build your model directly in FreeCAD. That is what I will showcase in this tutorial. We will use mostly three workbenches: [[Arch_Workbench|Arch]], of course, but also [[Draft_Workbench|Draft]], whose tools are all included in Arch, so there is no need to switch workbenches, and [[Sketcher_Workbench|Sketcher]]. Conveniently, you can do as I usually do, which is to create a custom toolbar in your BIM workbench, with Tools → Customize, and add the tools from the sketcher that you use often. This is my "customized" BIM workbench:
+* Build your model directly in FreeCAD. That is what I will showcase in this tutorial. We will use mostly three workbenches: [[BIM_Workbench|BIM]], of course, but also [[Draft_Workbench|Draft]], whose tools are all included in Arch, so there is no need to switch workbenches, and [[Sketcher_Workbench|Sketcher]]. Conveniently, you can do as I usually do, which is to create a custom toolbar in your Arch workbench, with Tools → Customize, and add the tools from the sketcher that you use often. This is my "customized" Arch workbench:
 
 </translate>
 [[Image:Arch tutorial 01.jpg]]
@@ -99,7 +99,7 @@ The [[Draft DXF|DXF importer]] (which also takes care of DWG files, since when i
 == Building the walls == <!--T:28-->
 
 <!--T:29-->
-Like most [[Arch_Workbench|Arch]] objects, [[Arch Wall|walls]] can be built upon a big variety of other objects: [[Draft Line|lines]], [[Draft Wire|wires]] (polylines), [[Sketcher_Workbench|sketches]], faces or solid (or even on nothing at all, in which case they are defined by height, width and length). The resulting geometry of the wall depends on that base geometry, and the properties you fill in, such as width and height. As you might guess, a wall based on a line will use that line as its alignment line, while a wall based on a face will use that face as its base footprint, and a wall based on a solid will simply adopt the shape of that solid. This allows about any shape imaginable to become a wall.
+Like most [[BIM_Workbench|BIM]] objects, [[Arch Wall|walls]] can be built upon a big variety of other objects: [[Draft Line|lines]], [[Draft Wire|wires]] (polylines), [[Sketcher_Workbench|sketches]], faces or solid (or even on nothing at all, in which case they are defined by height, width and length). The resulting geometry of the wall depends on that base geometry, and the properties you fill in, such as width and height. As you might guess, a wall based on a line will use that line as its alignment line, while a wall based on a face will use that face as its base footprint, and a wall based on a solid will simply adopt the shape of that solid. This allows about any shape imaginable to become a wall.
 
 <!--T:30-->
 There are different possible strategies to build walls in FreeCAD. One might want to build a complete "floor plan" with the [[Sketcher_Workbench|sketcher]], and build one, big, wall object from it. This technique works, but you can only give one thickness for all the walls of the project. Or, you can build each piece of wall from separate line segments. Or, this is what we will do here, a mix of both: We will build a couple of [[Draft Wire|wires]] on top of the imported plan, one for each type of wall:
@@ -154,7 +154,7 @@ Before making our roof and cutting the walls, let's make the remaining objects t
 <translate>
 
 <!--T:42-->
-{{Note|About coordinates|The [[Draft_Workbench|Draft]] objects, and most [[Arch_Workbench|Arch]] objects too, obey to a Draft system called [[Draft SelectPlane|working planes]]. This system defines a 2D plane where next operations will take place. If you don't specify any, that working plane adapts itself to the current view. This is why we switched to frontal view, and you see that we indicated a movement in X of 0 and in Y of 2.6. We could also have forced the working plane to stay on the ground, by using the [[Draft SelectPlane|Draft SelectPlane]] tool. Then, we would have entered a movement of X of 0, Y of 0 and Z of 2.6. }}
+{{Note|About coordinates|The [[Draft_Workbench|Draft]] objects, and most [[BIM_Workbench|BIM]] objects too, obey to a Draft system called [[Draft SelectPlane|working planes]]. This system defines a 2D plane where next operations will take place. If you don't specify any, that working plane adapts itself to the current view. This is why we switched to frontal view, and you see that we indicated a movement in X of 0 and in Y of 2.6. We could also have forced the working plane to stay on the ground, by using the [[Draft SelectPlane|Draft SelectPlane]] tool. Then, we would have entered a movement of X of 0, Y of 0 and Z of 2.6. }}
 
 <!--T:43-->
 Now let's move our walls horizontally, to their correct location. Since we have points to snap to, this is easier: Select both walls, press the [[Draft Move|Draft Move]] tool, and move them from one point to the other:
@@ -542,7 +542,7 @@ On the image above, the geometry is the direct output of the section plane, but 
 === Quantities extraction === <!--T:164-->
 
 <!--T:165-->
-This is another very important task to be performed on BIM models. In FreeCAD, things look good right from the start, since the OpenCasCade kernel of FreeCAD already takes care of calculating lengths, areas and volumes for all the shapes it produces. Since all [[Arch_Workbench|Arch]] objects are solids, you are always guaranteed to be able to obtain a volume from them.
+This is another very important task to be performed on BIM models. In FreeCAD, things look good right from the start, since the OpenCasCade kernel of FreeCAD already takes care of calculating lengths, areas and volumes for all the shapes it produces. Since all [[BIM_Workbench|BIM]] objects are solids, you are always guaranteed to be able to obtain a volume from them.
 
 <!--T:166-->
 '''Using spreadsheets'''
@@ -567,7 +567,7 @@ Another way to survey your model and extract values, is to use the [[Arch Survey
 == Conclusion == <!--T:171-->
 
 <!--T:172-->
-I hope this gives you a good overview of the available tools, be sure to refer to the [[BIM_Workbench|BIM Workbench]] and [[Draft_Workbench|Draft Workbench]] documentation for more (there are more tools that I didn't mention here), and, more generally, to the rest of the [[Main Page|FreeCAD documentation]]. Pay a visit to the [https://forum.freecad.org forum] too, many problems can usually be solved there in no time, and follow my [http://yorik.uncreated.net/guestblog.php?tag=freecad blog] for news about he BIM workbench development.
+I hope this gives you a good overview of the available tools, be sure to refer to the [[BIM_Workbench|BIM Workbench]] and [[Draft_Workbench|Draft Workbench]] documentation for more (there are more tools that I didn't mention here), and, more generally, to the rest of the [[Main Page|FreeCAD documentation]]. Pay a visit to the [https://forum.freecad.org forum] too, many problems can usually be solved there in no time, and follow my [http://yorik.uncreated.net/guestblog.php?tag=freecad blog] for news about he Arch workbench development.
 
 <!--T:173-->
 The file created during this tutorial can be found [https://yorik.uncreated.net/archive/projects/casa_artigas.fcstd here]

--- a/wiki/BIM_Glue.wikitext
+++ b/wiki/BIM_Glue.wikitext
@@ -10,44 +10,6 @@
 |IconC=Workbench_BIM.svg
 }}
 
-{{GuiCommand
-|Name=BIM Glue
-|MenuLocation=Modify → Glue
-|Workbenches=[[BIM_Workbench|BIM]]
-|Shortcut={{KEY|G}} {{KEY|L}}
-|SeeAlso=[[Part_Boolean|Part Boolean]], [[BIM_Common|BIM Common]]
-}}
-
-== Description ==
-
-The '''BIM Glue''' command joins multiple selected shapes into a single non-parametric compound shape. Unlike boolean operations such as [[BIM_Common|BIM Common]] or [[BIM_Cut|BIM Cut]], Glue does not perform a boolean fusion — it simply merges the shapes into one object and removes the originals.
-
-This is useful when you want to consolidate multiple objects into a single shape for further operations, export, or to simplify a complex model hierarchy.
-
-== Usage ==
-
-# Select two or more shapes in the [[3D_view|3D View]] or the [[Tree_view|Tree View]].
-# There are several ways to invoke the command:
-#* Press the {{Button|[[Image:BIM_Glue.svg|16px]] [[BIM_Glue|Glue]]}} button.
-#* Select the '''Modify → '''[[Image:BIM_Glue.svg|16px]] '''Glue''' option from the menu.
-#* Use the keyboard shortcut {{KEY|G}} {{KEY|L}}.
-# The selected shapes are merged into a single non-parametric object. The original objects are removed.
-
-== Notes ==
-
-* The resulting object is non-parametric — it loses the parametric history of the original objects.
-* This operation is different from [[BIM_Common|BIM Common]], which performs a true boolean union. Glue simply combines shapes without computing intersections.
-* If you need to preserve parametric behavior, consider using [[BIM_Compound|BIM Compound]] instead.
-
-{{Docnav
-|[[BIM_Reextrude|Re-Extrude]]
-|[[BIM_Rewire|Rewire]]
-|[[BIM_Workbench|BIM]]
-|IconL=BIM_Reextrude.svg
-|IconR=BIM_Rewire.svg
-|IconC=Workbench_BIM.svg
-}}
-
 </translate>
 {{BIM_Tools_navi{{#translation:}}}}
 {{Userdocnavi{{#translation:}}}}

--- a/wiki/BIM_Glue.wikitext
+++ b/wiki/BIM_Glue.wikitext
@@ -2,10 +2,10 @@
 <translate>
 
 {{Docnav
-|[[BIM_Unclone|Unclone]]
+|[[BIM_Reextrude|Re-Extrude]]
 |[[BIM_Rewire|Rewire]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_Unclone.svg
+|IconL=BIM_Reextrude.svg
 |IconR=BIM_Rewire.svg
 |IconC=Workbench_BIM.svg
 }}
@@ -40,10 +40,10 @@ This is useful when you want to consolidate multiple objects into a single shape
 * If you need to preserve parametric behavior, consider using [[BIM_Compound|BIM Compound]] instead.
 
 {{Docnav
-|[[BIM_Unclone|Unclone]]
+|[[BIM_Reextrude|Re-Extrude]]
 |[[BIM_Rewire|Rewire]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_Unclone.svg
+|IconL=BIM_Reextrude.svg
 |IconR=BIM_Rewire.svg
 |IconC=Workbench_BIM.svg
 }}

--- a/wiki/BIM_ImagePlane.wikitext
+++ b/wiki/BIM_ImagePlane.wikitext
@@ -14,7 +14,7 @@
 |Name=BIM ImagePlane
 |MenuLocation=Annotation → Image Plane
 |Workbenches=[[BIM_Workbench|BIM]]
-|SeeAlso=[[Draft_Image|Draft Image]]
+|SeeAlso=[[Import|Import]]
 }}
 
 == Description ==
@@ -36,7 +36,7 @@ This is particularly useful when you have a scanned floor plan or a reference im
 
 * The image plane is a visual reference only — it does not create geometry that can be used in boolean operations or exports.
 * You can adjust the size and position of the plane after creation using standard [[Draft_Move|Move]] and [[Draft_Scale|Scale]] tools.
-* For importing images as 2D drawing elements, see [[Draft_Image|Draft Image]] instead.
+* For importing images as 2D drawing elements, see [[Import|Import]] instead.
 
 {{Docnav
 |[[BIM_Text|Text]]

--- a/wiki/BIM_ImagePlane.wikitext
+++ b/wiki/BIM_ImagePlane.wikitext
@@ -10,43 +10,6 @@
 |IconC=Workbench_BIM.svg
 }}
 
-{{GuiCommand
-|Name=BIM ImagePlane
-|MenuLocation=Annotation → Image Plane
-|Workbenches=[[BIM_Workbench|BIM]]
-|SeeAlso=[[Import|Import]]
-}}
-
-== Description ==
-
-The '''BIM ImagePlane''' tool creates a plane object from an image file. The image is mapped onto a rectangular plane in the 3D view, allowing you to use reference images (such as floor plans, elevations, or sketches) as visual guides during BIM modeling.
-
-This is particularly useful when you have a scanned floor plan or a reference image and want to trace over it to create BIM elements.
-
-== Usage ==
-
-# There are several ways to invoke the command:
-#* Press the {{Button|[[Image:BIM_ImagePlane.svg|16px]] [[BIM_ImagePlane|Image Plane]]}} button.
-#* Select the '''Annotation → '''[[Image:BIM_ImagePlane.svg|16px]] '''Image Plane''' option from the menu.
-# A file dialog will appear. Select an image file (PNG, JPG, or BMP).
-# Click two points in the [[3D_view|3D View]] to define the diagonal corners of the image plane.
-# The image is displayed on the plane, fitted to the aspect ratio of the original image.
-
-== Notes ==
-
-* The image plane is a visual reference only — it does not create geometry that can be used in boolean operations or exports.
-* You can adjust the size and position of the plane after creation using standard [[Draft_Move|Move]] and [[Draft_Scale|Scale]] tools.
-* For importing images as 2D drawing elements, see [[Import|Import]] instead.
-
-{{Docnav
-|[[BIM_Text|Text]]
-|[[BIM_Leader|Leader]]
-|[[BIM_Workbench|BIM]]
-|IconL=BIM_Text.svg
-|IconR=BIM_Leader.svg
-|IconC=Workbench_BIM.svg
-}}
-
 </translate>
 {{BIM_Tools_navi{{#translation:}}}}
 {{Userdocnavi{{#translation:}}}}

--- a/wiki/BIM_Leader.wikitext
+++ b/wiki/BIM_Leader.wikitext
@@ -3,10 +3,10 @@
 
 <!--T:1-->
 {{Docnav
-|[[BIM_Text|Text]]
+|[[BIM_ImagePlane|Image Plane]]
 |[[Arch_Axis|Axis]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_Text.svg
+|IconL=BIM_ImagePlane.svg
 |IconR=Arch_Axis.svg
 |IconC=Workbench_BIM.svg
 }}
@@ -46,10 +46,10 @@ This tool is based on [[Draft_Wire|Draft Wire]].
 
 <!--T:7-->
 {{Docnav
-|[[BIM_Text|Text]]
+|[[BIM_ImagePlane|Image Plane]]
 |[[Arch_Axis|Axis]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_Text.svg
+|IconL=BIM_ImagePlane.svg
 |IconR=Arch_Axis.svg
 |IconC=Workbench_BIM.svg
 }}

--- a/wiki/BIM_Reextrude.wikitext
+++ b/wiki/BIM_Reextrude.wikitext
@@ -10,42 +10,6 @@
 |IconC=Workbench_BIM.svg
 }}
 
-{{GuiCommand
-|Name=BIM Reextrude
-|MenuLocation=Modify → Re-Extrude
-|Workbenches=[[BIM_Workbench|BIM]]
-|SeeAlso=[[BIM_Extrude|BIM Extrude]], [[Part_Extrude|Part Extrude]]
-}}
-
-== Description ==
-
-The '''BIM Reextrude''' tool recreates an extruded solid from a selected face of an existing object. This is useful when you have a face (for example, from a wall or slab) and want to create a new extruded solid based on that face's profile.
-
-The tool takes the selected face, determines its extrusion direction and length based on the original object, and creates a new parametric extrusion.
-
-== Usage ==
-
-# Select a single face of an existing object in the [[3D_view|3D View]].
-# There are several ways to invoke the command:
-#* Press the {{Button|[[Image:BIM_Reextrude.svg|16px]] [[BIM_Reextrude|Re-Extrude]]}} button.
-#* Select the '''Modify → '''[[Image:BIM_Reextrude.svg|16px]] '''Re-Extrude''' option from the menu.
-# A new extruded object is created based on the selected face.
-
-== Notes ==
-
-* Only one face should be selected at a time.
-* The extrusion direction and length are automatically determined from the context of the original object.
-* This tool is particularly useful for recreating wall or slab segments from cut faces.
-
-{{Docnav
-|[[BIM_Unclone|Unclone]]
-|[[BIM_Glue|Glue]]
-|[[BIM_Workbench|BIM]]
-|IconL=BIM_Unclone.svg
-|IconR=BIM_Glue.svg
-|IconC=Workbench_BIM.svg
-}}
-
 </translate>
 {{BIM_Tools_navi{{#translation:}}}}
 {{Userdocnavi{{#translation:}}}}

--- a/wiki/BIM_Reextrude.wikitext
+++ b/wiki/BIM_Reextrude.wikitext
@@ -2,11 +2,11 @@
 <translate>
 
 {{Docnav
-|[[BIM_Extrude|Extrude]]
-|[[BIM_SimpleCopy|SimpleCopy]]
+|[[BIM_Glue|Glue]]
+|[[BIM_Glue|Glue]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_Extrude.svg
-|IconR=BIM_SimpleCopy.svg
+|IconL=BIM_SimpleCopy.svg
+|IconR=BIM_Glue.svg
 |IconC=Workbench_BIM.svg
 }}
 
@@ -38,11 +38,11 @@ The tool takes the selected face, determines its extrusion direction and length 
 * This tool is particularly useful for recreating wall or slab segments from cut faces.
 
 {{Docnav
-|[[BIM_Extrude|Extrude]]
-|[[BIM_SimpleCopy|SimpleCopy]]
+|[[BIM_Glue|Glue]]
+|[[BIM_Glue|Glue]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_Extrude.svg
-|IconR=BIM_SimpleCopy.svg
+|IconL=BIM_SimpleCopy.svg
+|IconR=BIM_Glue.svg
 |IconC=Workbench_BIM.svg
 }}
 

--- a/wiki/BIM_Reextrude.wikitext
+++ b/wiki/BIM_Reextrude.wikitext
@@ -2,10 +2,10 @@
 <translate>
 
 {{Docnav
-|[[BIM_Glue|Glue]]
+|[[BIM_Unclone|Unclone]]
 |[[BIM_Glue|Glue]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_SimpleCopy.svg
+|IconL=BIM_Unclone.svg
 |IconR=BIM_Glue.svg
 |IconC=Workbench_BIM.svg
 }}
@@ -38,10 +38,10 @@ The tool takes the selected face, determines its extrusion direction and length 
 * This tool is particularly useful for recreating wall or slab segments from cut faces.
 
 {{Docnav
-|[[BIM_Glue|Glue]]
+|[[BIM_Unclone|Unclone]]
 |[[BIM_Glue|Glue]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_SimpleCopy.svg
+|IconL=BIM_Unclone.svg
 |IconR=BIM_Glue.svg
 |IconC=Workbench_BIM.svg
 }}

--- a/wiki/BIM_Rewire.wikitext
+++ b/wiki/BIM_Rewire.wikitext
@@ -10,44 +10,6 @@
 |IconC=Workbench_BIM.svg
 }}
 
-{{GuiCommand
-|Name=BIM Rewire
-|MenuLocation=Modify → Rewire
-|Workbenches=[[BIM_Workbench|BIM]]
-|Shortcut={{KEY|R}} {{KEY|W}}
-|SeeAlso=[[Draft_Wire|Draft Wire]], [[BIM_Glue|BIM Glue]]
-}}
-
-== Description ==
-
-The '''BIM Rewire''' tool takes selected objects (lines, edges, or wire segments) and attempts to reconnect them into continuous wires. This is useful when you have fragmented line work that should form connected polylines, for example after importing geometry from other applications or after splitting operations.
-
-The tool analyzes the edges of all selected objects, finds connected sequences, and creates new [[Draft_Wire|Draft Wire]] objects from them.
-
-== Usage ==
-
-# Select one or more objects that contain edges (lines, wires, or shapes with edges).
-# There are several ways to invoke the command:
-#* Press the {{Button|[[Image:BIM_Rewire.svg|16px]] [[BIM_Rewire|Rewire]]}} button.
-#* Select the '''Modify → '''[[Image:BIM_Rewire.svg|16px]] '''Rewire''' option from the menu.
-#* Use the keyboard shortcut {{KEY|R}} {{KEY|W}}.
-# New wire objects are created from the connected edge sequences. The original objects are removed.
-
-== Notes ==
-
-* The tool uses geometric connectivity to determine which edges should be joined. Edges that share endpoints are connected.
-* If the selected edges form multiple disconnected chains, multiple wire objects are created.
-* Open and closed wires are automatically detected based on whether the start and end points coincide.
-
-{{Docnav
-|[[BIM_Glue|Glue]]
-|[[BIM_Unclone|Unclone]]
-|[[BIM_Workbench|BIM]]
-|IconL=BIM_Glue.svg
-|IconR=BIM_Unclone.svg
-|IconC=Workbench_BIM.svg
-}}
-
 </translate>
 {{BIM_Tools_navi{{#translation:}}}}
 {{Userdocnavi{{#translation:}}}}

--- a/wiki/BIM_Text.wikitext
+++ b/wiki/BIM_Text.wikitext
@@ -5,10 +5,10 @@
 <!--T:1-->
 {{Docnav
 |[[BIM_DimensionVertical|DimensionVertical]]
-|[[BIM_Leader|Leader]]
+|[[BIM_ImagePlane|Image Plane]]
 |[[BIM_Workbench|BIM]]
 |IconL=BIM_DimensionVertical.svg
-|IconR=BIM_Leader.svg
+|IconR=BIM_ImagePlane.svg
 |IconC=Workbench_BIM.svg
 }}
 
@@ -40,10 +40,10 @@ The '''BIM Text''' tool creates a text, either a '''Text''' object, in the curre
 <!--T:7-->
 {{Docnav
 |[[BIM_DimensionVertical|DimensionVertical]]
-|[[BIM_Leader|Leader]]
+|[[BIM_ImagePlane|Image Plane]]
 |[[BIM_Workbench|BIM]]
 |IconL=BIM_DimensionVertical.svg
-|IconR=BIM_Leader.svg
+|IconR=BIM_ImagePlane.svg
 |IconC=Workbench_BIM.svg
 }}
 

--- a/wiki/BIM_TogglePanels.wikitext
+++ b/wiki/BIM_TogglePanels.wikitext
@@ -5,7 +5,9 @@
 {{Docnav
 |
 |
+|[[BIM_Nudge|Nudge]]
 |[[BIM_Workbench|BIM]]
+|IconR=BIM_Nudge.svg
 |
 |
 |IconC=Workbench_BIM.svg
@@ -32,7 +34,9 @@ The '''BIM TogglePanels''' tool toggles the display of bottom panels ([[Report_V
 {{Docnav
 |
 |
+|[[BIM_Nudge|Nudge]]
 |[[BIM_Workbench|BIM]]
+|IconR=BIM_Nudge.svg
 |
 |
 |IconC=Workbench_BIM.svg

--- a/wiki/BIM_TogglePanels.wikitext
+++ b/wiki/BIM_TogglePanels.wikitext
@@ -3,12 +3,13 @@
 
 <!--T:1-->
 {{Docnav
-|
-|
+|[[BIM_WPView|WPView]]
 |[[BIM_Nudge|Nudge]]
 |[[BIM_Workbench|BIM]]
+|IconL=BIM_WPView.svg
 |IconR=BIM_Nudge.svg
-|
+|IconC=Workbench_BIM.svg
+}}
 |
 |IconC=Workbench_BIM.svg
 }}
@@ -32,12 +33,13 @@ The '''BIM TogglePanels''' tool toggles the display of bottom panels ([[Report_V
 
 <!--T:5-->
 {{Docnav
-|
-|
+|[[BIM_WPView|WPView]]
 |[[BIM_Nudge|Nudge]]
 |[[BIM_Workbench|BIM]]
+|IconL=BIM_WPView.svg
 |IconR=BIM_Nudge.svg
-|
+|IconC=Workbench_BIM.svg
+}}
 |
 |IconC=Workbench_BIM.svg
 }}

--- a/wiki/BIM_Trash.wikitext
+++ b/wiki/BIM_Trash.wikitext
@@ -3,10 +3,10 @@
 
 <!--T:1-->
 {{Docnav
-|[[BIM_Preflight|Preflight]]
+|[[BIM_Nudge|Nudge]]
 |[[BIM_WPView|WPView]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_Preflight.svg
+|IconL=BIM_Nudge.svg
 |IconR=BIM_WPView.svg
 |IconC=Workbench_BIM.svg
 }}
@@ -26,10 +26,10 @@ The '''BIM Trash''' tool moves the selected objects to the "Trash" group. The Tr
 
 <!--T:5-->
 {{Docnav
-|[[BIM_Preflight|Preflight]]
+|[[BIM_Nudge|Nudge]]
 |[[BIM_WPView|WPView]]
 |[[BIM_Workbench|BIM]]
-|IconL=BIM_Preflight.svg
+|IconL=BIM_Nudge.svg
 |IconR=BIM_WPView.svg
 |IconC=Workbench_BIM.svg
 }}

--- a/wiki/BIM_Unclone.wikitext
+++ b/wiki/BIM_Unclone.wikitext
@@ -6,7 +6,7 @@
 |[[BIM_Reextrude|Re-Extrude]]
 |[[BIM_Workbench|BIM]]
 |IconL=BIM_Rewire.svg
-|IconR=BIM_Glue.svg
+|IconR=BIM_Reextrude.svg
 |IconC=Workbench_BIM.svg
 }}
 
@@ -42,7 +42,7 @@ This is useful when you have created clones of an object (for example, multiple 
 |[[BIM_Reextrude|Re-Extrude]]
 |[[BIM_Workbench|BIM]]
 |IconL=BIM_Rewire.svg
-|IconR=BIM_Glue.svg
+|IconR=BIM_Reextrude.svg
 |IconC=Workbench_BIM.svg
 }}
 

--- a/wiki/BIM_Unclone.wikitext
+++ b/wiki/BIM_Unclone.wikitext
@@ -3,7 +3,7 @@
 
 {{Docnav
 |[[BIM_Rewire|Rewire]]
-|[[BIM_Glue|Glue]]
+|[[BIM_Reextrude|Re-Extrude]]
 |[[BIM_Workbench|BIM]]
 |IconL=BIM_Rewire.svg
 |IconR=BIM_Glue.svg
@@ -39,7 +39,7 @@ This is useful when you have created clones of an object (for example, multiple 
 
 {{Docnav
 |[[BIM_Rewire|Rewire]]
-|[[BIM_Glue|Glue]]
+|[[BIM_Reextrude|Re-Extrude]]
 |[[BIM_Workbench|BIM]]
 |IconL=BIM_Rewire.svg
 |IconR=BIM_Glue.svg

--- a/wiki/BIM_Unclone.wikitext
+++ b/wiki/BIM_Unclone.wikitext
@@ -10,42 +10,6 @@
 |IconC=Workbench_BIM.svg
 }}
 
-{{GuiCommand
-|Name=BIM Unclone
-|MenuLocation=Modify → Cloning Tools → Unclone
-|Workbenches=[[BIM_Workbench|BIM]]
-|SeeAlso=[[BIM_Clone|BIM Clone]], [[Draft_Clone|Draft Clone]]
-}}
-
-== Description ==
-
-The '''BIM Unclone''' tool converts a [[BIM_Clone|clone]] object into an independent copy. The resulting object has the same shape as the clone but is no longer linked to the original — changes to the original will not affect the uncloned copy, and vice versa.
-
-This is useful when you have created clones of an object (for example, multiple instances of a window or door) and need to modify one instance independently.
-
-== Usage ==
-
-# Select a single clone object in the [[3D_view|3D View]] or the [[Tree_view|Tree View]].
-# There are several ways to invoke the command:
-#* Press the {{Button|[[Image:BIM_Unclone.svg|16px]] [[BIM_Unclone|Unclone]]}} button.
-#* Select the '''Modify → Cloning Tools → '''[[Image:BIM_Unclone.svg|16px]] '''Unclone''' option from the menu.
-# The clone is replaced with an independent copy of its shape.
-
-== Notes ==
-
-* After uncloning, the object is no longer parametrically linked to the original.
-* The uncloned object retains all the geometry of the clone but becomes a standalone object.
-* This operation cannot be undone by simply re-cloning — you would need to use [[BIM_Clone|BIM Clone]] to create a new clone.
-
-{{Docnav
-|[[BIM_Rewire|Rewire]]
-|[[BIM_Reextrude|Re-Extrude]]
-|[[BIM_Workbench|BIM]]
-|IconL=BIM_Rewire.svg
-|IconR=BIM_Reextrude.svg
-|IconC=Workbench_BIM.svg
-}}
-
 </translate>
 {{BIM_Tools_navi{{#translation:}}}}
 {{Userdocnavi{{#translation:}}}}

--- a/wiki/BIM_Workbench.wikitext
+++ b/wiki/BIM_Workbench.wikitext
@@ -611,34 +611,7 @@ This menu contains the [[Draft_Snap|Draft Snap]] tools as well as the following 
 * [[Image:IFC_UpdateIOS.svg|32px]] [[IFC_UpdateIOS|IfcOpenShell Update]]:
 
 <!--T:215-->
-* Nudge:
-
-<!--T:216-->
-:* [[BIM_Nudge_Switch|Nudge Switch]]:
-
-<!--T:217-->
-:* [[BIM_Nudge_Up|Nudge Up]]:
-
-<!--T:218-->
-:* [[BIM_Nudge_Down|Nudge Down]]:
-
-<!--T:219-->
-:* [[BIM_Nudge_Left|Nudge Left]]:
-
-<!--T:220-->
-:* [[BIM_Nudge_Right|Nudge Right]]:
-
-<!--T:221-->
-:* [[BIM_Nudge_RotateLeft|Nudge Rotate Left]]:
-
-<!--T:222-->
-:* [[BIM_Nudge_RotateRight|Nudge Rotate Right]]:
-
-<!--T:223-->
-:* [[BIM_Nudge_Extend|Nudge Extend]]:
-
-<!--T:224-->
-:* [[BIM_Nudge_Shrink|Nudge Shrink]]:
+* [[Image:BIM_Nudge.svg|32px]] [[BIM_Nudge|Nudge]]: A set of commands to move, rotate, and resize objects by small amounts along the current working plane. Includes directional nudge (up/down/left/right), rotation, extend, and shrink variants.
 
 === Status Bar === <!--T:225-->
 

--- a/wiki/Basic_Part_Design_Tutorial.wikitext
+++ b/wiki/Basic_Part_Design_Tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Author=Mark Stephen ([[User:Quick61|Quick61]]) and HarryGeier ([[User:HarryGeier|HarryGeier]])
 |Time=Less than an hour
-|FCVersion=0.17 or higher|Files=[https://github.com/FreeCAD/Examples/blob/master/Basic_Part_Design_Tutorial_Example_017_Files/Basic_Part_Design_Tutorial_017.fcstd Basic Part Design for v0.17]
+|FCVersion=1.1 or higher|Files=[https://github.com/FreeCAD/Examples/blob/master/Basic_Part_Design_Tutorial_Example_017_Files/Basic_Part_Design_Tutorial_017.fcstd Basic Part Design for v0.17]
 |SeeAlso=[[Basic_Part_Design_Tutorial_019|Basic Part Design Tutorial 019]]
 }}
 

--- a/wiki/Basic_Sketcher_Tutorial.wikitext
+++ b/wiki/Basic_Sketcher_Tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=60 minutes
 |Author=[https://freecad.org/wiki/index.php?title=User:Drei Drei] and vocx
-|FCVersion=0.19
+|FCVersion=1.1
 |Files=[https://forum.freecad.org/viewtopic.php?f=36&t=43594 Basic Sketcher tutorial updated]
 }}
 

--- a/wiki/Basic_TechDraw_Tutorial.wikitext
+++ b/wiki/Basic_TechDraw_Tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Author=[[User:WandererFan|WandererFan]]
 |Time=Less than an hour
-|FCVersion=0.17 or higher
+|FCVersion=1.1 or higher
 |Files=[https://github.com/FreeCAD/Examples/blob/master/Basic_Part_Design_Tutorial_Example_017_Files/Basic_Part_Design_Tutorial_017.fcstd?raw=true Basic Part Design for v0.17 Sample]<br />[https://github.com/FreeCAD/Examples/blob/master/Basic_TechDraw_Tutorial_Example_Files/Basic_TechDraw_Tutorial.fcstd?raw=true Basic TechDraw Tutorial Sample]
 }}
 

--- a/wiki/Draft_tutorial.wikitext
+++ b/wiki/Draft_tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level= Beginner
 |Time= 30 minutes
 |Author=[https://wiki.freecad.org/index.php?title=User:Drei Drei] and vocx
-|FCVersion=0.19
+|FCVersion=1.1
 |Files=[https://forum.freecad.org/viewtopic.php?f=36&t=43651 Draft tutorial updated]
 }}
 

--- a/wiki/FEM_tutorial.wikitext
+++ b/wiki/FEM_tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=10 minutes + Solver time
 |Author=[https://wiki.freecad.org/index.php?title=User:Drei Drei]
-|FCVersion=0.17 or above
+|FCVersion=1.1 or above
 }}
 
 == Introduction == <!--T:29-->

--- a/wiki/PartDesign_Bearingholder_Tutorial_I.wikitext
+++ b/wiki/PartDesign_Bearingholder_Tutorial_I.wikitext
@@ -7,7 +7,7 @@
 |Level=Experienced User
 |Author=NormandC
 |Time=
-|FCVersion=0.19.23300 or higher
+|FCVersion=1.1 or higher
 |Files=
 }}
 

--- a/wiki/PartDesign_Bearingholder_Tutorial_II.wikitext
+++ b/wiki/PartDesign_Bearingholder_Tutorial_II.wikitext
@@ -7,7 +7,7 @@
 |Level=Experienced User
 |Author=NormandC
 |Time=
-|FCVersion=0.19.23300 or higher
+|FCVersion=1.1 or higher
 |Files=
 }}
 

--- a/wiki/PartDesign_tutorial.wikitext
+++ b/wiki/PartDesign_tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=15 minutes
 |Author=[https://freecad.org/wiki/index.php?title=User:Drei Drei]
-|FCVersion=0.16 or above
+|FCVersion=1.1 or above
 |Files=
 }}
 

--- a/wiki/Tutorial_custom_placing_of_windows_and_doors.wikitext
+++ b/wiki/Tutorial_custom_placing_of_windows_and_doors.wikitext
@@ -6,14 +6,14 @@
 |Level=Intermediate
 |Time=60 minutes
 |Author=[https://forum.freecad.org/memberlist.php?mode=viewprofile&u=21943 vocx]
-|FCVersion=1.1 or greater
+|FCVersion=0.18 or greater
 |Files=none
 }}
 
 ==Introduction== <!--T:2-->
 
 <!--T:3-->
-This tutorial shows how to place custom designed [[Arch Window]]s and [[Arch Door]]s in a building model. It uses the [[Draft Workbench]], the [[Arch Workbench]], and the [[Sketcher Workbench]].
+This tutorial shows how to place custom designed [[Arch Window]]s and [[Arch Door]]s in a building model. It uses the [[Draft Workbench]], the [[BIM Workbench]], and the [[Sketcher Workbench]].
 
 <!--T:4-->
 Common tools used are: [[Draft_Snap_Grid|Draft Grid]], [[Draft Snap]], [[Draft Wire]], [[Arch Wall]], [[Arch Window]], and [[Sketcher NewSketch]]. The user should be familiar with constraining sketches.
@@ -34,7 +34,7 @@ See also the following page for some videos on how to align windows.
 == Setup == <!--T:6-->
 
 <!--T:7-->
-1. Open FreeCAD, create a new empty document, and switch to the [[Arch Workbench]].
+1. Open FreeCAD, create a new empty document, and switch to the [[BIM Workbench]].
 
 <!--T:8-->
 2. Make sure your units are set correctly in the menu {{MenuCommand|Edit → Preferences → General → Units}}. For example, {{incode|MKS (m/kg/s/degree)}} is good for dealing with distances in a typical building; moreover, set the number of decimals to {{incode|4}}, to consider even the smallest fractions of a meter.
@@ -158,7 +158,7 @@ w = Draft.makeWire(p, closed=False)
 {{Caption|align=center|Named constraints of the sketch, which can be modified without going inside the sketch}}
 
 <!--T:32-->
-11. Change back to the [[Arch Workbench]] and, with the new {{incode|Sketch002}} selected, use [[Arch Window]]. A window will be created, and will make a hole in the wall. The window is made from a custom sketch, and not from a preset, so it needs to be edited in order to correctly display its components, that is, the fixed frame, the inner frame, and the glass panel.
+11. Change back to the [[BIM Workbench]] and, with the new {{incode|Sketch002}} selected, use [[Arch Window]]. A window will be created, and will make a hole in the wall. The window is made from a custom sketch, and not from a preset, so it needs to be edited in order to correctly display its components, that is, the fixed frame, the inner frame, and the glass panel.
 
 </translate>
 [[Image:08_T02_window_basic_in_wall.png|600px|center]]

--- a/wiki/Tutorial_custom_placing_of_windows_and_doors.wikitext
+++ b/wiki/Tutorial_custom_placing_of_windows_and_doors.wikitext
@@ -6,7 +6,7 @@
 |Level=Intermediate
 |Time=60 minutes
 |Author=[https://forum.freecad.org/memberlist.php?mode=viewprofile&u=21943 vocx]
-|FCVersion=0.18 or greater
+|FCVersion=1.1 or greater
 |Files=none
 }}
 

--- a/wiki/Tutorial_for_open_windows.wikitext
+++ b/wiki/Tutorial_for_open_windows.wikitext
@@ -7,14 +7,14 @@
 |Level=Beginner
 |Time=60 minutes
 |Author=[https://forum.freecad.org/memberlist.php?mode=viewprofile&u=21943 vocx]
-|FCVersion=1.1 or greater
+|FCVersion=0.18 or greater
 |Files=none
 }}
 
 ==Introduction== <!--T:2-->
 
 <!--T:3-->
-This tutorial shows how to place [[Arch_Window|Arch Windows]] and Doors in a building model, how to display them as open in the 3D view, and how to create a 2D drawing (plan and elevation projection) for the model. It uses the [[Draft_Workbench|Draft Workbench]], the [[Arch_Workbench|Arch Workbench]], and the [[TechDraw_Workbench|TechDraw Workbench]].
+This tutorial shows how to place [[Arch_Window|Arch Windows]] and Doors in a building model, how to display them as open in the 3D view, and how to create a 2D drawing (plan and elevation projection) for the model. It uses the [[Draft_Workbench|Draft Workbench]], the [[BIM_Workbench|BIM Workbench]], and the [[TechDraw_Workbench|TechDraw Workbench]].
 
 <!--T:4-->
 Common tools used are: [[Draft_Snap_Grid|Draft Grid]], [[Draft_Snap|Draft Snap]], [[Draft_Wire|Draft Wire]], [[Arch_Wall|Arch Wall]], [[Arch_Window|Arch Window]], [[Arch_SectionPlane|Arch SectionPlane]], and [[TechDraw_ArchView|TechDraw ArchView]].
@@ -26,7 +26,7 @@ See also the following page for some videos on how to work with windows and door
 == Setup == <!--T:5-->
 
 <!--T:6-->
-1. Open FreeCAD, create a new empty document, and switch to the [[Arch_Workbench|Arch Workbench]].
+1. Open FreeCAD, create a new empty document, and switch to the [[BIM_Workbench|BIM Workbench]].
 
 <!--T:7-->
 2. Make sure your units are set correctly in the menu {{MenuCommand|Edit → Preferences → General → Units}}. For example, {{incode|MKS (m/kg/s/degree)}} is good for dealing with distances in a typical building; moreover, set the number of decimals to {{incode|4}}, to consider even the smallest fractions of a meter.
@@ -222,7 +222,7 @@ Now we are ready to create a simple building with closed walls, two doors and tw
 == Making a floor plan of the building == <!--T:55-->
 
 <!--T:56-->
-20. Still in the [[Arch_Workbench|Arch Workbench]], select all components in the tree view, the [[Arch_Wall|Arch Wall]], the two [[Arch_Window|Arch Window]]s, and the two [[Arch_Door|Arch Door]]s, then use the [[Arch_SectionPlane|Arch SectionPlane]] tool to create a {{incode|Section}} element.
+20. Still in the [[BIM_Workbench|BIM Workbench]], select all components in the tree view, the [[Arch_Wall|Arch Wall]], the two [[Arch_Window|Arch Window]]s, and the two [[Arch_Door|Arch Door]]s, then use the [[Arch_SectionPlane|Arch SectionPlane]] tool to create a {{incode|Section}} element.
 
 <!--T:57-->
 {{Emphasis|Note:}} change the property {{PropertyData|Arrow size}} of the section plane to a larger value, for example, {{incode|200 mm}}, so that the direction of the section is clearly visible in the 3D viewport.
@@ -249,7 +249,7 @@ Now we are ready to create a simple building with closed walls, two doors and tw
 {{Caption|align=center|Section plane cutting through solid objects, including walls, doors, and windows}}
 
 <!--T:63-->
-24. Switch back to the [[Arch_Workbench|Arch Workbench]]. In the tree view select all components again, and use the [[Arch_SectionPlane|Arch SectionPlane]] tool to create a second {{incode|Section001}} element.
+24. Switch back to the [[BIM_Workbench|BIM Workbench]]. In the tree view select all components again, and use the [[Arch_SectionPlane|Arch SectionPlane]] tool to create a second {{incode|Section001}} element.
 :24.1. Select {{incode|Section001}} and change the property {{PropertyData|Position}} to {{incode|[1.5 m, 2.0 m, 1.8 m]}}. This second plane does cut through all Arch objects.
 :24.2. Switch back to the [[TechDraw_Workbench|TechDraw Workbench]]. Select {{incode|Section001}}, use the [[TechDraw_ArchView|TechDraw ArchView]] tool to create {{incode|ArchView001}}, and set {{PropertyData|Scale}} to {{incode|0.02}}. The new view in the TechDraw page now shows all openings in the [[Arch_Wall|Arch Wall]] produced by doors and windows.
 
@@ -265,7 +265,7 @@ Now we are ready to create a simple building with closed walls, two doors and tw
 == Making an elevation projection of the building == <!--T:66-->
 
 <!--T:67-->
-25. Go back to the [[Arch_Workbench|Arch Workbench]]. In the tree view, select all components, the [[Arch_Wall|Arch Wall]], the two [[Arch_Window|Arch Window]]s, and the two [[Arch_Door|Arch Door]]s, then use the [[Arch_SectionPlane|Arch SectionPlane]] tool to create a third {{incode|Section002}} element.
+25. Go back to the [[BIM_Workbench|BIM Workbench]]. In the tree view, select all components, the [[Arch_Wall|Arch Wall]], the two [[Arch_Window|Arch Window]]s, and the two [[Arch_Door|Arch Door]]s, then use the [[Arch_SectionPlane|Arch SectionPlane]] tool to create a third {{incode|Section002}} element.
 :25.1. Rotate {{incode|Section002}}, so that it cuts vertically through the building. Change the properties {{PropertyData|Axis}} to {{incode|[1, 0, 0]}}, and {{PropertyData|Angle}} to {{incode|90}}.
 :25.2. Change the {{PropertyData|Position}} to {{incode|[1.5 m, -1 m, 1.5 m]}}, so that the plane is in front of the building.
 
@@ -287,7 +287,7 @@ Now we are ready to create a simple building with closed walls, two doors and tw
 == Arch and TechDraw interaction == <!--T:71-->
 
 <!--T:72-->
-As of the time of writing of this document (FreeCAD 0.18, November 2018), the [[TechDraw_Workbench|TechDraw Workbench]] can only display in its pages what the [[Arch_Workbench|Arch Workbench]] exports as [[SVG|SVG]]. This means that the appearance of the elements included within the [[Arch_SectionPlane|Arch SectionPlane]] tool, and displayed by the [[TechDraw_ArchView|TechDraw ArchView]] tool, is controlled by the [[Arch_Workbench|Arch Workbench]].
+As of the time of writing of this document (FreeCAD 0.18, November 2018), the [[TechDraw_Workbench|TechDraw Workbench]] can only display in its pages what the [[BIM_Workbench|BIM Workbench]] exports as [[SVG|SVG]]. This means that the appearance of the elements included within the [[Arch_SectionPlane|Arch SectionPlane]] tool, and displayed by the [[TechDraw_ArchView|TechDraw ArchView]] tool, is controlled by the [[BIM_Workbench|BIM Workbench]].
 
 <!--T:73-->
 The [[TechDraw_Workbench|TechDraw Workbench]] only has minimal control over how it displays those [[Arch_SectionPlane|Arch SectionPlane]] ({{incode|ArchView}}) objects. Therefore, bug reports and feature requests related to displaying Arch elements should be filed with both workbenches.

--- a/wiki/Tutorial_for_open_windows.wikitext
+++ b/wiki/Tutorial_for_open_windows.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=60 minutes
 |Author=[https://forum.freecad.org/memberlist.php?mode=viewprofile&u=21943 vocx]
-|FCVersion=0.18 or greater
+|FCVersion=1.1 or greater
 |Files=none
 }}
 

--- a/wiki/Whiffle_Ball_tutorial.wikitext
+++ b/wiki/Whiffle_Ball_tutorial.wikitext
@@ -6,7 +6,7 @@
 |Level=Beginner
 |Time=30 minutes
 |Author=r-frank and vocx
-|FCVersion=0.17 and above
+|FCVersion=1.1 and above
 |Files=[https://github.com/FreeCAD/Examples/blob/master/Whiffle_Ball_Tutorial_ExampleFiles/WhiffleBall_Tutorial_FCWiki.FCStd?raw=true WhiffleBall_Tutorial_FCWiki.FCStd]
 }}
 


### PR DESCRIPTION
## Changes



### FCVersion updates (0.14-0.19 → 1.1)
- `Arch_tutorial` — 0.14 → 1.1
- `PartDesign_tutorial` — 0.16 → 1.1
- `Basic_Part_Design_Tutorial` — 0.17 → 1.1
- `Basic_TechDraw_Tutorial` — 0.17 → 1.1
- `FEM_tutorial` — 0.17 → 1.1
- `Draft_tutorial` — 0.19 → 1.1
- `Basic_Sketcher_Tutorial` — 0.19 → 1.1
- `Advanced_TechDraw_Tutorial` — 0.19.23300 → 1.1
- `PartDesign_Bearingholder_Tutorial_I` — 0.19.23300 → 1.1
- `PartDesign_Bearingholder_Tutorial_II` — 0.19.23300 → 1.1
- `Tutorial_custom_placing_of_windows_and_doors` — 0.18 → 1.1
- `Tutorial_for_open_windows` — 0.18 → 1.1
- `Whiffle_Ball_tutorial` — 0.17 → 1.1

### Arch Workbench → BIM Workbench renames
- `Arch_tutorial` — 15 references updated
- `Tutorial_custom_placing_of_windows_and_doors` — 3 references updated
- `Tutorial_for_open_windows` — 7 references updated

Total: 14 tutorials updated, 25 Arch→BIM references fixed.