### PR TITLE
Document BIM Project Manager declination handling

### DIFF
--- a/wiki/BIM_ProjectManager.wikitext
+++ b/wiki/BIM_ProjectManager.wikitext
@@ -42,6 +42,9 @@ The BIM Project Setup dialog can create:
 * A set of [[Arch_BuildingPart|BuildingParts]] to represent levels. BuildingParts are generic BIM container objects that can be used to group other BIM objects in a number of meaningful ways, such as repeatable components or building levels.
 * A set of default [[Std_Group|groups]] inside each level. Groups can be used to organize your BIM objects in clearer categories, such as "Walls" or "Columns". They have no impact on the model itself, but often help to make your model structure clearer when it contains a lot of objects.
 
+<!--T:15-->
+{{Version|1.2}}: The Site true north field in the BIM Project Setup dialog uses the [[Arch_Site|Site]] {{PropertyData|Declination}} property. Project templates saved with the older {{Incode|siteDeviation}} key are still restored for compatibility.
+
 ==Templates== <!--T:8-->
 
 <!--T:7-->


### PR DESCRIPTION
## Summary
- add a FreeCAD 1.2 note to BIM Project Manager docs for the Site true north field now using the Site Declination property
- mention that older project templates using the siteDeviation key still restore for compatibility

## Source
- FreeCAD/FreeCAD#28913

## Validation
- Verified the branch diff is limited to wiki/BIM_ProjectManager.wikitext

Related to #26