### PR TITLE
docs: add missing entries to Release_notes_1.2 (RE, Points, Mesh)

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -325,8 +325,6 @@ ToDo (last check: 20260430, #29258):
 === Further Mesh improvements === <!--T:37-->
 * A status widget now displays the reason when adding a triangle to a mesh fails. [https://github.com/FreeCAD/FreeCAD/pull/29945 Pull request #29945]
 
-=== Further Mesh improvements === <!--T:37-->
-
 == OpenSCAD Workbench == <!--T:38-->
 
 === Further OpenSCAD improvements === <!--T:39-->
@@ -386,14 +384,10 @@ ToDo (last check: 20260430, #29258):
 === Further Points improvements === <!--T:45-->
 * Importing point clouds is now significantly faster. [https://github.com/FreeCAD/FreeCAD/pull/23100 Pull request #23100]
 
-=== Further Points improvements === <!--T:45-->
-
 == Reverse Engineering Workbench == <!--T:46-->
 
 === Further Reverse Engineering improvements === <!--T:47-->
 * The [[Reverse_Engineering_Workbench|Reverse Engineering Workbench]] was re-enabled after being temporarily disabled due to Qt6 compatibility issues. [https://github.com/FreeCAD/FreeCAD/pull/25492 Pull request #25492]
-
-=== Further Reverse Engineering improvements === <!--T:47-->
 
 == Robot Workbench == <!--T:48-->
 

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -387,7 +387,7 @@ ToDo (last check: 20260430, #29258):
 == Reverse Engineering Workbench == <!--T:46-->
 
 === Further Reverse Engineering improvements === <!--T:47-->
-* The [[Reverse_Engineering_Workbench|Reverse Engineering Workbench]] was re-enabled after being temporarily disabled due to Qt6 compatibility issues. [https://github.com/FreeCAD/FreeCAD/pull/25492 Pull request #25492]
+* The [[Reverse_Engineering_Workbench|Reverse Engineering Workbench]] is available again. [https://github.com/FreeCAD/FreeCAD/pull/25492 Pull request #25492]
 
 == Robot Workbench == <!--T:48-->
 

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -323,6 +323,9 @@ ToDo (last check: 20260430, #29258):
 == Mesh Workbench == <!--T:36-->
 
 === Further Mesh improvements === <!--T:37-->
+* A status widget now displays the reason when adding a triangle to a mesh fails. [https://github.com/FreeCAD/FreeCAD/pull/29945 Pull request #29945]
+
+=== Further Mesh improvements === <!--T:37-->
 
 == OpenSCAD Workbench == <!--T:38-->
 
@@ -381,8 +384,14 @@ ToDo (last check: 20260430, #29258):
 == Points Workbench == <!--T:44-->
 
 === Further Points improvements === <!--T:45-->
+* Importing point clouds is now significantly faster. [https://github.com/FreeCAD/FreeCAD/pull/23100 Pull request #23100]
+
+=== Further Points improvements === <!--T:45-->
 
 == Reverse Engineering Workbench == <!--T:46-->
+
+=== Further Reverse Engineering improvements === <!--T:47-->
+* The [[Reverse_Engineering_Workbench|Reverse Engineering Workbench]] was re-enabled after being temporarily disabled due to Qt6 compatibility issues. [https://github.com/FreeCAD/FreeCAD/pull/25492 Pull request #25492]
 
 === Further Reverse Engineering improvements === <!--T:47-->
 


### PR DESCRIPTION
Adds entries to three workbench sections that were empty in Release_notes_1.2:

1. **Reverse Engineering Workbench**: Note about re-enabling after Qt6 support was added (PR #25492)

2. **Points Workbench**: Note about faster point cloud import performance (PR #23100)

3. **Mesh Workbench**: Note about status widget displaying reason when adding a triangle fails (PR #29945)

All entries cite the original FreeCAD PRs. Only wiki root files modified, no T tags added.

Related to #30