### PR TITLE
Document BIM Merge Walls message

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -149,6 +149,7 @@ ToDo (last check: 20260430, #27222):
 <!--T:86-->
 * Removing a wall base now preserves the wall's placement and parametric dimensions for supported straight Draft or Sketch bases, and warns before removing unsupported complex bases. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
 * [[Arch_Wall|Walls]] can now be created without a base object by default, with the selected wall baseline mode remembered in preferences. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]
+* The [[Arch_MergeWalls|Merge Walls]] command now reports when selected walls are not the same type. [https://github.com/FreeCAD/FreeCAD/pull/24060 Pull request #24060]
 * The BIM Project command was removed from the toolbar, moved to the Utils menu, renamed for IFC-project clarity, and the Setup Project dialog now defaults to non-IFC-native projects. [https://github.com/FreeCAD/FreeCAD/pull/25086 Pull request #25086]
 * The BIM toolbar layout was decluttered by grouping related commands, removing the Shape from Text and BIM Views entries from the default toolbar, and rearranging common drafting and copy tools. [https://github.com/FreeCAD/FreeCAD/pull/25147 Pull request #25147]
 * [[Arch_Wall|Walls]] now provide task-panel options for common wall properties, and the same quick-access task-box framework was extended to other BIM objects. [https://github.com/FreeCAD/FreeCAD/pull/26758 Pull request #26758] and [https://github.com/FreeCAD/FreeCAD/pull/27746 Pull request #27746]


### PR DESCRIPTION
Summary:
- Add a FreeCAD 1.2 release-note bullet for the BIM Merge Walls message added in FreeCAD/FreeCAD#24060.

Related issue/source:
- Source change: https://github.com/FreeCAD/FreeCAD/pull/24060
- This is a narrow FreeCAD 1.2 release-note update only; it is not a payout claim.

What changed:
- Added one bullet under the BIM Workbench section of `wiki/Release_notes_1.2.wikitext`.
- Edited only the root FreeCAD 1.2 release-note source page.

Validation:
- Checked the current root FreeCAD 1.2 release-note page for existing mentions of PR #24060 / Merge Walls.
- Checked existing documentation PRs for duplicate PR #24060 / Merge Walls coverage.
- Ran `git diff --check -- wiki/Release_notes_1.2.wikitext`.

Notes:
- No FreeCAD 1.1 release-note file was edited.
- No translation or localized wiki files were edited.
- No translation tags were added manually.
