### PR TITLE
Document Measure curved face support

### DIFF
--- a/wiki/Std_Measure.wikitext
+++ b/wiki/Std_Measure.wikitext
@@ -42,14 +42,14 @@ The '''Std Measure''' command gives access to the Unified Measurement Facility. 
 # If no geometrical entities were preselected, do one of the following:
 #* Select the geometrical entities while leaving the ''Mode'' as ''Auto'' so that the mode will be automatically determined based on the selection.
 #* Choose a ''Mode'' other than ''Auto'' and then select the geometrical entities (clicking on them again will deselect them):
-#** ''Distance'' - the shortest distance between the selected entities, if circular/arc edges are selected, then the distance between the centers of the circles/arcs is measured,
+#** ''Distance'' - the shortest distance between the selected entities, including ({{Version|1.2}}) curved faces such as cylindrical, spherical, conical and toroidal faces. If circular/arc edges are selected, then the distance between the centers of the circles/arcs is measured,
 #** ''Distance Free'' - distance between two freely selected points (belonging to different entities - edges, faces),
 #** ''Angle'' - angle between the selected entities,
 #** ''Length'' - length of the selected edge,
 #** ''Position'' - coordinates of the selected vertex,
 #** ''Area'' - area of the selected face,
-#** ''Diameter'' - {{Version|1.2}}: diameter of the selected circular/arc edge or cylindrical/circular face,
-#** ''Radius'' - radius of the selected circular/arc edge or ({{Version|1.2}}) cylindrical/circular face,
+#** ''Diameter'' - {{Version|1.2}}: diameter of the selected circular/arc edge, cylindrical/circular face, spherical face or toroidal face,
+#** ''Radius'' - radius of the selected circular/arc edge or ({{Version|1.2}}) cylindrical/circular face, spherical face or toroidal face,
 #** ''Center of Mass'' - COM of the selected edge, face or solid (only if preselected in the tree).
 # The measurement result will be shown in the ''Result'' field and on a label displayed in the [[3D_View|3D View]]. That label will also include an icon indicating the type of measurement. The labels can be customized in the [[Preferences_Editor|Preferences]]. They can be moved in the 3D View by dragging them with a cursor.
 #* {{Version|1.2}}: To change the unit of the measurement value displayed in the ''Result'' field, select the desired unit from the dropdown list next to the ''Result'' field.


### PR DESCRIPTION
Part of #28.

This updates the Std Measure page for recent FreeCAD 1.2 behavior:
- FreeCAD/FreeCAD#29367: Distance mode accepts curved faces such as spherical, conical and toroidal faces.
- FreeCAD/FreeCAD#29369: Radius/Diameter measurements support spherical and toroidal faces.

Duplicate check: no existing PR found for Measure curved face, sphere/torus, or FreeCAD/FreeCAD#29367/#29369 documentation.

Validation: git diff --check -- wiki/Std_Measure.wikitext