### PR TITLE
Document BIM project site declination

### DIFF
--- a/wiki/BIM_ProjectManager.wikitext
+++ b/wiki/BIM_ProjectManager.wikitext
@@ -42,9 +42,8 @@ The BIM Project Setup dialog can create:
 * A set of [[Arch_BuildingPart|BuildingParts]] to represent levels. BuildingParts are generic BIM container objects that can be used to group other BIM objects in a number of meaningful ways, such as repeatable components or building levels.
 * A set of default [[Std_Group|groups]] inside each level. Groups can be used to organize your BIM objects in clearer categories, such as "Walls" or "Columns". They have no impact on the model itself, but often help to make your model structure clearer when it contains a lot of objects.
 
-==Site declination== <!--T:15-->
+==Site declination==
 
-<!--T:16-->
 The site declination field sets the {{PropertyData|Declination}} value of the created or selected [[Arch_Site|Site]]. Use this angle for the difference between the project's up direction and true north. Recent FreeCAD versions use the Site object's {{PropertyData|Declination}} property for this value; older project templates that stored the former site deviation entry can still be restored by the Project Setup dialog.
 
 ==Templates== <!--T:8-->

--- a/wiki/BIM_ProjectManager.wikitext
+++ b/wiki/BIM_ProjectManager.wikitext
@@ -36,11 +36,16 @@ The BIM Project Setup dialog can create:
 
 <!--T:6-->
 * A new [[Document_structure|document]]. Alternatively, the other objects will be created in the currently opened document.
-* A [[Arch_Site|site]]. The Site object represents a piece of terrain, where your project will be located. You can give it a number of useful properties, such as street address and earth coordinates. Upon creation, the site is just an empty container for other BIM objects, but a 3D object representing the actual terrain can be attached to it later on.
+* A [[Arch_Site|site]]. The Site object represents a piece of terrain, where your project will be located. You can give it a number of useful properties, such as street address, earth coordinates and the site's declination from true north. Upon creation, the site is just an empty container for other BIM objects, but a 3D object representing the actual terrain can be attached to it later on.
 * A [[Arch_Building|building]]. The Building object is a container for all the BIM objects that will belong to a same building. You can define a building type, and give it gross rectangular dimensions, that will be represented as a rectangle drawn on the XY-plane.
 * A set of [[Arch_Axis|axes]], by defining their number and spacing. Axes are used as guidelines to align 2D and 3D objects. These axes can be modified or new axes introduced later on.
 * A set of [[Arch_BuildingPart|BuildingParts]] to represent levels. BuildingParts are generic BIM container objects that can be used to group other BIM objects in a number of meaningful ways, such as repeatable components or building levels.
 * A set of default [[Std_Group|groups]] inside each level. Groups can be used to organize your BIM objects in clearer categories, such as "Walls" or "Columns". They have no impact on the model itself, but often help to make your model structure clearer when it contains a lot of objects.
+
+==Site declination== <!--T:15-->
+
+<!--T:16-->
+The site declination field sets the {{PropertyData|Declination}} value of the created or selected [[Arch_Site|Site]]. Use this angle for the difference between the project's up direction and true north. Recent FreeCAD versions use the Site object's {{PropertyData|Declination}} property for this value; older project templates that stored the former site deviation entry can still be restored by the Project Setup dialog.
 
 ==Templates== <!--T:8-->
 


### PR DESCRIPTION
## Summary
- document that BIM Project Setup can set a site's declination from true north
- add a focused Site declination section for the Site `Declination` property
- note that older project templates with the former site deviation entry can still be restored

## Related
- Contributes to #26
- Source change: FreeCAD/FreeCAD#28913
- Source issue: FreeCAD/FreeCAD#25326

## Validation
- `git diff --check -- wiki/BIM_ProjectManager.wikitext`
- confirmed `<translate>` and `</translate>` tag counts remain balanced
- confirmed translation markers are not duplicated

This is a focused slice of #26, not a claim that all BIM Workbench missing documentation is complete.
