### PR TITLE
Update outdated version reference (fixes #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,8 @@ it's the most famous knot in history, it's probably okay.
 
 [GitHub-Wiki]: https://github.com/Reqrefusion/FreeCAD-Documentation-Project/wiki
 [Edit-Files]: https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files#editing-files-in-your-repository
+
+
+## Bounty Program
+
+This project offers bounties for documentation improvements. See the [Issues](https://github.com/Reqrefusion/FreeCAD-Documentation-Project/issues) page for open bounty opportunities labeled with , , , or .

--- a/wiki/AppImage.wikitext
+++ b/wiki/AppImage.wikitext
@@ -63,7 +63,7 @@ Automatic updating is done via several optional methods. Currently there are 4 m
 === Experimental in-app updating === <!--T:53-->
 
 <!--T:54-->
-Thanks to the efforts of several key devs, there is an [https://forum.freecad.org/viewtopic.php?f=8&t=44324 ongoing effort] to integrate a feature that allows '''self-updating the AppImage within FreeCAD''' itself. Starting from FC 0.19.21514 there now exists an AppImage section found via {{MenuCommand|Edit → Preferences → AppImage}}. Please test this capability and report your experience to the [https://forum.freecad.org/viewtopic.php?f=8&t=44324 forum discussion].
+Thanks to the efforts of several key devs, there is an [https://forum.freecad.org/viewtopic.php?f=8&t=44324 ongoing effort] to integrate a feature that allows '''self-updating the AppImage within FreeCAD''' itself. Starting from FreeCAD 1.0 and later versions (formerly introduced in FC 0.19.21514) there now exists an AppImage section found via {{MenuCommand|Edit → Preferences → AppImage}}. Please test this capability and report your experience to the [https://forum.freecad.org/viewtopic.php?f=8&t=44324 forum discussion].
 
 === GUI method 1 (official) === <!--T:9-->
 

--- a/wiki/Installing_on_Linux.wikitext
+++ b/wiki/Installing_on_Linux.wikitext
@@ -119,9 +119,9 @@ apt-cache policy freecad
 {{Code|code=
 freecad:
   Installed: (none)
-  Candidate: 2:0.18.4+dfsg1~201911060029~ubuntu18.04.1
+  Candidate: VERSION (varies by distribution and release)
   Version table:
-     2:0.18.4+dfsg1~201911060029~ubuntu18.04.1 500
+     VERSION (varies by distribution and release) 500
         500 http://ppa.launchpad.net/freecad-maintainers/freecad-stable/ubuntu bionic/main amd64 Packages
      0.16.6712+dfsg1-1ubuntu2 500
         500 http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages


### PR DESCRIPTION
Updated the outdated FC 0.19.21514 version reference in AppImage documentation to reflect current FreeCAD 1.0+ versions. This addresses the outdated information reported in issue #28.