### PR TITLE
Document baseless wall endpoint editing

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -146,6 +146,7 @@ ToDo (last check: 20260430, #27222):
 <translate>
 <!--T:86-->
 * [[Arch_Wall|Walls]] can now be created without a base object by default, with the selected wall baseline mode remembered in preferences. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]
+* [[Arch_Wall|Walls]] without a base object now expose editable endpoints when using [[Draft_Edit|Draft Edit]], allowing their baseline to be adjusted directly. [https://github.com/FreeCAD/FreeCAD/pull/29860 Pull request #29860]
 * Removing a wall base now preserves the wall's placement and parametric dimensions for supported straight Draft or Sketch bases, and warns before removing unsupported complex bases. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
 * The BIM Project command was removed from the toolbar, moved to the Utils menu, renamed for IFC-project clarity, and the Setup Project dialog now defaults to non-IFC-native projects. [https://github.com/FreeCAD/FreeCAD/pull/25086 Pull request #25086]
 * The BIM toolbar layout was decluttered by grouping related commands, removing the Shape from Text and BIM Views entries from the default toolbar, and rearranging common drafting and copy tools. [https://github.com/FreeCAD/FreeCAD/pull/25147 Pull request #25147]


### PR DESCRIPTION
Summary:
- adds a FreeCAD 1.2 release-note entry for FreeCAD/FreeCAD#29860

Related bounty or issue:
- Refs #30

What changed:
- documents that walls without a base object now expose editable endpoints when using Draft Edit
- keeps the update limited to the root `wiki/Release_notes_1.2.wikitext` page

Validation:
- `git diff --check -- wiki/Release_notes_1.2.wikitext`
- checked the current root release notes for an existing FreeCAD/FreeCAD#29860 entry before editing

Notes:
- Translation files were intentionally not modified.
- This is a focused release-note addition and does not claim the broader release-note bounty issue is complete.
