### PR TITLE
Document BIM menu and toolbar release notes

### DIFF
--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -120,18 +120,17 @@ ToDo (last check: 20260430, #27222):
 * https://github.com/FreeCAD/FreeCAD/pull/24190
 * https://github.com/FreeCAD/FreeCAD/pull/24550
 * https://github.com/FreeCAD/FreeCAD/pull/24595
-* https://github.com/FreeCAD/FreeCAD/pull/25086
-* https://github.com/FreeCAD/FreeCAD/pull/25147
 * https://github.com/FreeCAD/FreeCAD/pull/26758
 * https://github.com/FreeCAD/FreeCAD/pull/27222
-* https://github.com/FreeCAD/FreeCAD/pull/27381
-* https://github.com/FreeCAD/FreeCAD/pull/27420
 * https://github.com/FreeCAD/FreeCAD/pull/27746
 * https://github.com/FreeCAD/FreeCAD/pull/28036
 * https://github.com/FreeCAD/FreeCAD/pull/28104
 * https://github.com/FreeCAD/FreeCAD/pull/28504
+* The BIM Project command was removed from the toolbar, moved to the Utils menu, renamed for IFC-project clarity, and the Setup Project dialog now defaults to non-IFC-native projects. [https://github.com/FreeCAD/FreeCAD/pull/25086 Pull request #25086]
+* The BIM toolbar layout was decluttered by grouping related commands, removing the Shape from Text and BIM Views entries from the default toolbar, and rearranging common drafting and copy tools. [https://github.com/FreeCAD/FreeCAD/pull/25147 Pull request #25147]
 * [[BIM_Windows|BIM Windows]] now include a Sliding Door preset whose opening follows the {{incode|Opening}} property, and the Tree View context menu can invert the sliding direction. [https://github.com/FreeCAD/FreeCAD/pull/27375 Pull request #27375]
 * [[BIM_Windows|BIM Windows]] now provide a task-panel options box for editing common window properties with expression-aware fields and a cancel action. [https://github.com/FreeCAD/FreeCAD/pull/27381 Pull request #27381]
+* [[BIM_Windows|BIM Window]] types can now use LinkGroups, avoiding out-of-scope subvolume warnings while preserving unset base-object properties. [https://github.com/FreeCAD/FreeCAD/pull/27420 Pull request #27420]
 
 === Further BIM improvements ===
 


### PR DESCRIPTION
Summary:
- syncs three BIM 1.2 entries into the English release notes
- removes the corresponding upstream PRs from the English BIM TODO list once documented

Related bounty or issue:
- Refs #26

What changed:
- documents the BIM Project command toolbar/menu change from FreeCAD/FreeCAD#25086
- documents the BIM toolbar layout cleanup from FreeCAD/FreeCAD#25147
- documents BIM Window LinkGroup support from FreeCAD/FreeCAD#27420
- removes FreeCAD/FreeCAD#27381 from the English TODO list because its entry is already present

Validation:
- git diff --check -- wiki/en/Release_notes_1.2.wikitext

Notes:
- This is a focused release-note sync for a few BIM items and does not claim the broader BIM documentation bounty is complete.
