### PR TITLE
Document Qt5 deprecation notice

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -104,6 +104,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Status_Bar#Quick_Measure|Quick Measure]] feature now shows the diameter of circular faces. [https://github.com/FreeCAD/FreeCAD/pull/29385 Pull request #29385]
 * [[Image:Part_SelectFilter.svg|24px]] [[Part_SelectFilter|Selection filters]] can now select other entities within the viewer pick radius instead of immediately showing the blocked-selection state. [https://github.com/FreeCAD/FreeCAD/pull/29705 Pull request #29705]
 * FreeCAD was adapted for OpenCascade 8 while keeping OpenCascade 7 compatibility, updating geometry, import/export, CAM, Sketcher, FEM mesh, and related code paths. [https://github.com/FreeCAD/FreeCAD/pull/25502 Pull request #25502]
+* CMake now warns that Qt 5 support is deprecated and scheduled for removal, prompting packagers and builders to update to Qt 6. [https://github.com/FreeCAD/FreeCAD/pull/30222 Pull request #30222]
 * On Unix-like systems, lock files now use owner-only permissions, and Coin image export avoids creating world-writable files. [https://github.com/FreeCAD/FreeCAD/pull/30239 Pull request #30239]
 
 === API === <!--T:15-->


### PR DESCRIPTION
Summary:
- Add a FreeCAD 1.2 release-note bullet for the CMake Qt 5 deprecation warning from FreeCAD/FreeCAD#30222.

Related issue/source:
- Source change: https://github.com/FreeCAD/FreeCAD/pull/30222
- This is a narrow FreeCAD 1.2 release-note update only; it is not a payout claim.

What changed:
- Added one bullet under the Core improvements section of `wiki/Release_notes_1.2.wikitext`.
- Edited only the root FreeCAD 1.2 release-note source page.

Validation:
- Checked the current root FreeCAD 1.2 release-note page for existing mentions of PR #30222 / Qt 5 deprecation / Qt 6 build warning.
- Checked existing documentation PRs for duplicate PR #30222 / Qt 5 deprecation coverage.
- Ran `git diff --check -- wiki/Release_notes_1.2.wikitext`.

Notes:
- No FreeCAD 1.1 release-note file was edited.
- No translation or localized wiki files were edited.
- No translation tags were added manually.
- This documents a build/deprecation notice, not a regression correction.
