### PR TITLE
Fix BIM Covering interactive offset typo

### DIFF
--- a/wiki/BIM_Covering.wikitext
+++ b/wiki/BIM_Covering.wikitext
@@ -182,7 +182,7 @@ Selecting Custom activates the {{Button|U Offset}} and {{Button|V Offset}} input
 
 The {{Button|Interactive}} button (available in Custom mode) enters an interactive grid placement mode. While active, a tile preview tracks the mouse cursor in the 3D View, anchored at its bottom-left corner.
 
-'''Setting the origin:''' click any point in the 3D View — typically a vertex of the base face — to set the grid origin at that point. The click ends the interactive session: the U offsed, V offset and rotation fields are updated automatically and the alignment is switched to Custom. To exit without placing, press {{KEY|Esc}}.
+'''Setting the origin:''' click any point in the 3D View — typically a vertex of the base face — to set the grid origin at that point. The click ends the interactive session: the U offset, V offset and rotation fields are updated automatically and the alignment is switched to Custom. To exit without placing, press {{KEY|Esc}}.
 
 '''Rotating the grid:''' optionally, before clicking to confirm the origin, press {{KEY|R}} to rotate the tile wireframe clockwise by one step, or {{KEY|Shift}}+{{KEY|R}} to rotate counter-clockwise. The Rotation field updates live with each keypress. The step size defaults to 15° and can be changed by setting {{PropertyView|PickRotationStep}} in the View tab of the object's properties panel.
 


### PR DESCRIPTION
Summary:
- Fixes a small typo in the BIM Covering interactive alignment instructions: "U offsed" -> "U offset".

Validation:
- `git diff --check -- wiki/BIM_Covering.wikitext`

Related issue:
- Part of the BIM Workbench documentation cleanup requested in #26.