### PR TITLE
Add missing BIM root tool descriptions

### DIFF
--- a/wiki/BIM_Workbench.wikitext
+++ b/wiki/BIM_Workbench.wikitext
@@ -563,10 +563,10 @@ This menu contains the [[Draft_Snap|Draft Snap]] tools as well as the following 
 * [[Image:BIM_Unclone.svg|32px]] [[BIM_Unclone|Unclone]]: Makes a cloned object independent from its original object
 
 <!--T:199-->
-* [[Image:BIM_Rewire.svg|32px]] [[BIM_Rewire|Rewire]]:
+* [[Image:BIM_Rewire.svg|32px]] [[BIM_Rewire|Rewire]]: Recreates wires from the edges of selected objects.
 
 <!--T:200-->
-* [[Image:BIM_Glue.svg|32px]] [[BIM_Glue|Glue]]:
+* [[Image:BIM_Glue.svg|32px]] [[BIM_Glue|Glue]]: Joins selected shapes into one non-parametric compound shape.
 
 <!--T:201-->
 * [[Image:BIM_Reextrude.svg|32px]] [[BIM_Reextrude|Re-Extrude]]: Recreates an extrusion from a shape that has lost its parametric extrusion by selecting a base face
@@ -602,16 +602,16 @@ This menu contains the [[Draft_Snap|Draft Snap]] tools as well as the following 
 * [[Image:BIM_Project.svg|32px]] [[BIM_Project|IFC Project]]: Creates an IFC project including selected objects.
 
 <!--T:211-->
-* [[Image:IFC_Diff.svg|32px]] [[IFC_Diff|IFC Diff]]:
+* [[Image:IFC_Diff.svg|32px]] [[IFC_Diff|IFC Diff]]: Shows the current unsaved changes in the IFC file.
 
 <!--T:212-->
-* [[Image:IFC_Expand.svg|32px]] [[IFC_Expand|IFC Expand]]:
+* [[Image:IFC_Expand.svg|32px]] [[IFC_Expand|IFC Expand]]: Expands the children of the selected objects or of the document.
 
 <!--T:213-->
-* [[Image:IFC_MakeProject.svg|32px]] [[IFC_MakeProject|Convert to IFC Project]]:
+* [[Image:IFC_MakeProject.svg|32px]] [[IFC_MakeProject|Convert to IFC Project]]: Converts the selected objects into an IFC project structure.
 
 <!--T:214-->
-* [[Image:IFC_UpdateIOS.svg|32px]] [[IFC_UpdateIOS|IfcOpenShell Update]]:
+* [[Image:IFC_UpdateIOS.svg|32px]] [[IFC_UpdateIOS|IfcOpenShell Update]]: Updates the embedded IfcOpenShell libraries used by the NativeIFC tools.
 
 <!--T:215-->
 * Nudge:


### PR DESCRIPTION
Summary
- Fill six missing descriptions on the root BIM Workbench wiki page only.
- Avoid translation subdirectories / language-specific pages.

Validation
- `git diff --check`

Issue
- Helps with #26 by adding missing BIM Workbench documentation details.

Source note
- Descriptions are based on the current linked command pages/tool names and existing FreeCAD NativeIFC/BIM behavior; no translation tags were added.