### PR TITLE
Document PartDesign empty transform selection messages

### DIFF
--- a/wiki/PartDesign_LinearPattern.wikitext
+++ b/wiki/PartDesign_LinearPattern.wikitext
@@ -42,6 +42,8 @@ The [[Image:PartDesign_LinearPattern.svg|24px]] '''PartDesign LinearPattern''' t
 #* Select the {{MenuCommand|Part Design → Transformation Features → [[Image:PartDesign_LinearPattern.svg|16px]] Linear Pattern}} option from the menu.
 # If there is no active Body, and there are two or more Bodies in the document, the {{MenuCommand|Active Body Required}} dialog will open and prompt you to activate one. If there is a single Body it will be activated automatically.
 # The {{MenuCommand|Linear Pattern Parameters}} [[Task_Panel|task panel]] opens. See [[#Options|Options]] for more information.
+<!--T:36-->
+# Make sure the feature list is not empty. {{Version|1.2}}: If the task panel is accepted without any feature, FreeCAD reports that no features were selected to be patterned.
 # Press the {{Button|OK}} button to finish.
 
 === Edit === <!--T:32-->

--- a/wiki/PartDesign_Mirrored.wikitext
+++ b/wiki/PartDesign_Mirrored.wikitext
@@ -42,6 +42,8 @@ The [[Image:PartDesign_Mirrored.svg|24px]] '''PartDesign Mirrored''' tool mirror
 #* Select the {{MenuCommand|Part Design → Transformation Features → [[Image:PartDesign_Mirrored.svg|16px]] Mirror}} option from the menu.
 # If there is no active Body, and there are two or more Bodies in the document, the {{MenuCommand|Active Body Required}} dialog will open and prompt you to activate one. If there is a single Body it will be activated automatically.
 # The {{MenuCommand|Mirror Parameters}} [[Task_Panel|task panel]] opens. See [[#Options|Options]] for more information.
+<!--T:50-->
+# Make sure the feature list is not empty. {{Version|1.2}}: If the task panel is accepted without any feature, FreeCAD reports that no features were selected to be mirrored.
 # Press the {{Button|OK}} button to finish.
 
 === Edit === <!--T:46-->

--- a/wiki/PartDesign_MultiTransform.wikitext
+++ b/wiki/PartDesign_MultiTransform.wikitext
@@ -45,6 +45,8 @@ The available transformations are: [[Image:PartDesign_Mirrored.svg|16px|link=Par
 #* Select the {{MenuCommand|Part Design → Transformation Features → [[Image:PartDesign_MultiTransform.svg|16px]] Multi-Transform}} option from the menu.
 # If there is no active Body, and there are two or more Bodies in the document, the {{MenuCommand|Active Body Required}} dialog will open and prompt you to activate one. If there is a single Body it will be activated automatically.
 # The {{MenuCommand|Multi-Transform Parameters}} [[Task_Panel|task panel]] opens. See [[#Options|Options]] for more information.
+<!--T:58-->
+# Make sure the feature list is not empty. {{Version|1.2}}: If the task panel is accepted without any feature, FreeCAD reports that no features were selected to be transformed.
 # Press the {{Button|OK}} button at the top to finish.
 
 === Edit === <!--T:45-->

--- a/wiki/PartDesign_PolarPattern.wikitext
+++ b/wiki/PartDesign_PolarPattern.wikitext
@@ -42,6 +42,8 @@ The [[Image:PartDesign_PolarPattern.svg|24px]] '''PartDesign PolarPattern''' too
 #* Select the {{MenuCommand|Part Design → Transformation Features → [[Image:PartDesign_PolarPattern.svg|16px]] Polar Pattern}} option from the menu.
 # If there is no active Body, and there are two or more Bodies in the document, the {{MenuCommand|Active Body Required}} dialog will open and prompt you to activate one. If there is a single Body it will be activated automatically.
 # The {{MenuCommand|Polar Pattern Parameters}} [[Task_Panel|task panel]] opens. See [[#Options|Options]] for more information.
+<!--T:57-->
+# Make sure the feature list is not empty. {{Version|1.2}}: If the task panel is accepted without any feature, FreeCAD reports that no features were selected to be patterned.
 # Press the {{Button|OK}} button to finish.
 
 === Edit === <!--T:52-->


### PR DESCRIPTION
Part of #79.

This documents the FreeCAD 1.2 user-facing messages added in FreeCAD/FreeCAD#26565 when PartDesign transformation tools are accepted with an empty feature list.

Updated pages:
- PartDesign Mirrored
- PartDesign LinearPattern
- PartDesign PolarPattern
- PartDesign MultiTransform

Duplicate check: no existing PR found for "empty transformed", "No features selected", or FreeCAD/FreeCAD#26565.

Validation: git diff --check