### PR TITLE
Document Windows file dialog start directory

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -53,6 +53,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Double-clicking on an expression field now clears the expression and keeps the current value. If no change is made, the expression is restored after losing focus. [https://github.com/FreeCAD/FreeCAD/pull/29414 Pull request #29414]
 * SpaceMouse rotations now honor the active navigation rotation center mode, including ''Object center'' and ''Drag at cursor'' modes. [https://github.com/FreeCAD/FreeCAD/pull/29998 Pull request #29998]
 * On macOS release builds, 3Dconnexion SpaceMouse devices now initialize correctly instead of reporting that the Navigation Framework is running outside an application bundle. [https://github.com/FreeCAD/FreeCAD/pull/29465 Pull request #29465]
+* On Windows, the File Open dialog now starts in FreeCAD's configured file-open/save path instead of the last directory remembered by Windows across FreeCAD versions. [https://github.com/FreeCAD/FreeCAD/pull/30059 Pull request #30059]
 * The [[Std_VarSet|VarSet]] ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 * There is now a warning when saving files created in older versions. A preference was added to allow disabling it. [https://github.com/FreeCAD/FreeCAD/pull/28389 Pull request #28389]
 * Clearing the recent files list now asks for confirmation before the list is removed. [https://github.com/FreeCAD/FreeCAD/pull/27274 Pull request #27274]


### PR DESCRIPTION
Summary:
- Add a FreeCAD 1.2 release-note bullet for the Windows File Open dialog start-directory fix from FreeCAD/FreeCAD#30059.

Related issue/source:
- Source change: https://github.com/FreeCAD/FreeCAD/pull/30059
- Fixed upstream issue: https://github.com/FreeCAD/FreeCAD/issues/30042
- This is a narrow FreeCAD 1.2 release-note update only; it is not a payout claim.

What changed:
- Added one bullet under the user-interface improvements section of `wiki/Release_notes_1.2.wikitext`.
- Edited only the root FreeCAD 1.2 release-note source page.

Validation:
- Checked the current root FreeCAD 1.2 release-note page for existing mentions of PR #30059 / Win32 FileDialog / configured directory behavior.
- Checked existing documentation PRs for duplicate PR #30059 / Windows File Open dialog coverage.
- Ran `git diff --check -- wiki/Release_notes_1.2.wikitext`.

Notes:
- No FreeCAD 1.1 release-note file was edited.
- No translation or localized wiki files were edited.
- No translation tags were added manually.
