### PR TITLE
Fix Download Classifications macro snippet

### DIFF
--- a/wiki/Macro_Download_Classifications.wikitext
+++ b/wiki/Macro_Download_Classifications.wikitext
@@ -42,8 +42,9 @@ apireq = "https://api.github.com/repos/Moult/IfcClassification/contents/xml"
 
 r = requests.get(apireq)
 if r.ok:
+    os.makedirs(target, exist_ok=True)
     j = json.loads(r.content)
-    print("Installing to", target", ...")
+    print("Installing to", target, "...")
     for f in j:
         df = requests.get(f["download_url"])
         with open(os.path.join(target, f["name"]), 'wb') as tf:


### PR DESCRIPTION
## Summary
- fix the embedded Download Classifications macro syntax error in the install message
- create the BIM Classification target folder before writing downloaded files

## Validation
- parsed the embedded macro code with Python ast.parse
- git diff --check

Refs #28