### PR TITLE
Document Native IFC material layer import fix

### DIFF
--- a/wiki/Native_IFC.wikitext
+++ b/wiki/Native_IFC.wikitext
@@ -181,7 +181,7 @@ IFC '''properties''', which are grouped under property sets, are custom properti
 '''Layers''' get loaded when double-clicking an object. Layers get represented as [[Draft Layer|normal FreeCAD layers]], but they are hosted inside the IFC project. When using the [[BIM Layers]] tool, an additional icon indicates if the layer is part of an IFC project or not.
 
 <!--T:58-->
-'''Materials''' follow the same logic. They are only loaded when double-clicking the object, they are represented as normal [[Arch Material|materials]], but get hosted inside the IFC project.
+'''Materials''' follow the same logic. They are only loaded when double-clicking the object, they are represented as normal [[Arch Material|materials]], but get hosted inside the IFC project. In FreeCAD 1.2 and later, Native IFC import handles IFC logical values on material layers, such as {{Incode|IfcMaterialLayer.IsVentilated}}, so layers can load when these values are {{Incode|UNKNOWN}} or boolean values.
 
 == Building structure == <!--T:59-->
 

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -163,6 +163,7 @@ ToDo (last check: 20260430, #27222):
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
 * [[BIM_DrawingView|DrawingView]] cut lines now use the default line width and cut areas line thickness ratio preferences for thicker cut-line output. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]
 * IFC import now treats a multicore preference value of 0 as disabled before creating the IfcOpenShell geometry iterator, avoiding invalid worker counts when multicore processing is turned off. [https://github.com/FreeCAD/FreeCAD/pull/30201 Pull request #30201]
+* [[Native_IFC|Native IFC]] import now handles {{incode|IfcLogical}} values on material-layer attributes, including {{incode|IfcMaterialLayer.IsVentilated}}, avoiding crashes when those values are {{incode|UNKNOWN}} or boolean. [https://github.com/FreeCAD/FreeCAD/pull/28591 Pull request #28591]
 
 == CAM Workbench == <!--T:25-->
 


### PR DESCRIPTION
## Summary
- Documents that Native IFC import handles IFC logical values on material-layer attributes such as `IfcMaterialLayer.IsVentilated` in FreeCAD 1.2 and later.
- Adds a matching FreeCAD 1.2 release note for FreeCAD/FreeCAD#28591.

## Source
- FreeCAD/FreeCAD#28591

## Bounty
- Contributes to #26.

## Verification
- Checked existing documentation PRs and wiki content for `28591`, `IfcLogical`, and `IsVentilated`; no duplicate coverage found.
- Reviewed the source PR metadata and implementation summary for the Native IFC material-layer import fix.
