### PR TITLE
Update Developer Hub with current FreeCAD developer resources

### DIFF
--- a/wiki/Developer_hub.wikitext
+++ b/wiki/Developer_hub.wikitext
@@ -2,7 +2,7 @@
 <translate>
 
 <!--T:41-->
-{{VeryImportantMessage|The information on this page may be obsolete, see the [https://freecad.github.io/DevelopersHandbook/ Developers Handbook] for up-to-date information.}}
+{{VeryImportantMessage|For current FreeCAD development information, start with the [https://freecad.github.io/DevelopersHandbook/ Developers Handbook]. This hub also links older wiki pages that may still be useful for specific topics.}}
 
 </translate>
 [[Image:Crystal_Clear_app_tutorials.png|64px]]
@@ -11,10 +11,17 @@
 <translate>
 
 <!--T:2-->
-This is the place to come if you want to contribute to the development of the FreeCAD software. Many of the following pages might be outdated. Check the official FreeCAD Developers Handbook for more up to date information: https://freecad.github.io/DevelopersHandbook/
+This is the place to come if you want to contribute to the development of the FreeCAD software. For current setup, contribution, review, design and maintainer guidance, start with the official [https://freecad.github.io/DevelopersHandbook/ FreeCAD Developers Handbook].
 
 <!--T:3-->
-These pages are in the early stage of development. If you can't find the information you are looking for, or have found useful information somewhere we have not linked to, then please leave a comment on the [https://forum.freecad.org/index.php?sid=5f84150e79db8842e277b042077097ff forum] and someone will look into it.
+These pages are in the early stage of development. If you can't find the information you are looking for, or have found useful information somewhere we have not linked to, then please leave a comment on the [https://forum.freecad.org/ forum] and someone will look into it.
+
+== Current developer resources ==
+
+* [https://freecad.github.io/DevelopersHandbook/ Developers Handbook]: Current guide for development setup, roadmap, design guidance, code formatting, code review, maintainer procedures and technical orientation.
+* [https://freecad.github.io/SourceDoc/ Source documentation]: Generated API and source documentation for FreeCAD. The source is maintained in the [https://github.com/FreeCAD/SourceDoc FreeCAD/SourceDoc] repository.
+* [https://github.com/FreeCAD/Addon-Academy Addon Academy]: Documentation, examples and guides for developing FreeCAD addons.
+* [https://github.com/FreeCAD/lens-docs Lens documentation]: Documentation for Ondsel Lens, a free/libre product data management system designed for FreeCAD and FreeCAD-based software.
 
 == Developer Documentation == <!--T:32-->
 
@@ -33,8 +40,8 @@ The developer documentation comprises the following sections:
 * [[Third_Party_Libraries|Third Party Libraries]]
 * [[Third_Party_Tools|Third Party Tools]]
 * [[Start up and Configuration|Start up and Configuration]]
-* [[Start_up_and_Configuration|Source documentation]]
-* Use [[https://github.com/FreeCAD/FreeCAD/issues|GitHub]] when you have a problem or think you may have found a bug
+* [https://freecad.github.io/SourceDoc/ Source documentation]
+* Use [https://github.com/FreeCAD/FreeCAD/issues GitHub] when you have a problem or think you may have found a bug
 
 === Packaging === <!--T:19-->
 
@@ -65,6 +72,7 @@ The developer documentation comprises the following sections:
 * Understanding [[The_FreeCAD_source_code|The FreeCAD source code]]
 * [[Tracker#Submitting_patches|Submitting patches]]
 * Add [[Gui_Command|Features]] or a [[Workbench_creation|Workbench]] to FreeCAD
+* [https://github.com/FreeCAD/Addon-Academy Addon Academy] for addon development documentation, examples and guides
 * [[Branding|Branding]] or ''how to give FreeCAD a unique look''
 * [[Artwork|Artwork]] we made for FreeCAD, that you can freely reuse.
 * [[Artwork_Guidelines|Artwork guidelines]] standards for icons
@@ -110,7 +118,7 @@ OpenCascade is a software development platform for 3D surface and solid modeling
 * [http://opencascade.wikidot.com/romansarticles Roman Lygin's tutorials]
 * [https://dev.opencascade.org/cdoc/overview/html/index.html Full Online Documentation]
 * [https://dev.opencascade.org/doc/refman/html/index.html Reference Manual]
-* [http://opencascade.wikidot.com The openCascade wiki] (currently containing ?? Chinese spam)
+* [http://opencascade.wikidot.com The OpenCascade wiki]
 
 ==== File format ==== <!--T:27-->
 


### PR DESCRIPTION
## Summary

Updates `wiki/Developer_hub.wikitext` for #329 by making the Developer Hub point to the current maintained FreeCAD developer resources while keeping the older wiki links available for topic-specific reference.

## Changes and sources

- Reworded the top warning and intro to direct current contributors to the Developers Handbook.
  Source: https://freecad.github.io/DevelopersHandbook/

- Added a "Current developer resources" section with links to:
  - Developers Handbook: https://freecad.github.io/DevelopersHandbook/
  - Source documentation: https://freecad.github.io/SourceDoc/ and https://github.com/FreeCAD/SourceDoc
  - Addon Academy: https://github.com/FreeCAD/Addon-Academy
  - Lens documentation: https://github.com/FreeCAD/lens-docs

- Updated the Source documentation link in the compiling section to use the maintained SourceDoc site instead of pointing to the startup/configuration wiki page.
  Source: https://github.com/FreeCAD/SourceDoc

- Added Addon Academy to the modifying/developing section because it is the current FreeCAD-owned addon-development documentation repository.
  Source: https://github.com/FreeCAD/Addon-Academy

- Removed the stale editorial note from the OpenCascade wiki link and normalized the link label.


