### PR TITLE
Add missing BIM Workbench tool descriptions

### DIFF
--- a/wiki/BIM_Workbench.wikitext
+++ b/wiki/BIM_Workbench.wikitext
@@ -563,10 +563,10 @@ This menu contains the [[Draft_Snap|Draft Snap]] tools as well as the following 
 * [[Image:BIM_Unclone.svg|32px]] [[BIM_Unclone|Unclone]]: Makes a cloned object independent from its original object
 
 <!--T:199-->
-* [[Image:BIM_Rewire.svg|32px]] [[BIM_Rewire|Rewire]]:
+* [[Image:BIM_Rewire.svg|32px]] [[BIM_Rewire|Rewire]]: Recreates wires from the edges of selected objects.
 
 <!--T:200-->
-* [[Image:BIM_Glue.svg|32px]] [[BIM_Glue|Glue]]:
+* [[Image:BIM_Glue.svg|32px]] [[BIM_Glue|Glue]]: Joins selected shapes into one non-parametric compound shape.
 
 <!--T:201-->
 * [[Image:BIM_Reextrude.svg|32px]] [[BIM_Reextrude|Re-Extrude]]: Recreates an extrusion from a shape that has lost its parametric extrusion by selecting a base face
@@ -602,16 +602,16 @@ This menu contains the [[Draft_Snap|Draft Snap]] tools as well as the following 
 * [[Image:BIM_Project.svg|32px]] [[BIM_Project|IFC Project]]: Creates an IFC project including selected objects.
 
 <!--T:211-->
-* [[Image:IFC_Diff.svg|32px]] [[IFC_Diff|IFC Diff]]:
+* [[Image:IFC_Diff.svg|32px]] [[IFC_Diff|IFC Diff]]: Shows the current unsaved changes in the IFC file.
 
 <!--T:212-->
-* [[Image:IFC_Expand.svg|32px]] [[IFC_Expand|IFC Expand]]:
+* [[Image:IFC_Expand.svg|32px]] [[IFC_Expand|IFC Expand]]: Expands the children of the selected objects or of the document.
 
 <!--T:213-->
-* [[Image:IFC_MakeProject.svg|32px]] [[IFC_MakeProject|Convert to IFC Project]]:
+* [[Image:IFC_MakeProject.svg|32px]] [[IFC_MakeProject|Convert to IFC Project]]: Converts the current selection to an IFC project.
 
 <!--T:214-->
-* [[Image:IFC_UpdateIOS.svg|32px]] [[IFC_UpdateIOS|IfcOpenShell Update]]:
+* [[Image:IFC_UpdateIOS.svg|32px]] [[IFC_UpdateIOS|IfcOpenShell Update]]: Updates the bundled IfcOpenShell components used by the native IFC tools.
 
 <!--T:215-->
 * Nudge:

--- a/wiki/en/BIM_Workbench.wikitext
+++ b/wiki/en/BIM_Workbench.wikitext
@@ -378,9 +378,9 @@ This menu contains the [[Draft_Snap|Draft Snap]] tools as well as the following 
 
 * [[Image:BIM_Unclone.svg|32px]] [[BIM_Unclone|Unclone]]: Makes a cloned object independent from its original object
 
-* [[Image:BIM_Rewire.svg|32px]] [[BIM_Rewire|Rewire]]:
+* [[Image:BIM_Rewire.svg|32px]] [[BIM_Rewire|Rewire]]: Recreates wires from the edges of selected objects.
 
-* [[Image:BIM_Glue.svg|32px]] [[BIM_Glue|Glue]]:
+* [[Image:BIM_Glue.svg|32px]] [[BIM_Glue|Glue]]: Joins selected shapes into one non-parametric compound shape.
 
 * [[Image:BIM_Reextrude.svg|32px]] [[BIM_Reextrude|Re-Extrude]]: Recreates an extrusion from a shape that has lost its parametric extrusion by selecting a base face
 
@@ -398,19 +398,19 @@ This menu contains the [[Draft_Snap|Draft Snap]] tools as well as the following 
 
 :* [[Image:Arch_Structure.svg|32px]] [[Arch_Structure|Structure]]: Creates a structural element from scratch or using a selected object as a base.
 
-:* [[Image:Arch_StructuralSystem.svg|32px]] [[Arch_StructuralSystem|Structural System]]:
+:* [[Image:Arch_StructuralSystem.svg|32px]] [[Arch_StructuralSystem|Structural System]]: Creates a structural system by distributing a structure along axis systems.
 
-:* [[Image:Arch_StructuresFromSelection.svg|32px]] [[Arch_StructuresFromSelection|Multiple Structures]]:
+:* [[Image:Arch_StructuresFromSelection.svg|32px]] [[Arch_StructuresFromSelection|Multiple Structures]]: Creates multiple structural elements from selected edges, using each edge as an extrusion path.
 
 * [[Image:BIM_Project.svg|32px]] [[BIM_Project|IFC Project]]: Creates an IFC project including selected objects.
 
-* [[Image:IFC_Diff.svg|32px]] [[IFC_Diff|IFC Diff]]:
+* [[Image:IFC_Diff.svg|32px]] [[IFC_Diff|IFC Diff]]: Shows the current unsaved changes in the IFC file.
 
-* [[Image:IFC_Expand.svg|32px]] [[IFC_Expand|IFC Expand]]:
+* [[Image:IFC_Expand.svg|32px]] [[IFC_Expand|IFC Expand]]: Expands the children of the selected objects or of the document.
 
-* [[Image:IFC_MakeProject.svg|32px]] [[IFC_MakeProject|Convert to IFC Project]]:
+* [[Image:IFC_MakeProject.svg|32px]] [[IFC_MakeProject|Convert to IFC Project]]: Converts the current selection to an IFC project.
 
-* [[Image:IFC_UpdateIOS.svg|32px]] [[IFC_UpdateIOS|IfcOpenShell Update]]:
+* [[Image:IFC_UpdateIOS.svg|32px]] [[IFC_UpdateIOS|IfcOpenShell Update]]: Updates the bundled IfcOpenShell components used by the native IFC tools.
 
 * Nudge:
 


### PR DESCRIPTION
Summary
- Fill in missing descriptions for several BIM Workbench utility/IFC tools.
- Keep the translatable root page and the English page aligned.

Validation
- Ran `git diff --check`.
- Verified the edited pages contain the new Rewire and IFC Expand descriptions.

Issue
- Helps with #26 by adding missing BIM Workbench documentation details.

Notes
- Descriptions are based on the current FreeCAD command tooltips/source behavior where available.