### PR TITLE
Document VS Code embedded Python paths

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -105,6 +105,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * [[Image:Part_SelectFilter.svg|24px]] [[Part_SelectFilter|Selection filters]] can now select other entities within the viewer pick radius instead of immediately showing the blocked-selection state. [https://github.com/FreeCAD/FreeCAD/pull/29705 Pull request #29705]
 * FreeCAD was adapted for OpenCascade 8 while keeping OpenCascade 7 compatibility, updating geometry, import/export, CAM, Sketcher, FEM mesh, and related code paths. [https://github.com/FreeCAD/FreeCAD/pull/25502 Pull request #25502]
 * On Unix-like systems, lock files now use owner-only permissions, and Coin image export avoids creating world-writable files. [https://github.com/FreeCAD/FreeCAD/pull/30239 Pull request #30239]
+* The bundled VS Code workspace settings now include FreeCAD's embedded Python search paths, improving Python module resolution when developing FreeCAD with VS Code. [https://github.com/FreeCAD/FreeCAD/pull/22743 Pull request #22743]
 
 === API === <!--T:15-->
 


### PR DESCRIPTION
Summary:
- Add a FreeCAD 1.2 release-note bullet for the VS Code workspace settings update that includes FreeCAD's embedded Python search paths.

Related issue/source:
- Source change: https://github.com/FreeCAD/FreeCAD/pull/22743
- This is a narrow release-note update only; it is not a payout claim.

What changed:
- Added one bullet under the Core improvements section of `wiki/Release_notes_1.2.wikitext`.
- Edited only the root source wiki page.

Validation:
- Checked the current root FreeCAD 1.2 and 1.1 release-note pages for existing mentions of PR #22743, VS Code, embedded Python paths, and Python module resolution.
- Checked existing documentation PRs for duplicate PR #22743 / VS Code embedded Python path coverage.
- Ran `git diff --check -- wiki/Release_notes_1.2.wikitext`.

Notes:
- No translation or localized wiki files were edited.
- No translation tags were added manually.
