### PR TITLE
Update developer hub links

### DIFF
--- a/wiki/Developer_hub.wikitext
+++ b/wiki/Developer_hub.wikitext
@@ -21,6 +21,13 @@ These pages are in the early stage of development. If you can't find the informa
 <!--T:4-->
 The developer documentation comprises the following sections:
 
+=== Current developer resources ===
+
+* [https://freecad.github.io/DevelopersHandbook/ Developers Handbook]: Current entry point for build and contributor documentation.
+* [https://freecad.github.io/SourceDoc/ SourceDoc]: Generated source and API documentation for FreeCAD.
+* [https://github.com/FreeCAD/Addon-Academy Addon Academy]: Add-on development materials and examples.
+* [https://github.com/FreeCAD/lens-docs Lens documentation]: Documentation for the Lens add-on project.
+
 === Compiling FreeCAD === <!--T:33-->
 
 <!--T:5-->
@@ -33,7 +40,7 @@ The developer documentation comprises the following sections:
 * [[Third_Party_Libraries|Third Party Libraries]]
 * [[Third_Party_Tools|Third Party Tools]]
 * [[Start up and Configuration|Start up and Configuration]]
-* [[Start_up_and_Configuration|Source documentation]]
+* [[Source_documentation|Source documentation]]
 * Use [[https://github.com/FreeCAD/FreeCAD/issues|GitHub]] when you have a problem or think you may have found a bug
 
 === Packaging === <!--T:19-->


### PR DESCRIPTION
Addresses #329.

Summary:
- add a small Current developer resources section with the Developers Handbook, SourceDoc, Addon Academy, and Lens docs links
- fix the Source documentation entry so it points at Source_documentation instead of Start_up_and_Configuration

Notes:
- only the root wiki page is changed; translation files are untouched per the repository README
