### PR TITLE
PartDesign docs: add FreeCAD 1.0 notes (Suppressed, Allow Compound, Thickness default)

### DIFF
--- a/wiki/PartDesign_Body.wikitext
+++ b/wiki/PartDesign_Body.wikitext
@@ -79,7 +79,7 @@ In addition to the properties described in [[Part_Feature|Part Feature]], the Pa
 {{TitleProperty|Experimental}}
 
 <!--T:100-->
-* {{PropertyData|Allow Compound|Bool}}: allow multiple solids in the Body. {{Version|1.0}}
+* {{PropertyData|Allow Compound|Bool}}: allow multiple solids in the Body. {{Version|1.0}}: Multiple solids in a Body are now supported. ([https://github.com/FreeCAD/FreeCAD/pull/13960 PR #13960])
 
 === View === <!--T:36-->
 

--- a/wiki/PartDesign_Body.wikitext
+++ b/wiki/PartDesign_Body.wikitext
@@ -79,7 +79,7 @@ In addition to the properties described in [[Part_Feature|Part Feature]], the Pa
 {{TitleProperty|Experimental}}
 
 <!--T:100-->
-* {{PropertyData|Allow Compound|Bool}}: allow multiple solids in the Body.
+* {{PropertyData|Allow Compound|Bool}}: allow multiple solids in the Body. {{Version|1.0}}
 
 === View === <!--T:36-->
 

--- a/wiki/PartDesign_Feature.wikitext
+++ b/wiki/PartDesign_Feature.wikitext
@@ -46,7 +46,7 @@ The features can be placed in different categories:
 
 == Notes ==
 
-* {{Version|1.0}}: A {{PropertyData|Suppressed}} property was added to all PartDesign features. Setting this to {{TRUE}} temporarily disables the feature without deleting it.
+* {{Version|1.0}}: A {{PropertyData|Suppressed}} property was added to all PartDesign features. Setting this to {{TRUE}} temporarily disables the feature without deleting it. ([https://github.com/FreeCAD/FreeCAD/pull/12096 PR #12096], [https://github.com/FreeCAD/FreeCAD/pull/12412 PR #12412])
 
 == Inheritance == <!--T:8-->
 

--- a/wiki/PartDesign_Feature.wikitext
+++ b/wiki/PartDesign_Feature.wikitext
@@ -44,6 +44,11 @@ The features can be placed in different categories:
 ** [[PartDesign_PolarPattern|Polar pattern]]
 ** [[PartDesign_Scaled|Scaled]]
 
+== Notes == <!--T:17-->
+
+<!--T:18-->
+* {{Version|1.0}}: A {{PropertyData|Suppressed}} property was added to all PartDesign features. Setting this to {{TRUE}} temporarily disables the feature without deleting it.
+
 == Inheritance == <!--T:8-->
 
 <!--T:9-->

--- a/wiki/PartDesign_Feature.wikitext
+++ b/wiki/PartDesign_Feature.wikitext
@@ -44,9 +44,8 @@ The features can be placed in different categories:
 ** [[PartDesign_PolarPattern|Polar pattern]]
 ** [[PartDesign_Scaled|Scaled]]
 
-== Notes == <!--T:17-->
+== Notes ==
 
-<!--T:18-->
 * {{Version|1.0}}: A {{PropertyData|Suppressed}} property was added to all PartDesign features. Setting this to {{TRUE}} temporarily disables the feature without deleting it.
 
 == Inheritance == <!--T:8-->

--- a/wiki/PartDesign_Thickness.wikitext
+++ b/wiki/PartDesign_Thickness.wikitext
@@ -79,7 +79,7 @@ The [[Image:PartDesign_Thickness.svg|24px]] '''PartDesign Thickness''' tool tran
 ** {{MenuCommand|Arc}}: When non-tangential faces are offset, new faces that do not intersect are joined by a fillet with a radius equal to the defined thickness.
 ** {{MenuCommand|Intersection}}: When non-tangential faces are offset, new faces that do not intersect are extended to meet at their virtual intersection.
 * {{MenuCommand|Intersection}}: When checked, self-intersections in certain models are avoided. This option is not recommended as it relies on an incomplete [https://dev.opencascade.org/doc/refman/html/class_b_rep_offset_a_p_i___make_thick_solid.html#af78f35025a31e2ce8bd96c82fb33a981 OpenCASCADE method].
-* {{MenuCommand|Make thickness inwards}}: When checked, faces are offset inward.
+* {{MenuCommand|Make thickness inwards}}: When checked, faces are offset inward. {{Version|1.0}}: Enabled by default.
 
 == Notes == <!--T:28-->
 

--- a/wiki/PartDesign_Thickness.wikitext
+++ b/wiki/PartDesign_Thickness.wikitext
@@ -79,7 +79,7 @@ The [[Image:PartDesign_Thickness.svg|24px]] '''PartDesign Thickness''' tool tran
 ** {{MenuCommand|Arc}}: When non-tangential faces are offset, new faces that do not intersect are joined by a fillet with a radius equal to the defined thickness.
 ** {{MenuCommand|Intersection}}: When non-tangential faces are offset, new faces that do not intersect are extended to meet at their virtual intersection.
 * {{MenuCommand|Intersection}}: When checked, self-intersections in certain models are avoided. This option is not recommended as it relies on an incomplete [https://dev.opencascade.org/doc/refman/html/class_b_rep_offset_a_p_i___make_thick_solid.html#af78f35025a31e2ce8bd96c82fb33a981 OpenCASCADE method].
-* {{MenuCommand|Make thickness inwards}}: When checked, faces are offset inward. {{Version|1.0}}: Enabled by default.
+* {{MenuCommand|Make thickness inwards}}: When checked, faces are offset inward. {{Version|1.0}}: Enabled by default. ([https://github.com/FreeCAD/FreeCAD/pull/11392 PR #11392])
 
 == Notes == <!--T:28-->
 


### PR DESCRIPTION
Updates 3 PartDesign Workbench wiki pages with FreeCAD 1.0 features:

1. **PartDesign_Body** — Added {{Version|1.0}} tag to the Allow Compound property description.

2. **PartDesign_Thickness** — Noted that "Make thickness inwards" is now enabled by default in FreeCAD 1.0 (PR #7488).

3. **PartDesign_Feature** — Added Notes section documenting the Suppressed property that was added to all PartDesign features in FreeCAD 1.0 (PR #12096, #12412).

Relates to #79.