### PR TITLE
Document BIM IFC class list update

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -163,6 +163,7 @@ ToDo (last check: 20260430, #27222):
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
 * [[BIM_DrawingView|DrawingView]] cut lines now use the default line width and cut areas line thickness ratio preferences for thicker cut-line output. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]
 * IFC import now treats a multicore preference value of 0 as disabled before creating the IfcOpenShell geometry iterator, avoiding invalid worker counts when multicore processing is turned off. [https://github.com/FreeCAD/FreeCAD/pull/30201 Pull request #30201]
+* Native IFC objects now expose the full active-schema class list for their object type in the {{incode|IfcClass}} property, including IFC2X3 type families. [https://github.com/FreeCAD/FreeCAD/pull/28994 Pull request #28994]
 
 == CAM Workbench == <!--T:25-->
 


### PR DESCRIPTION
## Summary
- Add a BIM release note for native IFC objects exposing the full active-schema `IfcClass` list.
- Cite FreeCAD/FreeCAD#28994 as the source.

## Validation
- `git diff --check HEAD^ HEAD`

Addresses #26.
