### PR TITLE
Document BIM Link behavior

### DIFF
--- a/wiki/BIM_Link.wikitext
+++ b/wiki/BIM_Link.wikitext
@@ -26,7 +26,6 @@
 <!--T:4-->
 The [[File:BIM_Link.svg|24px]] [[BIM_Link|BIM Link]] command is a shortcut to [[Std_LinkMake|Std LinkMake]], but starts a [[Draft_Move|Draft Move]] operation immediately after, allowing a link to be created and placed in one go.
 
-<!--T:8-->
 It creates an {{incode|App::Link}} object that references the selected source object. This is useful when the same BIM object has to appear several times in a model, for example repeated windows, equipment, rebars or curtain-wall elements, while keeping the repeated objects lightweight.
 
 ==Usage== <!--T:5-->
@@ -41,17 +40,15 @@ It creates an {{incode|App::Link}} object that references the selected source ob
 # The [[Draft_Move|Draft Move]] command starts automatically.
 # Click in the [[3D_View|3D View]] to place the new link.
 
-==Notes== <!--T:9-->
+==Notes==
 
-<!--T:10-->
 * The command requires at least one selected object.
 * The created object is a standard FreeCAD {{incode|App::Link}}, so changes to the linked source object are reflected by its links.
 * Compared with [[BIM_Clone|BIM Clone]], links are intended for lightweight repeated references to the same geometry. Clones remain available and may still be better supported in older BIM workflows.
 * For BIM objects that need object-specific host information, such as windows, rebars, curtain walls and equipment, the workbench can keep selected link properties independent from the source object. This allows a linked window, for example, to be hosted by a different wall without changing the original window.
 
-==Scripting== <!--T:11-->
+==Scripting==
 
-<!--T:12-->
 The command creates an {{incode|App::Link}} and assigns its {{incode|LinkedObject}} to the selected source object. It then starts the [[Draft_Move|Draft Move]] command for the newly created link.
 
 

--- a/wiki/BIM_Link.wikitext
+++ b/wiki/BIM_Link.wikitext
@@ -26,6 +26,9 @@
 <!--T:4-->
 The [[File:BIM_Link.svg|24px]] [[BIM_Link|BIM Link]] command is a shortcut to [[Std_LinkMake|Std LinkMake]], but starts a [[Draft_Move|Draft Move]] operation immediately after, allowing a link to be created and placed in one go.
 
+<!--T:8-->
+It creates an {{incode|App::Link}} object that references the selected source object. This is useful when the same BIM object has to appear several times in a model, for example repeated windows, equipment, rebars or curtain-wall elements, while keeping the repeated objects lightweight.
+
 ==Usage== <!--T:5-->
 
 <!--T:6-->
@@ -37,6 +40,19 @@ The [[File:BIM_Link.svg|24px]] [[BIM_Link|BIM Link]] command is a shortcut to [[
 # A link is created from the selected object.
 # The [[Draft_Move|Draft Move]] command starts automatically.
 # Click in the [[3D_View|3D View]] to place the new link.
+
+==Notes== <!--T:9-->
+
+<!--T:10-->
+* The command requires at least one selected object.
+* The created object is a standard FreeCAD {{incode|App::Link}}, so changes to the linked source object are reflected by its links.
+* Compared with [[BIM_Clone|BIM Clone]], links are intended for lightweight repeated references to the same geometry. Clones remain available and may still be better supported in older BIM workflows.
+* For BIM objects that need object-specific host information, such as windows, rebars, curtain walls and equipment, the workbench can keep selected link properties independent from the source object. This allows a linked window, for example, to be hosted by a different wall without changing the original window.
+
+==Scripting== <!--T:11-->
+
+<!--T:12-->
+The command creates an {{incode|App::Link}} and assigns its {{incode|LinkedObject}} to the selected source object. It then starts the [[Draft_Move|Draft Move]] command for the newly created link.
 
 
 <!--T:7-->


### PR DESCRIPTION
## Summary
- expand the BIM Link command page with what the command creates and when to use it
- document the App::Link behavior, BIM Clone comparison, and BIM-specific host-property handling from FreeCAD/FreeCAD#28104
- keep the change scoped to the root BIM_Link wiki page

## Related
- Contributes to #26
- Source change: FreeCAD/FreeCAD#28104
- /claim #26

## Validation
- `git diff --check -- wiki/BIM_Link.wikitext`
- confirmed `<translate>` and `</translate>` tag counts remain balanced
- confirmed translation markers are not duplicated

This is a focused slice of #26, not a claim that all BIM Workbench missing documentation is complete.