### PR TITLE
Document Draft SelectPlane confirmation behavior

### DIFF
--- a/wiki/Draft_SelectPlane.wikitext
+++ b/wiki/Draft_SelectPlane.wikitext
@@ -47,6 +47,7 @@ The [[Image:Draft_tray_button_plane.png]] button in the [[Draft_Tray|Draft Tray]
 #** [[Arch_AxisSystem|Arch AxisSystems]] ({{Version|1.0}})
 #** [[Arch_BuildingPart|Arch BuildingParts]]
 #** [[Arch_SectionPlane|Arch SectionPlanes]]
+#** [[Part_DatumPlane|Part DatumPlanes]].
 #** [[Std_Part|Std Parts]]: to avoid selecting subelements it is advisable to select these in the [[Tree_View|Tree View]].
 #** Non-solid objects that consist of a single flat face or a single curved edge, or ({{Version|1.0}}) that have three or more vertices.
 #** Solid objects or objects without a shape that have a {{PropertyData|Placement}} property. ({{Version|1.0}})
@@ -72,7 +73,7 @@ The [[Image:Draft_tray_button_plane.png]] button in the [[Draft_Tray|Draft Tray]
 # Do one of the following:
 #* Select a single object. See the [[#Usage_with_pre-selection|previous paragraph]].
 #* Select one or more subelements. See the [[#Usage_with_pre-selection|previous paragraph]].
-# Click anywhere in the [[3D_View|3D View]] to confirm the selection and finish the command.
+# Click an empty area in the [[3D_View|3D View]] to confirm the selection and finish the command. Clicking selectable geometry changes the selection instead of finishing the command.
 # The working plane and the button in the [[Draft_Tray|Draft Tray]] are updated.
 
 ==Usage with presets== <!--T:35-->


### PR DESCRIPTION
## Summary
- add Part DatumPlane to the documented Draft SelectPlane supported object list
- clarify that post-selection is confirmed by clicking an empty 3D View area

## Context
- Upstream FreeCAD change: FreeCAD/FreeCAD#23333
- Related documentation issue: #27

## Validation
- git diff --check -- wiki/Draft_SelectPlane.wikitext

Addresses part of #27.
