### PR TITLE
Document Assembly simulation playback buttons

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -132,6 +132,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * A new command has been added to select all joints associated with a chosen component. [https://github.com/FreeCAD/FreeCAD/pull/27530 Pull request #27530]
 * A button was added to rotate joint offsets by 90 degrees. [https://github.com/FreeCAD/FreeCAD/pull/29717 Pull request #29717]
 * Editing sketches from assemblies no longer briefly activates the sketch's source document or crashes when leaving the Assembly context. [https://github.com/FreeCAD/FreeCAD/pull/29271 Pull request #29271]
+* The simulation playback controls now use larger and more distinguishable play and step buttons. [https://github.com/FreeCAD/FreeCAD/pull/30257 Pull request #30257]
 * [[Assembly_CreateSimulation|Simulations]] now offer export to video format. [https://github.com/FreeCAD/FreeCAD/pull/25307 Pull request #25307]
 * [[Assembly_CreateView|Exploded View]] can now be created temporarily. [https://github.com/FreeCAD/FreeCAD/pull/25456 Pull request #25456]
 


### PR DESCRIPTION
Summary:
- Add a FreeCAD 1.2 release-note entry for the Assembly simulation playback button UI update.

Related bounty or issue:
- Reqrefusion/FreeCAD-Documentation-Project#30
- FreeCAD/FreeCAD#30257

What changed:
- Added one root `wiki/Release_notes_1.2.wikitext` bullet describing the larger, more distinguishable simulation playback play/step buttons.

Validation:
- Checked current root release notes for existing #30257/playback-control coverage.
- Ran `git diff --check -- wiki/Release_notes_1.2.wikitext`.

Notes:
- This PR only edits the wiki root release-notes file; it does not modify translation files or add manual translation tags.
