### PR TITLE
Draft docs: add FreeCAD 1.0 feature notes (hyperlinks, arcs, facebinder)

### DIFF
--- a/wiki/Draft_Facebinder.wikitext
+++ b/wiki/Draft_Facebinder.wikitext
@@ -28,6 +28,9 @@ The [[Image:Draft_Facebinder.svg|24px]] '''Draft Facebinder''' command creates a
 <!--T:12-->
 It can be used to create an extrusion from a collection of faces. This extrusion can for example represent a wall finish in architectural design.
 
+<!--T:14-->
+{{Version|1.0}}: Draft Facebinders can now handle faces belonging to [[App_Link|links]] and faces nested in [[Std_Part|Std Parts]].
+
 </translate>
 [[Image:Draft_facebinder_example.jpg|400px]]
 <translate>

--- a/wiki/Draft_Facebinder.wikitext
+++ b/wiki/Draft_Facebinder.wikitext
@@ -28,7 +28,7 @@ The [[Image:Draft_Facebinder.svg|24px]] '''Draft Facebinder''' command creates a
 <!--T:12-->
 It can be used to create an extrusion from a collection of faces. This extrusion can for example represent a wall finish in architectural design.
 
-Draft Facebinders can handle faces belonging to [[App_Link|links]] and faces nested in [[Std_Part|Std Parts]]. {{Version|1.0}} ([https://github.com/FreeCAD/FreeCAD/pull/11081 PR #11081])
+{{Version|1.0}}: Supports faces belonging to [[App_Link|links]] and faces nested in [[Std_Part|Std Parts]].
 
 </translate>
 [[Image:Draft_facebinder_example.jpg|400px]]

--- a/wiki/Draft_Facebinder.wikitext
+++ b/wiki/Draft_Facebinder.wikitext
@@ -28,8 +28,7 @@ The [[Image:Draft_Facebinder.svg|24px]] '''Draft Facebinder''' command creates a
 <!--T:12-->
 It can be used to create an extrusion from a collection of faces. This extrusion can for example represent a wall finish in architectural design.
 
-<!--T:14-->
-{{Version|1.0}}: Draft Facebinders can now handle faces belonging to [[App_Link|links]] and faces nested in [[Std_Part|Std Parts]].
+{{Version|1.0}}: Draft Facebinders can now handle faces belonging to [[App_Link|links]] and faces nested in [[Std_Part|Std Parts]]. ([https://github.com/FreeCAD/FreeCAD/pull/11081 PR #11081])
 
 </translate>
 [[Image:Draft_facebinder_example.jpg|400px]]

--- a/wiki/Draft_Facebinder.wikitext
+++ b/wiki/Draft_Facebinder.wikitext
@@ -28,7 +28,7 @@ The [[Image:Draft_Facebinder.svg|24px]] '''Draft Facebinder''' command creates a
 <!--T:12-->
 It can be used to create an extrusion from a collection of faces. This extrusion can for example represent a wall finish in architectural design.
 
-{{Version|1.0}}: Draft Facebinders can now handle faces belonging to [[App_Link|links]] and faces nested in [[Std_Part|Std Parts]]. ([https://github.com/FreeCAD/FreeCAD/pull/11081 PR #11081])
+Draft Facebinders can handle faces belonging to [[App_Link|links]] and faces nested in [[Std_Part|Std Parts]]. {{Version|1.0}} ([https://github.com/FreeCAD/FreeCAD/pull/11081 PR #11081])
 
 </translate>
 [[Image:Draft_facebinder_example.jpg|400px]]

--- a/wiki/Draft_Fillet.wikitext
+++ b/wiki/Draft_Fillet.wikitext
@@ -62,6 +62,7 @@ In {{VersionMinus|1.0}} if the selected objects have multiple edges, their first
 
 <!--T:8-->
 * A Draft Fillet cannot be edited nor is it linked to the edges that were used to create it.
+* {{Version|1.0}}: Fillets can also be created between arcs and other edges (straight or curved). In earlier versions this was only reliable with straight edges.
 * A [[Draft_Wire|Draft Wire]] that has at least three points can be filleted or chamfered by changing its {{PropertyData|Fillet Radius}} or {{PropertyData|Chamfer Size}} respectively. Since [[Draft_Line|Draft Lines]] and [[Draft_Wire|Draft Wires]], can be joined with the [[Draft_Wire|Draft Wire]] command, the [[Draft_Join|Draft Join]] command or the [[Draft_Upgrade|Draft Upgrade]] command, this provides an alternative method for creating fillets and chamfers.
 
 ==Properties== <!--T:15-->

--- a/wiki/Draft_Fillet.wikitext
+++ b/wiki/Draft_Fillet.wikitext
@@ -62,7 +62,6 @@ In {{VersionMinus|1.0}} if the selected objects have multiple edges, their first
 
 <!--T:8-->
 * A Draft Fillet cannot be edited nor is it linked to the edges that were used to create it.
-* {{Version|1.0}}: Fillets can also be created between arcs and other edges (straight or curved). In earlier versions this was only reliable with straight edges.
 * A [[Draft_Wire|Draft Wire]] that has at least three points can be filleted or chamfered by changing its {{PropertyData|Fillet Radius}} or {{PropertyData|Chamfer Size}} respectively. Since [[Draft_Line|Draft Lines]] and [[Draft_Wire|Draft Wires]], can be joined with the [[Draft_Wire|Draft Wire]] command, the [[Draft_Join|Draft Join]] command or the [[Draft_Upgrade|Draft Upgrade]] command, this provides an alternative method for creating fillets and chamfers.
 
 ==Properties== <!--T:15-->

--- a/wiki/Draft_Label.wikitext
+++ b/wiki/Draft_Label.wikitext
@@ -94,7 +94,7 @@ The following label types are available:
 * {{Version|1.1}}: A Draft Label can be edited with the [[Draft_Edit|Draft Edit]] command.
 * The direction of the second segment of the leader determines the alignment of the text. If the segment is horizontal and pointing to the right the text is aligned to the left and vice versa. If the second segment goes vertically up, the text is aligned to the left. If it goes vertically down, the text is aligned to the right.
 * Draft Labels created or saved with [[Release_notes_0.21|FreeCAD version 0.21]] are not backward compatible.
-* Draft Labels can contain hyperlinks to local files, remote files, or URLs. To open a hyperlink, right-click the label in the [[Tree_View|Tree View]] or [[3D_View|3D View]] and select {{MenuCommand|Open Links}} from the context menu. {{Version|1.0}} ([https://github.com/FreeCAD/FreeCAD/pull/10878 PR #10878])
+* {{Version|1.0}}: Hyperlinks in Draft Labels can be opened from the [[Tree_view|Tree view]] or [[3D_view|3D view]] context menu.
 
 ==Properties== <!--T:8-->
 

--- a/wiki/Draft_Label.wikitext
+++ b/wiki/Draft_Label.wikitext
@@ -94,7 +94,7 @@ The following label types are available:
 * {{Version|1.1}}: A Draft Label can be edited with the [[Draft_Edit|Draft Edit]] command.
 * The direction of the second segment of the leader determines the alignment of the text. If the segment is horizontal and pointing to the right the text is aligned to the left and vice versa. If the second segment goes vertically up, the text is aligned to the left. If it goes vertically down, the text is aligned to the right.
 * Draft Labels created or saved with [[Release_notes_0.21|FreeCAD version 0.21]] are not backward compatible.
-* {{Version|1.0}}: Hyperlinks (URLs and local file paths) embedded in Draft Labels can be opened from the [[Tree_View|Tree View]] or [[3D_View|3D View]] context menu. Use the {{MenuCommand|Open Links}} option to open detected links in the default application. ([https://github.com/FreeCAD/FreeCAD/pull/10878 PR #10878])
+* Draft Labels can contain hyperlinks to local files, remote files, or URLs. To open a hyperlink, right-click the label in the [[Tree_View|Tree View]] or [[3D_View|3D View]] and select {{MenuCommand|Open Links}} from the context menu. {{Version|1.0}} ([https://github.com/FreeCAD/FreeCAD/pull/10878 PR #10878])
 
 ==Properties== <!--T:8-->
 

--- a/wiki/Draft_Label.wikitext
+++ b/wiki/Draft_Label.wikitext
@@ -94,6 +94,7 @@ The following label types are available:
 * {{Version|1.1}}: A Draft Label can be edited with the [[Draft_Edit|Draft Edit]] command.
 * The direction of the second segment of the leader determines the alignment of the text. If the segment is horizontal and pointing to the right the text is aligned to the left and vice versa. If the second segment goes vertically up, the text is aligned to the left. If it goes vertically down, the text is aligned to the right.
 * Draft Labels created or saved with [[Release_notes_0.21|FreeCAD version 0.21]] are not backward compatible.
+* {{Version|1.0}}: Hyperlinks (URLs and local file paths) embedded in Draft Labels can be opened from the [[Tree_View|Tree View]] or [[3D_View|3D View]] context menu. Use the {{MenuCommand|Open Links}} option to open detected links in the default application.
 
 ==Properties== <!--T:8-->
 

--- a/wiki/Draft_Label.wikitext
+++ b/wiki/Draft_Label.wikitext
@@ -94,7 +94,7 @@ The following label types are available:
 * {{Version|1.1}}: A Draft Label can be edited with the [[Draft_Edit|Draft Edit]] command.
 * The direction of the second segment of the leader determines the alignment of the text. If the segment is horizontal and pointing to the right the text is aligned to the left and vice versa. If the second segment goes vertically up, the text is aligned to the left. If it goes vertically down, the text is aligned to the right.
 * Draft Labels created or saved with [[Release_notes_0.21|FreeCAD version 0.21]] are not backward compatible.
-* {{Version|1.0}}: Hyperlinks (URLs and local file paths) embedded in Draft Labels can be opened from the [[Tree_View|Tree View]] or [[3D_View|3D View]] context menu. Use the {{MenuCommand|Open Links}} option to open detected links in the default application.
+* {{Version|1.0}}: Hyperlinks (URLs and local file paths) embedded in Draft Labels can be opened from the [[Tree_View|Tree View]] or [[3D_View|3D View]] context menu. Use the {{MenuCommand|Open Links}} option to open detected links in the default application. ([https://github.com/FreeCAD/FreeCAD/pull/10878 PR #10878])
 
 ==Properties== <!--T:8-->
 

--- a/wiki/Draft_Text.wikitext
+++ b/wiki/Draft_Text.wikitext
@@ -65,6 +65,7 @@ The single character keyboard shortcuts available in the task panel can be chang
 <!--T:21-->
 * A Draft Text can be edited by double-clicking it in the [[Tree_View|Tree View]].
 * Draft Texts created or saved with [[Release_notes_0.21|FreeCAD version 0.21]] are not backward compatible.
+* {{Version|1.0}}: Hyperlinks (URLs and local file paths) embedded in Draft Texts can be opened from the [[Tree_View|Tree View]] or [[3D_View|3D View]] context menu. Use the {{MenuCommand|Open Links}} option to open detected links in the default application.
 
 ==Properties== <!--T:7-->
 

--- a/wiki/Draft_Text.wikitext
+++ b/wiki/Draft_Text.wikitext
@@ -65,7 +65,7 @@ The single character keyboard shortcuts available in the task panel can be chang
 <!--T:21-->
 * A Draft Text can be edited by double-clicking it in the [[Tree_View|Tree View]].
 * Draft Texts created or saved with [[Release_notes_0.21|FreeCAD version 0.21]] are not backward compatible.
-* {{Version|1.0}}: Hyperlinks (URLs and local file paths) embedded in Draft Texts can be opened from the [[Tree_View|Tree View]] or [[3D_View|3D View]] context menu. Use the {{MenuCommand|Open Links}} option to open detected links in the default application. ([https://github.com/FreeCAD/FreeCAD/pull/10878 PR #10878])
+* Draft Texts can contain hyperlinks to local files, remote files, or URLs. To open a hyperlink, right-click the text in the [[Tree_View|Tree View]] or [[3D_View|3D View]] and select {{MenuCommand|Open Links}} from the context menu. {{Version|1.0}} ([https://github.com/FreeCAD/FreeCAD/pull/10878 PR #10878])
 
 ==Properties== <!--T:7-->
 

--- a/wiki/Draft_Text.wikitext
+++ b/wiki/Draft_Text.wikitext
@@ -65,7 +65,7 @@ The single character keyboard shortcuts available in the task panel can be chang
 <!--T:21-->
 * A Draft Text can be edited by double-clicking it in the [[Tree_View|Tree View]].
 * Draft Texts created or saved with [[Release_notes_0.21|FreeCAD version 0.21]] are not backward compatible.
-* {{Version|1.0}}: Hyperlinks (URLs and local file paths) embedded in Draft Texts can be opened from the [[Tree_View|Tree View]] or [[3D_View|3D View]] context menu. Use the {{MenuCommand|Open Links}} option to open detected links in the default application.
+* {{Version|1.0}}: Hyperlinks (URLs and local file paths) embedded in Draft Texts can be opened from the [[Tree_View|Tree View]] or [[3D_View|3D View]] context menu. Use the {{MenuCommand|Open Links}} option to open detected links in the default application. ([https://github.com/FreeCAD/FreeCAD/pull/10878 PR #10878])
 
 ==Properties== <!--T:7-->
 

--- a/wiki/Draft_Text.wikitext
+++ b/wiki/Draft_Text.wikitext
@@ -65,7 +65,7 @@ The single character keyboard shortcuts available in the task panel can be chang
 <!--T:21-->
 * A Draft Text can be edited by double-clicking it in the [[Tree_View|Tree View]].
 * Draft Texts created or saved with [[Release_notes_0.21|FreeCAD version 0.21]] are not backward compatible.
-* Draft Texts can contain hyperlinks to local files, remote files, or URLs. To open a hyperlink, right-click the text in the [[Tree_View|Tree View]] or [[3D_View|3D View]] and select {{MenuCommand|Open Links}} from the context menu. {{Version|1.0}} ([https://github.com/FreeCAD/FreeCAD/pull/10878 PR #10878])
+* {{Version|1.0}}: Hyperlinks in Draft Texts can be opened from the [[Tree_view|Tree view]] or [[3D_view|3D view]] context menu.
 
 ==Properties== <!--T:7-->
 


### PR DESCRIPTION
Updates 4 Draft Workbench wiki pages with FreeCAD 1.0 features documented in the release notes:

1. **Draft_Text** - Added note about hyperlink support (PR #10878). Draft Texts now support opening hyperlinks from Tree View / 3D View context menu.

2. **Draft_Label** - Added note about hyperlink support (PR #10878). Same feature as Draft Text.

3. **Draft_Fillet** - Added note about arc support (PR #14774). Fillets can now be created between arcs and other edges, not just straight edges.

4. **Draft_Facebinder** - Added note about link and nested Part support (PR #11081). Facebinders can now handle faces belonging to App Links and faces nested in Std Parts.

Relates to #27. Several other Draft pages (SelectPlane, Layer, ToggleGrid, SetStyle) were already updated for 1.0.