### PR TITLE
Document Conda warning-as-error preset

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -105,6 +105,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * [[Image:Part_SelectFilter.svg|24px]] [[Part_SelectFilter|Selection filters]] can now select other entities within the viewer pick radius instead of immediately showing the blocked-selection state. [https://github.com/FreeCAD/FreeCAD/pull/29705 Pull request #29705]
 * FreeCAD was adapted for OpenCascade 8 while keeping OpenCascade 7 compatibility, updating geometry, import/export, CAM, Sketcher, FEM mesh, and related code paths. [https://github.com/FreeCAD/FreeCAD/pull/25502 Pull request #25502]
 * On Unix-like systems, lock files now use owner-only permissions, and Coin image export avoids creating world-writable files. [https://github.com/FreeCAD/FreeCAD/pull/30239 Pull request #30239]
+* The Conda release build preset now enables {{Incode|FREECAD_WARN_ERROR}}, and related warnings were fixed so release CI catches new compiler warnings earlier. [https://github.com/FreeCAD/FreeCAD/pull/30228 Pull request #30228]
 
 === API === <!--T:15-->
 


### PR DESCRIPTION
Summary:
Document the Conda release preset warning-as-error change in the FreeCAD 1.2 release notes.

Related issue/source:
FreeCAD/FreeCAD#30228

What changed:
- Added one Core release-note bullet for the Conda release preset enabling `FREECAD_WARN_ERROR`.
- Cited the merged upstream source PR.

Validation:
- Checked root `wiki/Release_notes_1.2.wikitext` on `main` for `30228`, `FREECAD_WARN_ERROR`, and related Conda wording.
- Checked existing docs PRs for `30228`, `FREECAD_WARN_ERROR`, and Conda release preset wording.
- Confirmed the branch changes exactly one root release-note file.

Notes:
- This edits only `wiki/Release_notes_1.2.wikitext`.
- No FreeCAD 1.1 file, translation/localized file, or manual translation tag was touched.
- This documents a merged build/CI quality change, not a regression correction.
