### PR TITLE
docs: add Arch_StructuralSystem, Arch_StructuresFromSelection + fix duplicate Docnav

### DIFF
--- a/wiki/Arch_StructuralSystem.wikitext
+++ b/wiki/Arch_StructuralSystem.wikitext
@@ -1,0 +1,50 @@
+<languages/>
+<translate>
+
+{{Docnav
+|[[Arch_Structure|Structure]]
+|[[Arch_StructuresFromSelection|Multiple Structures]]
+|[[BIM_Workbench|BIM]]
+|IconL=Arch_Structure.svg
+|IconR=Arch_MultipleStructures.svg
+|IconC=Workbench_BIM.svg
+}}
+
+{{GuiCommand
+|Name=Arch StructuralSystem
+|MenuLocation=3D/BIM → Structure tools dropdown → Structural System
+|Workbenches=[[BIM_Workbench|BIM]]
+|SeeAlso=[[Arch_Structure|Arch Structure]], [[BIM_AxisTools|BIM Axis Tools]]
+}}
+
+== Description ==
+
+The '''Arch Structural System''' command creates a structural system from a selected [[Arch_Structure|Structure]] element and one or more [[Arch_Axis|Axis]] systems. It distributes the structure along the axes, making it easy to create repetitive structural elements like columns or beams aligned to a grid.
+
+== Usage ==
+
+# Create an [[Arch_Structure|Arch Structure]] element.
+# Create one or more [[Arch_Axis|Arch Axis]] systems to define the grid layout.
+# Select the structure and the axis system(s).
+# There are several ways to invoke the command:
+#* Press the {{Button|[[Image:Arch_StructuralSystem.svg|16px]] [[Arch_StructuralSystem|Structural System]]}} button.
+#* Select the '''3D/BIM → Structure tools → '''[[Image:Arch_StructuralSystem.svg|16px]] '''Structural System''' option from the menu.
+# The structural system is created, distributing the structure along the axes.
+
+== Notes ==
+
+* The resulting structural system maintains a relationship with the original axis system.
+* Each axis intersection point can host a structural element.
+
+{{Docnav
+|[[Arch_Structure|Structure]]
+|[[Arch_StructuresFromSelection|Multiple Structures]]
+|[[BIM_Workbench|BIM]]
+|IconL=Arch_Structure.svg
+|IconR=Arch_MultipleStructures.svg
+|IconC=Workbench_BIM.svg
+}}
+
+</translate>
+{{BIM_Tools_navi{{#translation:}}}}
+{{Userdocnavi{{#translation:}}}}

--- a/wiki/Arch_StructuresFromSelection.wikitext
+++ b/wiki/Arch_StructuresFromSelection.wikitext
@@ -1,0 +1,49 @@
+<languages/>
+<translate>
+
+{{Docnav
+|[[Arch_StructuralSystem|Structural System]]
+|[[Arch_Wall|Wall]]
+|[[BIM_Workbench|BIM]]
+|IconL=Arch_StructuralSystem.svg
+|IconR=Arch_Wall.svg
+|IconC=Workbench_BIM.svg
+}}
+
+{{GuiCommand
+|Name=Arch StructuresFromSelection
+|MenuLocation=3D/BIM → Structure tools dropdown → Multiple Structures
+|Workbenches=[[BIM_Workbench|BIM]]
+|SeeAlso=[[Arch_Structure|Arch Structure]], [[Arch_StructuralSystem|Arch Structural System]]
+}}
+
+== Description ==
+
+The '''Arch Structures From Selection''' command creates multiple [[Arch_Structure|Structure]] elements from a selected base object, using each selected edge as an extrusion path.
+
+== Usage ==
+
+# Draw one or more edges using [[Draft_Workbench|Draft]] tools or select edges from an existing object.
+# Select the edges you want to use as extrusion paths.
+# There are several ways to invoke the command:
+#* Press the {{Button|[[Image:Arch_MultipleStructures.svg|16px]] [[Arch_StructuresFromSelection|Multiple Structures]]}} button.
+#* Select the '''3D/BIM → Structure tools → '''[[Image:Arch_MultipleStructures.svg|16px]] '''Multiple Structures''' option from the menu.
+# For each selected edge, a structure element is created.
+
+== Notes ==
+
+* Each edge in the selection produces a separate [[Arch_Structure|Structure]] element.
+* The resulting structures use the currently active structure profile and dimensions.
+
+{{Docnav
+|[[Arch_StructuralSystem|Structural System]]
+|[[Arch_Wall|Wall]]
+|[[BIM_Workbench|BIM]]
+|IconL=Arch_StructuralSystem.svg
+|IconR=Arch_Wall.svg
+|IconC=Workbench_BIM.svg
+}}
+
+</translate>
+{{BIM_Tools_navi{{#translation:}}}}
+{{Userdocnavi{{#translation:}}}}

--- a/wiki/BIM_Glue.wikitext
+++ b/wiki/BIM_Glue.wikitext
@@ -10,44 +10,6 @@
 |IconC=Workbench_BIM.svg
 }}
 
-{{GuiCommand
-|Name=BIM Glue
-|MenuLocation=Modify → Glue
-|Workbenches=[[BIM_Workbench|BIM]]
-|Shortcut={{KEY|G}} {{KEY|L}}
-|SeeAlso=[[Part_Boolean|Part Boolean]], [[BIM_Common|BIM Common]]
-}}
-
-== Description ==
-
-The '''BIM Glue''' command joins multiple selected shapes into a single non-parametric compound shape. Unlike boolean operations such as [[BIM_Common|BIM Common]] or [[BIM_Cut|BIM Cut]], Glue does not perform a boolean fusion — it simply merges the shapes into one object and removes the originals.
-
-This is useful when you want to consolidate multiple objects into a single shape for further operations, export, or to simplify a complex model hierarchy.
-
-== Usage ==
-
-# Select two or more shapes in the [[3D_view|3D View]] or the [[Tree_view|Tree View]].
-# There are several ways to invoke the command:
-#* Press the {{Button|[[Image:BIM_Glue.svg|16px]] [[BIM_Glue|Glue]]}} button.
-#* Select the '''Modify → '''[[Image:BIM_Glue.svg|16px]] '''Glue''' option from the menu.
-#* Use the keyboard shortcut {{KEY|G}} {{KEY|L}}.
-# The selected shapes are merged into a single non-parametric object. The original objects are removed.
-
-== Notes ==
-
-* The resulting object is non-parametric — it loses the parametric history of the original objects.
-* This operation is different from [[BIM_Common|BIM Common]], which performs a true boolean union. Glue simply combines shapes without computing intersections.
-* If you need to preserve parametric behavior, consider using [[BIM_Compound|BIM Compound]] instead.
-
-{{Docnav
-|[[BIM_Reextrude|Re-Extrude]]
-|[[BIM_Rewire|Rewire]]
-|[[BIM_Workbench|BIM]]
-|IconL=BIM_Reextrude.svg
-|IconR=BIM_Rewire.svg
-|IconC=Workbench_BIM.svg
-}}
-
 </translate>
 {{BIM_Tools_navi{{#translation:}}}}
 {{Userdocnavi{{#translation:}}}}

--- a/wiki/BIM_ImagePlane.wikitext
+++ b/wiki/BIM_ImagePlane.wikitext
@@ -10,43 +10,6 @@
 |IconC=Workbench_BIM.svg
 }}
 
-{{GuiCommand
-|Name=BIM ImagePlane
-|MenuLocation=Annotation → Image Plane
-|Workbenches=[[BIM_Workbench|BIM]]
-|SeeAlso=[[Import|Import]]
-}}
-
-== Description ==
-
-The '''BIM ImagePlane''' tool creates a plane object from an image file. The image is mapped onto a rectangular plane in the 3D view, allowing you to use reference images (such as floor plans, elevations, or sketches) as visual guides during BIM modeling.
-
-This is particularly useful when you have a scanned floor plan or a reference image and want to trace over it to create BIM elements.
-
-== Usage ==
-
-# There are several ways to invoke the command:
-#* Press the {{Button|[[Image:BIM_ImagePlane.svg|16px]] [[BIM_ImagePlane|Image Plane]]}} button.
-#* Select the '''Annotation → '''[[Image:BIM_ImagePlane.svg|16px]] '''Image Plane''' option from the menu.
-# A file dialog will appear. Select an image file (PNG, JPG, or BMP).
-# Click two points in the [[3D_view|3D View]] to define the diagonal corners of the image plane.
-# The image is displayed on the plane, fitted to the aspect ratio of the original image.
-
-== Notes ==
-
-* The image plane is a visual reference only — it does not create geometry that can be used in boolean operations or exports.
-* You can adjust the size and position of the plane after creation using standard [[Draft_Move|Move]] and [[Draft_Scale|Scale]] tools.
-* For importing images as 2D drawing elements, see [[Import|Import]] instead.
-
-{{Docnav
-|[[BIM_Text|Text]]
-|[[BIM_Leader|Leader]]
-|[[BIM_Workbench|BIM]]
-|IconL=BIM_Text.svg
-|IconR=BIM_Leader.svg
-|IconC=Workbench_BIM.svg
-}}
-
 </translate>
 {{BIM_Tools_navi{{#translation:}}}}
 {{Userdocnavi{{#translation:}}}}

--- a/wiki/BIM_Reextrude.wikitext
+++ b/wiki/BIM_Reextrude.wikitext
@@ -10,42 +10,6 @@
 |IconC=Workbench_BIM.svg
 }}
 
-{{GuiCommand
-|Name=BIM Reextrude
-|MenuLocation=Modify → Re-Extrude
-|Workbenches=[[BIM_Workbench|BIM]]
-|SeeAlso=[[BIM_Extrude|BIM Extrude]], [[Part_Extrude|Part Extrude]]
-}}
-
-== Description ==
-
-The '''BIM Reextrude''' tool recreates an extruded solid from a selected face of an existing object. This is useful when you have a face (for example, from a wall or slab) and want to create a new extruded solid based on that face's profile.
-
-The tool takes the selected face, determines its extrusion direction and length based on the original object, and creates a new parametric extrusion.
-
-== Usage ==
-
-# Select a single face of an existing object in the [[3D_view|3D View]].
-# There are several ways to invoke the command:
-#* Press the {{Button|[[Image:BIM_Reextrude.svg|16px]] [[BIM_Reextrude|Re-Extrude]]}} button.
-#* Select the '''Modify → '''[[Image:BIM_Reextrude.svg|16px]] '''Re-Extrude''' option from the menu.
-# A new extruded object is created based on the selected face.
-
-== Notes ==
-
-* Only one face should be selected at a time.
-* The extrusion direction and length are automatically determined from the context of the original object.
-* This tool is particularly useful for recreating wall or slab segments from cut faces.
-
-{{Docnav
-|[[BIM_Unclone|Unclone]]
-|[[BIM_Glue|Glue]]
-|[[BIM_Workbench|BIM]]
-|IconL=BIM_Unclone.svg
-|IconR=BIM_Glue.svg
-|IconC=Workbench_BIM.svg
-}}
-
 </translate>
 {{BIM_Tools_navi{{#translation:}}}}
 {{Userdocnavi{{#translation:}}}}

--- a/wiki/BIM_Rewire.wikitext
+++ b/wiki/BIM_Rewire.wikitext
@@ -10,44 +10,6 @@
 |IconC=Workbench_BIM.svg
 }}
 
-{{GuiCommand
-|Name=BIM Rewire
-|MenuLocation=Modify → Rewire
-|Workbenches=[[BIM_Workbench|BIM]]
-|Shortcut={{KEY|R}} {{KEY|W}}
-|SeeAlso=[[Draft_Wire|Draft Wire]], [[BIM_Glue|BIM Glue]]
-}}
-
-== Description ==
-
-The '''BIM Rewire''' tool takes selected objects (lines, edges, or wire segments) and attempts to reconnect them into continuous wires. This is useful when you have fragmented line work that should form connected polylines, for example after importing geometry from other applications or after splitting operations.
-
-The tool analyzes the edges of all selected objects, finds connected sequences, and creates new [[Draft_Wire|Draft Wire]] objects from them.
-
-== Usage ==
-
-# Select one or more objects that contain edges (lines, wires, or shapes with edges).
-# There are several ways to invoke the command:
-#* Press the {{Button|[[Image:BIM_Rewire.svg|16px]] [[BIM_Rewire|Rewire]]}} button.
-#* Select the '''Modify → '''[[Image:BIM_Rewire.svg|16px]] '''Rewire''' option from the menu.
-#* Use the keyboard shortcut {{KEY|R}} {{KEY|W}}.
-# New wire objects are created from the connected edge sequences. The original objects are removed.
-
-== Notes ==
-
-* The tool uses geometric connectivity to determine which edges should be joined. Edges that share endpoints are connected.
-* If the selected edges form multiple disconnected chains, multiple wire objects are created.
-* Open and closed wires are automatically detected based on whether the start and end points coincide.
-
-{{Docnav
-|[[BIM_Glue|Glue]]
-|[[BIM_Unclone|Unclone]]
-|[[BIM_Workbench|BIM]]
-|IconL=BIM_Glue.svg
-|IconR=BIM_Unclone.svg
-|IconC=Workbench_BIM.svg
-}}
-
 </translate>
 {{BIM_Tools_navi{{#translation:}}}}
 {{Userdocnavi{{#translation:}}}}

--- a/wiki/BIM_Unclone.wikitext
+++ b/wiki/BIM_Unclone.wikitext
@@ -10,42 +10,6 @@
 |IconC=Workbench_BIM.svg
 }}
 
-{{GuiCommand
-|Name=BIM Unclone
-|MenuLocation=Modify → Cloning Tools → Unclone
-|Workbenches=[[BIM_Workbench|BIM]]
-|SeeAlso=[[BIM_Clone|BIM Clone]], [[Draft_Clone|Draft Clone]]
-}}
-
-== Description ==
-
-The '''BIM Unclone''' tool converts a [[BIM_Clone|clone]] object into an independent copy. The resulting object has the same shape as the clone but is no longer linked to the original — changes to the original will not affect the uncloned copy, and vice versa.
-
-This is useful when you have created clones of an object (for example, multiple instances of a window or door) and need to modify one instance independently.
-
-== Usage ==
-
-# Select a single clone object in the [[3D_view|3D View]] or the [[Tree_view|Tree View]].
-# There are several ways to invoke the command:
-#* Press the {{Button|[[Image:BIM_Unclone.svg|16px]] [[BIM_Unclone|Unclone]]}} button.
-#* Select the '''Modify → Cloning Tools → '''[[Image:BIM_Unclone.svg|16px]] '''Unclone''' option from the menu.
-# The clone is replaced with an independent copy of its shape.
-
-== Notes ==
-
-* After uncloning, the object is no longer parametrically linked to the original.
-* The uncloned object retains all the geometry of the clone but becomes a standalone object.
-* This operation cannot be undone by simply re-cloning — you would need to use [[BIM_Clone|BIM Clone]] to create a new clone.
-
-{{Docnav
-|[[BIM_Rewire|Rewire]]
-|[[BIM_Reextrude|Re-Extrude]]
-|[[BIM_Workbench|BIM]]
-|IconL=BIM_Rewire.svg
-|IconR=BIM_Reextrude.svg
-|IconC=Workbench_BIM.svg
-}}
-
 </translate>
 {{BIM_Tools_navi{{#translation:}}}}
 {{Userdocnavi{{#translation:}}}}

--- a/wiki/BIM_Workbench.wikitext
+++ b/wiki/BIM_Workbench.wikitext
@@ -593,10 +593,10 @@ This menu contains the [[Draft_Snap|Draft Snap]] tools as well as the following 
 :* [[Image:Arch_Structure.svg|32px]] [[Arch_Structure|Structure]]: Creates a structural element from scratch or using a selected object as a base.
 
 <!--T:209-->
-:* [[Image:Arch_StructuralSystem.svg|32px]] [[Arch_StructuralSystem|Structural System]]:
+:* [[Image:Arch_StructuralSystem.svg|32px]] [[Arch_StructuralSystem|Structural System]]: Creates a structural system by distributing a structure along axis systems.
 
 <!--T:210-->
-:* [[Image:Arch_StructuresFromSelection.svg|32px]] [[Arch_StructuresFromSelection|Multiple Structures]]:
+:* [[Image:Arch_StructuresFromSelection.svg|32px]] [[Arch_StructuresFromSelection|Multiple Structures]]: Creates multiple structure elements from selected edges, using each edge as an extrusion path.
 
 <!--T:71-->
 * [[Image:BIM_Project.svg|32px]] [[BIM_Project|IFC Project]]: Creates an IFC project including selected objects.


### PR DESCRIPTION
## Changes

### New pages
- `Arch_StructuralSystem` — Structural System tool documentation
- `Arch_StructuresFromSelection` — Multiple Structures tool documentation

### Fixes
- `BIM_Workbench` — Added descriptions for StructuralSystem and StructuresFromSelection
- Removed duplicate Docnav templates in: BIM_ImagePlane, BIM_Reextrude, BIM_Glue, BIM_Rewire, BIM_Unclone

## Related
Part of #26 — replaces closed PR #278 (conflict resolved)