### PR TITLE
Document BIM Tree View transform context menu

### DIFF
--- a/wiki/BIM_Workbench.wikitext
+++ b/wiki/BIM_Workbench.wikitext
@@ -660,7 +660,7 @@ The Status Bar contains a few buttons that allow to easily change different stat
 === Tree View context menu === <!--T:227-->
 
 <!--T:228-->
-TBD
+When one or more transformable objects are selected in the [[Tree_View|Tree View]], the context menu can include the standard {{MenuCommand|Transform}} command. {{Version|1.2}}: BIM and Draft view providers avoid adding a second duplicate Transform entry for annotation objects such as Draft lines, Draft rectangles and Arch axes.
 
 === 3D View context menu === <!--T:229-->
 


### PR DESCRIPTION
## Summary
- replaces the BIM Workbench Tree View context-menu placeholder with the standard Transform behavior
- notes the FreeCAD 1.2 fix that prevents duplicate Transform entries for BIM/Draft annotation objects

## Context
- Upstream FreeCAD change: FreeCAD/FreeCAD#29604
- Related bounty/reward issue: #26

## Validation
- git diff --check -- wiki/BIM_Workbench.wikitext

Refs #26