### PR TITLE
docs: clarify PartDesign Thickness description

### DIFF
--- a/wiki/PartDesign_Workbench.wikitext
+++ b/wiki/PartDesign_Workbench.wikitext
@@ -187,7 +187,7 @@ These tools apply a treatment to edges or faces.
 * [[File:PartDesign_Draft.svg|32px]] [[PartDesign_Draft|Draft]]: applies an angular draft to selected faces of the active body.
 
 <!--T:95-->
-* [[File:PartDesign_Thickness.svg|32px]] [[PartDesign_Thickness|Thickness]]: creates a thick shell from the active body and opens selected face.
+* [[File:PartDesign_Thickness.svg|32px]] [[PartDesign_Thickness|Thickness]]: creates a thick shell from the active body and opens the selected face.
 
 === Part Design Transformation Features toolbar === <!--T:84-->
 


### PR DESCRIPTION
Summary:
- Clarifies the PartDesign Workbench description of the Thickness tool by adding the missing article before “selected face”.

Tests:
- `git diff --check`

Context:
- Small documentation wording improvement related to PartDesign docs (#79). This PR does not claim to fully resolve the bounty issue.