### PR TITLE
Document BIM wall release notes in English

### DIFF
--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -118,8 +118,6 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 ToDo (last check: 20260430, #27222):
 * https://github.com/FreeCAD/FreeCAD/pull/24078
 * https://github.com/FreeCAD/FreeCAD/pull/24190
-* https://github.com/FreeCAD/FreeCAD/pull/24550
-* https://github.com/FreeCAD/FreeCAD/pull/24595
 * https://github.com/FreeCAD/FreeCAD/pull/25086
 * https://github.com/FreeCAD/FreeCAD/pull/25147
 * https://github.com/FreeCAD/FreeCAD/pull/26758
@@ -130,6 +128,8 @@ ToDo (last check: 20260430, #27222):
 * https://github.com/FreeCAD/FreeCAD/pull/28036
 * https://github.com/FreeCAD/FreeCAD/pull/28104
 * https://github.com/FreeCAD/FreeCAD/pull/28504
+* [[Arch_Wall|Walls]] can now be created without a base object by default, with the selected wall baseline mode remembered in preferences. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]
+* Removing a wall base now preserves the wall's placement and parametric dimensions for supported straight Draft or Sketch bases, and warns before removing unsupported complex bases. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
 * [[BIM_Windows|BIM Windows]] now include a Sliding Door preset whose opening follows the {{incode|Opening}} property, and the Tree View context menu can invert the sliding direction. [https://github.com/FreeCAD/FreeCAD/pull/27375 Pull request #27375]
 * [[BIM_Windows|BIM Windows]] now provide a task-panel options box for editing common window properties with expression-aware fields and a cancel action. [https://github.com/FreeCAD/FreeCAD/pull/27381 Pull request #27381]
 


### PR DESCRIPTION
Summary:
- syncs two BIM wall entries into the English FreeCAD 1.2 release notes
- removes the corresponding upstream PRs from the English BIM TODO list once documented

Related bounty or issue:
- Refs #26

What changed:
- documents baseless wall creation defaults from FreeCAD/FreeCAD#24595
- documents wall base removal behavior from FreeCAD/FreeCAD#24550

Validation:
- git diff --check -- wiki/en/Release_notes_1.2.wikitext

Notes:
- This is a focused release-note sync for two BIM wall items and does not claim the broader BIM documentation bounty is complete.
