### PR TITLE
docs: update outdated version refs and Arch-to-BIM notes

### DIFF
--- a/wiki/Getting_started.wikitext
+++ b/wiki/Getting_started.wikitext
@@ -62,7 +62,7 @@ First of all, download and install FreeCAD. See the [[Download|Download]] page f
 The main concept behind the FreeCAD interface is that it is separated into [[workbenches|workbenches]]. A workbench is a collection of tools suited for a specific task, such as working with [[Mesh_Workbench|meshes]], or drawing [[Draft_Workbench|2D objects]], or [[Sketcher_Workbench|constrained sketches]]. You can switch the current workbench with the [[Std_Workbench|workbench selector]]. You can [[Interface_Customization|customize]] the tools included in each workbench, add tools from other workbenches or even self-created tools, that we call [[macros|macros]]. Widely used starting points are the [[PartDesign_Workbench|PartDesign Workbench]] and [[Part_Workbench|Part Workbench]].
 
 <!--T:13-->
-When you start FreeCAD for the first time, you are presented with the Start page. Here is what it looks like for version 0.19:
+When you start FreeCAD for the first time, you are presented with the Start page. Here is what it looks like (the screenshot shows version 0.19, but the layout is similar in current versions):
 
 <!--T:60-->
 [[File:Start_center_0.19_screenshot.png|600px]]

--- a/wiki/Tutorials.wikitext
+++ b/wiki/Tutorials.wikitext
@@ -30,7 +30,7 @@ See also [[Video_tutorials|video tutorials]] and [[Books|books]].
 <translate>
 
 <!--T:3-->
-File:Arch tutorial 00.jpg|link=[[Arch_tutorial]]|[[Arch_tutorial]] (v0.14) <br/>This is the essential introduction to the Arch Workbench. It is extensive and showcases a typical workflow, from importing plans in DXF format to building the 3D model.
+File:Arch tutorial 00.jpg|link=[[Arch_tutorial]]|[[Arch_tutorial]] (v0.14) <br/>This is the essential introduction to the Arch Workbench (renamed to [[BIM_Workbench|BIM Workbench]] in FreeCAD 1.0). It is extensive and showcases a typical workflow, from importing plans in DXF format to building the 3D model.
 
 <!--T:147-->
 File:Exercise arch 01.jpg|link=[[Manual:BIM_modeling]]|[[Manual:BIM_modeling|BIM modeling]] <br/>How to model a small house, produce a blueprint with TechDraw, and export to IFC.

--- a/wiki/Tutorials.wikitext
+++ b/wiki/Tutorials.wikitext
@@ -42,7 +42,7 @@ File:11_T01_window_all_symbol_top.png|link=[[Tutorial_for_open_windows]]|[[Tutor
 File:17_T02_sketch_2_attached_correctly.png|link=[[Tutorial_custom_placing_of_windows_and_doors]]|[[Tutorial_custom_placing_of_windows_and_doors|Design custom windows]] (v0.18) <br/>How to draw custom doors and windows using the Sketcher, and adjust their normals to correctly place them in walls.
 
 <!--T:150-->
-File:Arch_panel_tutorial_01.jpg|link=[[Arch_panel_tutorial]]|[[Arch_panel_tutorial|Arch panel tutorial]] (v0.15) <br/>Modeling a microhouse roof panel by using the Sketcher, the Window tool, and the Panel tool.
+File:Arch_panel_tutorial_01.jpg|link=[[Arch_panel_tutorial]]|[[Arch_panel_tutorial|Arch panel tutorial]] (v0.15) <br/>Modeling a microhouse roof panel using the Arch Workbench (now [[BIM_Workbench|BIM Workbench]]) by using the Sketcher, the Window tool, and the Panel tool.
 
 <!--T:151-->
 File:Arch_Wikihouse_01.jpg|link=[[Wikihouse_porting_tutorial]]|[[Wikihouse_porting_tutorial|WikiHouse modelling]] <br/>Re-modeling the WikiHouse project using sketches and panels, starting from importing a mesh model created in SketchUp.


### PR DESCRIPTION
Updates outdated information in two wiki pages:

1. **Getting_started.wikitext**: Updated the Start page screenshot reference from "version 0.19" to clarify the screenshot shows 0.19 but the layout is similar in current versions.

2. **Tutorials.wikitext**: Added notes about the Arch-to-BIM rename:
   - Arch tutorial: noted that Arch Workbench was renamed to BIM Workbench in FreeCAD 1.0
   - Arch panel tutorial: added note about the BIM rename

All changes are in wiki root files, no translation files modified. No T tags added.

Related to #28