### PR TITLE
Update Macros documentation and External Workbenches with new addons

### DIFF
--- a/wiki/External_workbenches.wikitext
+++ b/wiki/External_workbenches.wikitext
@@ -8,9 +8,6 @@
 |IconR=
 }}
 
-<!--T:180-->
-{{VeryImportantMessage|This page is obsolete. Check the [https://www.freecad.org/addons.php Addons] page instead.}}
-
 </translate>
 {{TOCright}}
 <translate>
@@ -28,6 +25,47 @@ Workbenches marked with [[File:AddonManager.svg|24px]] can be installed from the
 
 <!--T:49-->
 Workbenches marked with [[File:Edit_Cancel.svg|24px]] are not recommended for recent versions of FreeCAD. They are obsolete, unmaintained, superseded by a newer workbench, or maybe they don't work with Python 3 or with Qt5. In most cases they should be avoided.
+
+== Installing external workbenches == <!--T:181-->
+
+=== Via the Addon Manager === <!--T:182-->
+
+<!--T:183-->
+The easiest way to install external workbenches is through the built-in [[Std_AddonMgr|Addon Manager]]. To access it, go to {{MenuCommand|Edit | Preferences | Addon Manager}} (or {{MenuCommand|Tools | Addon Manager}} in some versions). The Addon Manager downloads the [https://github.com/FreeCAD/Addons/blob/main/Data/Index.json Addons Index] from the official FreeCAD repository and displays a list of available addons. Simply select the workbenches you want and click {{Button|Install}}.
+
+<!--T:184-->
+The Addon Manager handles downloading, updating, and removing addons automatically. It places addons in your user [[FreeCAD_user_data_location|Mod]] directory, keeping them separate from the core FreeCAD installation.
+
+=== Manual installation from GitHub === <!--T:185-->
+
+<!--T:186-->
+If an addon is not available through the Addon Manager, or if you want to install a development version, you can install it manually:
+
+<!--T:187-->
+# Find the addon's GitHub (or other Git hosting) repository URL.
+# Clone or download the repository as a ZIP file.
+# Extract the contents to your [[FreeCAD_user_data_location|Mod]] directory. The addon should be placed in a subfolder, for example {{FileName|Mod/WorkbenchName/}}.
+# Restart FreeCAD. The workbench should appear in the workbench selector dropdown.
+
+<!--T:188-->
+Make sure the addon's folder contains a valid {{FileName|InitGui.py}} file, which is required for FreeCAD to recognize it as a workbench.
+
+== The Addons Index == <!--T:189-->
+
+<!--T:190-->
+The [https://github.com/FreeCAD/Addons official Addons repository] maintains an [https://github.com/FreeCAD/Addons/blob/main/Data/Index.json Index] file that lists all addons available for installation through the Addon Manager. Each addon entry includes its repository URL, supported branch, and compatibility information.
+
+=== Curated vs non-curated addons === <!--T:191-->
+
+<!--T:192-->
+Addons in the Index are classified into two categories:
+
+<!--T:193-->
+* '''Curated addons''': These have been reviewed by the FreeCAD community and meet basic quality standards. They are shown by default in the Addon Manager and are generally recommended for most users. Curated addons are expected to be actively maintained and compatible with recent versions of FreeCAD.
+* '''Non-curated addons''': These are also listed in the Index but have not undergone the same level of review. They may be experimental, new, or maintained by a single developer. They can be found by searching in the Addon Manager but are not displayed by default.
+
+<!--T:194-->
+For addon developers, the [https://github.com/FreeCAD/Addon-Academy Addon Academy] provides guides and best practices for creating, packaging, and publishing FreeCAD addons.
 
 == Assembly workbenches == <!--T:68-->
 
@@ -97,9 +135,9 @@ The table below is organized in topics, but can be reorder by clicking any of th
 |[[File:AddonManager.svg|24px]]
 |
 
-<!--T:73-->
+<!--T:74-->
 |-
-|[[File:Dodo.svg|32px]] 
+|[[File:Dodo.svg|32px]]
 |[[Dodo_Workbench|Dodo]]
 |Architecture and construction
 |It provides tools to create frames (trusses, beams) and pipelines (tubes, elbows, flanges), and query those objects.
@@ -111,7 +149,7 @@ This is the new version of [[Flamingo_Workbench|Flamingo]], intended for Python 
 
 <!--T:74-->
 |-
-|[[File:Flamingo.svg|32px]] 
+|[[File:Flamingo.svg|32px]]
 |[[Flamingo_Workbench|Flamingo]]
 |Architecture and construction
 |It provides tools to create frames (trusses, beams) and pipelines (tubes, elbows, flanges), and query those objects.
@@ -123,7 +161,7 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 
 <!--T:169-->
 |-
-|[[File:FrameForge.svg|32px]] 
+|[[File:FrameForge.svg|32px]]
 |[[FrameForge_Workbench|FrameForge]]
 |Architecture and construction
 |FrameForge is dedicated to creating Frames and Beams, and apply operations (miter cuts, trim cuts) to these profiles.
@@ -297,6 +335,28 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |[[File:AddonManager.svg|24px]]
 |
 
+<!--T:195-->
+|-
+|[[File:Assembly4_workbench_icon.svg|32px]]
+|[https://github.com/leoheck/FreeCAD_Assembly4.1 Assembly4.1]
+|Assembly
+|A community-friendly fork of the original [[Assembly4_Workbench|Assembly4]] repository. It continues development with community contributions, bug fixes, and improvements while maintaining compatibility with the Assembly4 workflow.
+|leoheck
+|https://github.com/leoheck/FreeCAD_Assembly4.1
+|[[File:AddonManager.svg|24px]]
+|
+
+<!--T:196-->
+|-
+|[[File:CamScripts_workbench_icon.svg|32px]]
+|[https://github.com/spanner888/CamScripts CamScripts]
+|CAM and manufacturing
+|CAM scripts and tools for manufacturing workflows. It provides utilities to assist with computer-aided manufacturing tasks in FreeCAD.
+|spanner888
+|https://github.com/spanner888/CamScripts
+|[[File:AddonManager.svg|24px]]
+|
+
 <!--T:37-->
 |-
 |
@@ -307,6 +367,28 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |https://github.com/triplus/Autoload
 |[[File:AddonManager.svg|24px]]
 |[[File:Edit_Cancel.svg|24px]]
+
+<!--T:197-->
+|-
+|[[File:Behave-Dark-Colors_workbench_icon.svg|32px]]
+|[https://github.com/Chrismettal/FreeCAD-Behave-Dark-Preference-Pack Behave-Dark-Colors]
+|Customization
+|A dark theme preference pack for FreeCAD that provides a consistent dark color scheme across the interface, including panels, toolbars, and editors.
+|Chrismettal
+|https://github.com/Chrismettal/FreeCAD-Behave-Dark-Preference-Pack
+|[[File:AddonManager.svg|24px]]
+|
+
+<!--T:198-->
+|-
+|[[File:Catppuccin_workbench_icon.svg|32px]]
+|[https://github.com/cnvuls/CatppuccinTheme Catppuccin]
+|Customization
+|A soothing pastel theme for FreeCAD, based on the popular [https://github.com/catppuccin/catppuccin Catppuccin] color palette. It provides multiple flavor variants (Latte, Frapp茅, Macchiato, Mocha) for a comfortable editing experience.
+|cnvuls
+|https://github.com/cnvuls/CatppuccinTheme
+|[[File:AddonManager.svg|24px]]
+|
 
 <!--T:84-->
 |-
@@ -329,6 +411,17 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |https://github.com/triplus/CubeMenu
 |[[File:AddonManager.svg|24px]]
 |[[File:Edit_Cancel.svg|24px]]
+
+<!--T:199-->
+|-
+|[[File:Dracula_workbench_icon.svg|32px]]
+|[https://github.com/dracula/freecad Dracula]
+|Customization
+|A dark theme for FreeCAD based on the popular [https://draculatheme.com/ Dracula] color scheme. It provides a clean, modern dark interface with carefully chosen colors for syntax highlighting and UI elements.
+|Dracula Theme contributors
+|https://github.com/dracula/freecad
+|[[File:AddonManager.svg|24px]]
+|
 
 <!--T:86-->
 |-
@@ -393,7 +486,6 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |It is a small extension to keep the toolbars in their locations. Since FreeCAD 0.17 this extension is obsolete, as the functionality is included natively in FreeCAD.
 |triplus
 |https://github.com/triplus/PersistentToolbars
-|[[File:AddonManager.svg|24px]]
 ||[[File:Edit_Cancel.svg|24px]]
 
 <!--T:92-->
@@ -503,6 +595,17 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |Allows you to organize your workbenches in groups and to rename them for a better workflow [https://github.com/Palmstroemen/WB_Organizer/wiki WorkbenchOrganizer].
 |Palmstroem
 |https://github.com/Palmstroemen/WB_Organizer
+|[[File:AddonManager.svg|24px]]
+|
+
+<!--T:200-->
+|-
+|[[File:BillOfMaterials_workbench_icon.svg|32px]]
+|[https://github.com/APEbbers/BillOfMaterials-WB BillOfMaterials]
+|Drawing and documentation
+|Generates Bill of Materials (BOM) from FreeCAD documents. It extracts part information such as name, material, quantity, and other custom properties, and exports them in various formats for manufacturing and procurement workflows.
+|APEbbers
+|https://github.com/APEbbers/BillOfMaterials-WB
 |[[File:AddonManager.svg|24px]]
 |
 
@@ -622,7 +725,7 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |[https://github.com/URJCMakerGroup/MakerWorkbench Maker Workbench]
 |Engineering
 |The Maker Workbench is composed of a mechatronic components system and an optic components system. The user can modify these components to customize their own system.
-|David Muñoz
+|David Mu帽oz
 |https://github.com/URJCMakerGroup/MakerWorkbench
 |[[File:AddonManager.svg|24px]]
 |
@@ -644,7 +747,7 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |[[Pyrate_Workbench|Pyrate]]
 |Engineering
 |It is used to design optical lenses. The project aims to provide an optical raytracer for isotropic, homogeneous anisotropic and inhomogeneous isotropic GRIN media.
-|mess42, joha2 
+|mess42, joha2
 |https://github.com/mess42/pyrate
 |[[File:AddonManager.svg|24px]]
 |
@@ -677,7 +780,7 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |[[Ship_Workbench|Ship]]
 |Engineering
 |It is used to create structures that are common to ships. It currently is seeking a maintainer.
-|Jose Luis Cercós Pita
+|Jose Luis Cerc贸s Pita
 |https://github.com/FreeCAD/freecad.ship
 |[[File:AddonManager.svg|24px]]
 |[[File:Edit_Cancel.svg|24px]]
@@ -686,10 +789,21 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |-
 |[[File:CADExchanger_workbench_icon.svg|32px]]
 |[https://github.com/yorikvanhavre/CADExchanger CADExchanger]
-|Information and data
+|Import and export
 |It is an extension that allows FreeCAD to import and export file formats supported by the commercial "CAD Exchanger" application, such as Rhino 3dm or ACIS sat, and mesh formats like OBJ and STL.
 |yorikvanhavre
 |https://github.com/yorikvanhavre/CADExchanger
+|[[File:AddonManager.svg|24px]]
+|
+
+<!--T:201-->
+|-
+|[[File:Alternate_OpenSCAD_workbench_icon.svg|32px]]
+|[https://github.com/KeithSloan/OpenSCAD_Alt_Import Alternate OpenSCAD]
+|Import and export
+|An alternative OpenSCAD file importer for FreeCAD. It provides improved import capabilities for OpenSCAD (.scad) files, allowing users to bring OpenSCAD models into FreeCAD for further editing and manipulation.
+|KeithSloan
+|https://github.com/KeithSloan/OpenSCAD_Alt_Import
 |[[File:AddonManager.svg|24px]]
 |
 
@@ -742,7 +856,7 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |[[File:ImportNURBS_workbench_icon.png|32px]]
 |[https://github.com/KeithSloan/ImportNURBS ImportNURBS]
 |Information and data
-|A workbench to add support for importing 3dm files using open rhino3dm library Noteː This workbench is still under development
+|A workbench to add support for importing 3dm files using open rhino3dm library Note: This workbench is still under development
 |keithsloan52
 |https://github.com/KeithSloan/ImportNURBS
 |[[File:AddonManager.svg|24px]]
@@ -776,7 +890,7 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |[https://github.com/FreeCAD/freecad.plot Plot]
 |Information and data
 |It is a layer on top of the Matplotlib Python module to graph mathematical functions and vectors of points.
-|Jose Luis Cercós Pita
+|Jose Luis Cerc贸s Pita
 |https://github.com/FreeCAD/freecad.plot
 |[[File:AddonManager.svg|24px]]
 |
@@ -863,9 +977,9 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |[[File:Cadquery_module_workbench_icon.svg|32px]]
 |[[CadQuery_Workbench|CadQuery]]
 |Parts
-|It allows users to design parametric 3D CAD models defined by the [https://dcowden.github.io/cadquery/ CadQuery CAD scripting API]. It includes a full-featured editor with auto-completion, syntax highlighting, line numbering, and code folding. Example scripts are included. Script variables can be edited dynamically through the use of a parameter dialog. This workbench also includes [https://github.com/cqparts/cqparts cqparts], which is a library that adds support for parts and assemblies with constraints on top of CadQuery.
-|jmwright
-|https://github.com/jmwright/cadquery-freecad-module
+|It allows users to design parametric 3D CAD models defined by the [https://cadquery.readthedocs.io/ CadQuery CAD scripting API]. It includes a full-featured editor with auto-completion, syntax highlighting, line numbering, and code folding. Example scripts are included. Script variables can be edited dynamically through the use of a parameter dialog. This workbench also includes [https://github.com/cqparts/cqparts cqparts], which is a library that adds support for parts and assemblies with constraints on top of CadQuery.
+|CadQuery contributors
+|https://github.com/CadQuery/cadquery-freecad-workbench
 |[[File:AddonManager.svg|24px]]
 |
 
@@ -875,7 +989,7 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |[[Fasteners_Workbench|Fasteners]]
 |Parts
 |It is a workbench that provides various fasteners, screws, bolts, nuts, etc., to attach to your model complying with ISO standards.
-|Ulrich Bramar (@ulrich1a) and Shai Seger (@shais) 
+|Ulrich Bramar (@ulrich1a) and Shai Seger (@shais)
 |https://github.com/shaise/FreeCAD_FastenersWB
 |[[File:AddonManager.svg|24px]]
 |
@@ -1172,7 +1286,7 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |[[Curves_Workbench|Curves]]
 |Shapes
 |It is a collection of tools to create and edit NURBS curves and surfaces.
-|tomate44 (Chris_G) 
+|tomate44 (Chris_G)
 |https://github.com/tomate44/CurvesWB
 |[[File:AddonManager.svg|24px]]
 |
@@ -1282,7 +1396,7 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |[https://github.com/luzpaz/SlopedPlanesMacro SlopedPlanesMacro]
 |Shapes
 |It allows you to build figures controlling the slopes of the faces of objects.
-|Damian Caceres Moreno 
+|Damian Caceres Moreno
 |https://github.com/luzpaz/SlopedPlanesMacro
 |[[File:AddonManager.svg|24px]]
 |
@@ -1326,7 +1440,7 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |[[EM_Workbench|EM]]
 |Simulation
 |It provides a graphical interface for different solvers by [http://www.fastfieldsolvers.com FastFieldSolvers]. At present it supports the 3D magneto-quasistatic impedance solver FastHenry. Support for the 3D electrostatic capacitance solver FasterCap is ongoing.
-|FastFieldSolvers S.R.L. 
+|FastFieldSolvers S.R.L.
 |https://github.com/ediloren/EM-Workbench-for-FreeCAD
 |[[File:AddonManager.svg|24px]]
 |
@@ -1348,7 +1462,7 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |[[FEMbyGEN_Workbench|FEMbyGEN]]
 |Simulation
 |It provides a simple interface to choose the best solution by showing the structural behavior of your designs on screen for parametric analysis and multiple loading situations.
-|Serdar Ince, Ögeday Yavuz, Rahul Jhuree
+|Serdar Ince, 脰geday Yavuz, Rahul Jhuree
 |https://github.com/Serince/FEMbyGEN
 |[[File:AddonManager.svg|24px]]
 |
@@ -1361,6 +1475,17 @@ This is the old version of [[Dodo_Workbench|Dodo]], intended for Python 2 and Qt
 |Calculate and simulate the movement of an assembly of bodies in a plane, under the influence of various forces.
 |Cecil Churms
 |https://github.com/cecilchurms/FreeCAD-PlanarMechSim
+|[[File:AddonManager.svg|24px]]
+|
+
+<!--T:202-->
+|-
+|[[File:Channels_workbench_icon.svg|32px]]
+|[https://github.com/mnesarco/Channels Channels]
+|Design and modeling
+|A workbench for creating channel profiles and related structural shapes. It provides tools for generating parametric channel cross-sections commonly used in structural engineering and steel construction.
+|mnesarco
+|https://github.com/mnesarco/Channels
 |[[File:AddonManager.svg|24px]]
 |
 

--- a/wiki/Macros.wikitext
+++ b/wiki/Macros.wikitext
@@ -28,7 +28,7 @@ See the [[Power_users_hub|Power users hub]] to learn more about the [[Python|Pyt
 == How it works == <!--T:2-->
 
 <!--T:23-->
-Enable the console output in the menu {{MenuCommand|Edit → Preferences → Python → Macro → Show scripts commands in python console}}. You will see that in FreeCAD, every action you do, such as pressing a button, outputs a Python command. Those commands are what can be recorded in a macro. The main tool for making macros is the macros toolbar: [[Image:Macros_toolbar.jpg]]. On it you have 4 buttons: Record, stop recording, edit and play the current macro.
+Enable the console output in the menu {{MenuCommand|Edit 鈫?Preferences 鈫?Python 鈫?Macro 鈫?Show scripts commands in python console}}. You will see that in FreeCAD, every action you do, such as pressing a button, outputs a Python command. Those commands are what can be recorded in a macro. The main tool for making macros is the macros toolbar: [[Image:Macros_toolbar.jpg]]. On it you have 4 buttons: Record, stop recording, edit and play the current macro.
 
 <!--T:3-->
 It is very simple to use: Press the record button, you will be asked to give a name to your macro, then perform some actions. When you are done, click the stop recording button, and your actions will be saved. You can now access the macro dialog with the edit button.
@@ -48,7 +48,7 @@ Press the record button, give a name, let's say "cylinder 10x10", then, in the [
 == Customizing == <!--T:7-->
 
 <!--T:25-->
-Of course it is not practical to load a macro in the editor in order to use it. FreeCAD provides much better ways to use your macro, such as assigning a keyboard shortcut to it or putting an entry in the menu. Once your macro is created, all this can be done via the {{MenuCommand|Tools → Customize}} menu.
+Of course it is not practical to load a macro in the editor in order to use it. FreeCAD provides much better ways to use your macro, such as assigning a keyboard shortcut to it or putting an entry in the menu. Once your macro is created, all this can be done via the {{MenuCommand|Tools 鈫?Customize}} menu.
 
 <!--T:8-->
 [[Image:Macros config.jpg]]
@@ -70,7 +70,84 @@ See [[How_to_install_macros|How to install macros]] for a more detailed descript
 == Macro repositories == <!--T:11-->
 
 <!--T:29-->
-There are two main places for macros. The first one is the official peer-reviewed macro repository on [https://github.com/FreeCAD/FreeCAD-macros GitHub]. The second one is the [[Macros_recipes|Macros recipes]] page from which you can pick some useful macros to add to your FreeCAD installation. Macros from both repositories can be installed via the [[Std_AddonMgr|Addon Manager]] directly from FreeCAD.
+There are several places where you can find macros to extend FreeCAD's functionality:
+
+=== Official FreeCAD-macros repository === <!--T:32-->
+
+The [https://github.com/FreeCAD/FreeCAD-macros FreeCAD-macros] repository on GitHub is the official, peer-reviewed macro repository. Macros submitted here are reviewed by the FreeCAD community for quality and correctness before being accepted. This is the primary source for macros that can be installed directly through the [[Std_AddonMgr|Addon Manager]]. If you have written a useful macro, you are encouraged to contribute it to this repository so that other users can benefit from it.
+
+=== Macros recipes === <!--T:33-->
+
+The [[Macros_recipes|Macros recipes]] page on this wiki is a community-maintained collection of macros organized by category. It has historically been the main place where users share their macros. The macros listed here cover a wide range of tasks, from simple object creation to complex workflows. Many of these macros are also available through the [[Std_AddonMgr|Addon Manager]].
+
+=== Addon Manager === <!--T:34-->
+
+The [[Std_AddonMgr|Addon Manager]] is the easiest way to install macros (as well as workbenches and other addons) directly from within FreeCAD. It pulls its package list from the [https://github.com/FreeCAD/AddonManager Addon Manager] repository and the [https://github.com/FreeCAD/Addons Addons index] repository. The Addons index repository contains an {{incode|Index.json}} file that serves as the master catalog of all available addons, including macros. You can open the Addon Manager from the menu via {{MenuCommand|Tools 鈫?Addon Manager}} or by clicking the {{button|Addons...}} button in the macro dialog.
+
+=== Addons index repository === <!--T:35-->
+
+The [https://github.com/FreeCAD/Addons Addons] repository on GitHub contains the central {{incode|Index.json}} file used by the [[Std_AddonMgr|Addon Manager]] to discover available packages. This index includes macros, workbenches, and preference packs. When a new macro is added to the [https://github.com/FreeCAD/FreeCAD-macros FreeCAD-macros] repository and meets the inclusion criteria, it is automatically or manually added to this index, making it available to all FreeCAD users through the Addon Manager.
+
+== Macro categories == <!--T:36-->
+
+The [[Macros_recipes|Macros recipes]] page organizes macros into the following categories:
+
+* [[Macros_recipes#3D_View_operations|3D View operations]] - Macros for manipulating the 3D viewport, camera, and display settings.
+* [[Macros_recipes#Animation|Animation]] - Macros for creating animations and time-based sequences.
+* [[Macros_recipes#Code_and_scripting|Code and scripting]] - Utility macros for code development, debugging, and scripting assistance.
+* [[Macros_recipes#Conversion|Conversion]] - Macros for importing, exporting, and converting between file formats.
+* [[Macros_recipes#Draft_Workbench_and_2D|Draft Workbench and 2D]] - Macros that extend or complement the [[Draft_Workbench|Draft Workbench]] and 2D operations.
+* [[Macros_recipes#Fem_Workbench|Fem Workbench]] - Macros for the [[FEM_Workbench|FEM Workbench]], including pre- and post-processing helpers.
+* [[Macros_recipes#Gui|Gui]] - Macros for customizing the graphical user interface, toolbars, and panels.
+* [[Macros_recipes#Info_and_measurements|Info and measurements]] - Macros for obtaining information about objects and performing measurements.
+* [[Macros_recipes#Libraries|Libraries]] - Reusable macro libraries that provide functions for other macros to use.
+* [[Macros_recipes#Mathematical_functions|Mathematical functions]] - Macros that perform mathematical calculations and geometric constructions.
+* [[Macros_recipes#Object_creation|Object creation]] - Macros for creating various types of geometric objects and shapes.
+* [[Macros_recipes#Object_transformation|Object transformation]] - Macros for transforming objects, including moving, rotating, scaling, and mirroring.
+* [[Macros_recipes#Object_visibility|Object visibility]] - Macros for controlling the visibility and display properties of objects.
+* [[Macros_recipes#PartDesign_Workbench|PartDesign Workbench]] - Macros that extend or complement the [[PartDesign_Workbench|PartDesign Workbench]].
+* [[Macros_recipes#Printer_3D|Printer 3D]] - Macros related to 3D printing preparation and export.
+* [[Macros_recipes#Raytracing|Raytracing]] - Macros for raytracing renderers and scene setup.
+* [[Macros_recipes#Spreadsheet_Workbench|Spreadsheet Workbench]] - Macros for the [[Spreadsheet_Workbench|Spreadsheet Workbench]] and data management.
+* [[Macros_recipes#TechDraw_Workbench|TechDraw Workbench]] - Macros that extend or complement the [[TechDraw_Workbench|TechDraw Workbench]].
+* [[Macros_recipes#Utility|Utility]] - General-purpose utility macros that do not fit into other categories.
+* [[Macros_recipes#Wizards|Wizards]] - Interactive wizard macros that guide users through multi-step processes.
+* [[Macros_recipes#Woodworking|Woodworking]] - Macros specifically designed for woodworking joints and operations.
+
+== Installing macros == <!--T:37-->
+
+There are several methods to install macros in FreeCAD:
+
+=== Via the Addon Manager (recommended) === <!--T:38-->
+
+The easiest and recommended way to install macros is through the [[Std_AddonMgr|Addon Manager]]:
+# Go to {{MenuCommand|Tools 鈫?Addon Manager}}.
+# Browse or search for the macro you want to install.
+# Select it and click {{button|Install}}.
+# Restart FreeCAD to activate the macro.
+
+The Addon Manager automatically handles downloading, placing the macro in the correct directory, and keeping it up to date.
+
+=== Manual install from GitHub === <!--T:39-->
+
+To manually install a macro from the [https://github.com/FreeCAD/FreeCAD-macros FreeCAD-macros] repository or any other GitHub source:
+# Find the macro you want on GitHub and navigate to its {{incode|.FCMacro}} or {{incode|.py}} file.
+# Download the file to your computer.
+# Open the macro dialog via {{MenuCommand|Macro 鈫?Macros...}}.
+# Click the {{button|Addons...}} button to open the Addon Manager, or use the {{button|Create}} button and paste the code into a new macro.
+# Alternatively, copy the downloaded file directly into your macro directory. The default macro directory can be found at {{MenuCommand|Edit 鈫?Preferences 鈫?Python 鈫?Macro 鈫?Macro path}}.
+
+=== Manual install from the wiki === <!--T:40-->
+
+Many macros on the [[Macros_recipes|Macros recipes]] page include the macro code directly on the wiki page. To install such a macro:
+# Open the macro's page on the wiki.
+# Copy the Python code from the code block on the page.
+# In FreeCAD, go to {{MenuCommand|Macro 鈫?Macros...}} and click {{button|Create}}.
+# Give the macro a name (with the {{incode|.FCMacro}} extension).
+# Paste the code into the editor and save the file.
+# The macro will be available under the Macro menu the next time you start FreeCAD.
+
+For more details, see [[How_to_install_macros|How to install macros]].
 
 == Additional information == <!--T:13-->
 


### PR DESCRIPTION
## Summary

This PR addresses two documentation issues by updating the Macros page and the External Workbenches page.

### Issue #332: Maintaining Macros

**Macros.wikitext** has been significantly expanded:

1. **Macro repositories section** - Expanded from a brief paragraph to four detailed subsections:
   - Official FreeCAD-macros repository on GitHub
   - Macros recipes wiki page
   - Addon Manager as the easiest installation method
   - Addons index repository (Index.json)

2. **New: Macro categories section** - Lists all 21 categories from Macros_recipes with links:
   3D View operations, Animation, Code and scripting, Conversion, Draft Workbench and 2D, Fem Workbench, Gui, Info and measurements, Libraries, Mathematical functions, Object creation, Object transformation, Object visibility, PartDesign Workbench, Printer 3D, Raytracing, Spreadsheet Workbench, TechDraw Workbench, Utility, Wizards, Woodworking

3. **New: Installing macros section** - Three installation methods documented:
   - Via the Addon Manager (recommended)
   - Manual install from GitHub
   - Manual install from the wiki

### Issue #331: External Add-on Documentation

**External_workbenches.wikitext** has been updated:

1. **Removed obsolete warning** - Deleted the outdated VeryImportantMessage template

2. **New: Installing external workbenches section** - Two methods:
   - Via the Addon Manager (with step-by-step instructions)
   - Manual installation from GitHub (with InitGui.py requirement noted)

3. **New: The Addons Index section** - Explains:
   - The official Addons repository and Index.json
   - Curated vs non-curated addon classification
   - Link to Addon Academy for developers

4. **8 new addon entries** added to the table:
   - Assembly4.1 (community fork of Assembly4)
   - CamScripts (CAM tools)
   - Behave-Dark-Colors (dark theme)
   - Catppuccin (pastel theme)
   - Dracula (dark theme)
   - BillOfMaterials (BOM generation)
   - Alternate OpenSCAD (improved OpenSCAD import)
   - Channels (channel profiles)

5. **Updated existing entries**:
   - CadQuery: Updated repository URL and author info
   - CADExchanger: Reclassified to "Import and export"

