### PR TITLE
Document temporary Exploded View release note

### DIFF
--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -112,6 +112,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * A new command has been added to select all joints associated with a chosen component. [https://github.com/FreeCAD/FreeCAD/pull/27530 Pull request #27530]
 * A button was added to rotate joint offsets by 90 degrees. [https://github.com/FreeCAD/FreeCAD/pull/29717 Pull request #29717]
 * Editing sketches from assemblies no longer briefly activates the sketch's source document or crashes when leaving the Assembly context. [https://github.com/FreeCAD/FreeCAD/pull/29271 Pull request #29271]
+* [[Assembly_CreateView|Exploded View]] can now be created temporarily. [https://github.com/FreeCAD/FreeCAD/pull/25456 Pull request #25456]
 
 == BIM Workbench ==
 


### PR DESCRIPTION
Summary:
- adds the temporary Exploded View entry to the English FreeCAD 1.2 release notes

Related bounty or issue:
- Refs #30

What changed:
- documents the Assembly CreateView temporary exploded-view behavior from FreeCAD/FreeCAD#25456

Validation:
- git diff --check -- wiki/en/Release_notes_1.2.wikitext

Notes:
- This is a focused release-note sync and does not claim the broader missing-release-notes bounty is complete.
