### PR TITLE
Update Developer Hub with current developer resources

### DIFF
--- a/wiki/Developer_hub.wikitext
+++ b/wiki/Developer_hub.wikitext
@@ -2,7 +2,7 @@
 <translate>
 
 <!--T:41-->
-{{VeryImportantMessage|For current FreeCAD development information, start with the [https://freecad.github.io/DevelopersHandbook/ Developers Handbook]. This hub also links older wiki pages that may still be useful for specific topics.}}
+{{VeryImportantMessage|For current FreeCAD development information, start with the [https://freecad.github.io/DevelopersHandbook/ Developers Handbook]. This hub keeps older wiki pages for topic-specific reference, but the handbook is the primary entry point for new contributors.}}
 
 </translate>
 [[Image:Crystal_Clear_app_tutorials.png|64px]]
@@ -11,17 +11,18 @@
 <translate>
 
 <!--T:2-->
-This is the place to come if you want to contribute to the development of the FreeCAD software. For current setup, contribution, review, design and maintainer guidance, start with the official [https://freecad.github.io/DevelopersHandbook/ FreeCAD Developers Handbook].
+This is the place to come if you want to contribute to the development of the FreeCAD software. The official [https://freecad.github.io/DevelopersHandbook/ FreeCAD Developers Handbook] is the primary guide for development setup, contribution workflow, design guidance, formatting, code review, maintainer procedures and technical orientation.
 
 <!--T:3-->
 These pages are in the early stage of development. If you can't find the information you are looking for, or have found useful information somewhere we have not linked to, then please leave a comment on the [https://forum.freecad.org/ forum] and someone will look into it.
 
 == Current developer resources ==
 
-* [https://freecad.github.io/DevelopersHandbook/ Developers Handbook]: Current guide for development setup, roadmap, design guidance, code formatting, code review, maintainer procedures and technical orientation.
-* [https://freecad.github.io/SourceDoc/ Source documentation]: Generated API and source documentation for FreeCAD. The source is maintained in the [https://github.com/FreeCAD/SourceDoc FreeCAD/SourceDoc] repository.
-* [https://github.com/FreeCAD/Addon-Academy Addon Academy]: Documentation, examples and guides for developing FreeCAD addons.
-* [https://github.com/FreeCAD/lens-docs Lens documentation]: Documentation for Ondsel Lens, a free/libre product data management system designed for FreeCAD and FreeCAD-based software.
+* [https://freecad.github.io/DevelopersHandbook/ Developers Handbook]: current guide for roadmap, getting started, design, code formatting, code review, maintainer procedures and technical orientation.
+* [https://github.com/FreeCAD/FreeCAD FreeCAD source repository]: source code, pull requests, issues and contributor files for the main FreeCAD project.
+* [https://freecad.github.io/SourceDoc/ Source documentation]: generated API and source documentation for FreeCAD's C++ and Python code. The source is maintained in the [https://github.com/FreeCAD/SourceDoc FreeCAD/SourceDoc] repository.
+* [https://freecad.github.io/Addon-Academy/ Addon Academy]: guides, topics and demos for creating, developing, publishing and maintaining FreeCAD addons. The source is maintained in the [https://github.com/FreeCAD/Addon-Academy FreeCAD/Addon-Academy] repository.
+* [https://github.com/FreeCAD/lens-docs Lens documentation]: documentation for the FreeCAD Lens addon.
 
 == Developer Documentation == <!--T:32-->
 
@@ -31,7 +32,8 @@ The developer documentation comprises the following sections:
 === Compiling FreeCAD === <!--T:33-->
 
 <!--T:5-->
-* [https://github.com/FreeCAD/FreeCAD GitHub repo]: If you are new to git, read [[Source_code_management|Source code management]]
+* [https://github.com/FreeCAD/FreeCAD GitHub repo]: main source repository. If you are new to git, read [[Source_code_management|Source code management]].
+* [https://freecad.github.io/DevelopersHandbook/gettingstarted/ Developers Handbook - Getting Started]: current development environment and build setup.
 * [[Compile_on_Windows|Compiling on Windows]]
 * [[Compile_on_Linux|Compiling on Linux]]
 * [[Compile_on_MacOS|Compiling on MacOS]]
@@ -41,7 +43,7 @@ The developer documentation comprises the following sections:
 * [[Third_Party_Tools|Third Party Tools]]
 * [[Start up and Configuration|Start up and Configuration]]
 * [https://freecad.github.io/SourceDoc/ Source documentation]
-* Use [https://github.com/FreeCAD/FreeCAD/issues GitHub] when you have a problem or think you may have found a bug
+* Use [https://github.com/FreeCAD/FreeCAD/issues GitHub issues] for confirmed bugs and feature requests after checking the forum and existing reports.
 
 === Packaging === <!--T:19-->
 
@@ -71,8 +73,9 @@ The developer documentation comprises the following sections:
 <!--T:7-->
 * Understanding [[The_FreeCAD_source_code|The FreeCAD source code]]
 * [[Tracker#Submitting_patches|Submitting patches]]
-* Add [[Gui_Command|Features]] or a [[Workbench_creation|Workbench]] to FreeCAD
-* [https://github.com/FreeCAD/Addon-Academy Addon Academy] for addon development documentation, examples and guides
+* [https://freecad.github.io/DevelopersHandbook/technical/ Developers Handbook - Technical Guide] for the current high-level source-code orientation.
+* Add [[Gui_Command|features]] or a [[Workbench_creation|workbench]] to FreeCAD.
+* [https://freecad.github.io/Addon-Academy/ Addon Academy] for addon development guides, topics and runnable examples.
 * [[Branding|Branding]] or ''how to give FreeCAD a unique look''
 * [[Artwork|Artwork]] we made for FreeCAD, that you can freely reuse.
 * [[Artwork_Guidelines|Artwork guidelines]] standards for icons
@@ -86,26 +89,13 @@ The developer documentation comprises the following sections:
 <!--T:16-->
 * [[Translating_an_external_workbench|Translating an external workbench]]
 
-=== Module developer's guide === <!--T:36-->
+=== Module and addon references === <!--T:36-->
 
 <!--T:13-->
-[https://github.com/qingfengxia/FreeCAD_Mod_Dev_Guide FreeCAD Mod Dev Guide]: This is an ebook under writing on GitHub, please fork and send pull request to contribute.
+For new addon work, use the [https://freecad.github.io/Addon-Academy/ Addon Academy] first. It covers addon structure, local development, publishing, maintenance, dependencies, licensing and worked examples such as commands, workbenches, document objects, preferences pages and macros.
 
 <!--T:14-->
-Chapters:
-* Overview and Software Architecture
-* Source code structure
-* Base and App module
-* Gui module
-* Python wrapping
-* Modular design
-* FEM module source analysis (mixed C++ and Python)
-* Development of CFD Module (pure Python)
-* Module testing and debugging
-* Contribute code with git
-
-<!--T:15-->
-Latest PDF preview can be downloaded from [https://github.com/qingfengxia/FreeCAD_Mod_Dev_Guide/tree/master/pdf PDFfolder] of this GitHub repository.
+The community [https://github.com/qingfengxia/FreeCAD_Mod_Dev_Guide FreeCAD Mod Dev Guide] remains a useful source-code architecture reference for deeper module topics, including App and Gui modules, Python wrapping, modular design, testing and debugging. Treat it as supplementary material rather than the primary onboarding guide.
 
 === Internals === <!--T:21-->
 
@@ -115,10 +105,10 @@ Latest PDF preview can be downloaded from [https://github.com/qingfengxia/FreeCA
 OpenCascade is a software development platform for 3D surface and solid modeling, CAD data exchange, and visualization, mostly in the form of C++ libraries.
 
 <!--T:18-->
-* [http://opencascade.wikidot.com/romansarticles Roman Lygin's tutorials]
+* [https://opencascade.wikidot.com/romansarticles Roman Lygin's tutorials]
 * [https://dev.opencascade.org/cdoc/overview/html/index.html Full Online Documentation]
 * [https://dev.opencascade.org/doc/refman/html/index.html Reference Manual]
-* [http://opencascade.wikidot.com The OpenCascade wiki]
+* [https://opencascade.wikidot.com The OpenCascade wiki]
 
 ==== File format ==== <!--T:27-->
 
@@ -144,16 +134,15 @@ The development of a new solver architecture could improve the way the solver is
 FreeCAD, though usable in certain areas, is at the beginning of a long way into the CAD mainstream. There is still a lot to do to reach a state where we can compete with commercial software.
 
 <!--T:39-->
-[[FreeCAD_1.0_Development_Cycle|FreeCAD 1.0 Development Cycle]]
+* [https://freecad.github.io/DevelopersHandbook/roadmap/ Developers Handbook - Roadmap]
+* [[Development_roadmap|Development roadmap]]
 
 == Community == <!--T:30-->
 
 <!--T:31-->
-* [ircs://irc.libera.chat:6697/freecad IRC channel] ,synchronized with [https://gitter.im/FreeCAD/FreeCAD gitter channel]
 * [https://forum.freecad.org/viewforum.php?f=6 Development forum]
-
-<!--T:10-->
-* [[Development_roadmap|Development roadmap]]
+* [https://github.com/FreeCAD/FreeCAD/issues GitHub issues]
+* [https://github.com/FreeCAD/FreeCAD/pulls GitHub pull requests]
 
 == Credits == <!--T:40-->
 

--- a/wiki/Developer_hub.wikitext
+++ b/wiki/Developer_hub.wikitext
@@ -2,7 +2,7 @@
 <translate>
 
 <!--T:41-->
-{{VeryImportantMessage|The information on this page may be obsolete, see the [https://freecad.github.io/DevelopersHandbook/ Developers Handbook] for up-to-date information.}}
+{{VeryImportantMessage|For current FreeCAD development information, start with the [https://freecad.github.io/DevelopersHandbook/ Developers Handbook]. This hub also links older wiki pages that may still be useful for specific topics.}}
 
 </translate>
 [[Image:Crystal_Clear_app_tutorials.png|64px]]
@@ -11,10 +11,17 @@
 <translate>
 
 <!--T:2-->
-This is the place to come if you want to contribute to the development of the FreeCAD software. Many of the following pages might be outdated. Check the official FreeCAD Developers Handbook for more up to date information: https://freecad.github.io/DevelopersHandbook/
+This is the place to come if you want to contribute to the development of the FreeCAD software. For current setup, contribution, review, design and maintainer guidance, start with the official [https://freecad.github.io/DevelopersHandbook/ FreeCAD Developers Handbook].
 
 <!--T:3-->
-These pages are in the early stage of development. If you can't find the information you are looking for, or have found useful information somewhere we have not linked to, then please leave a comment on the [https://forum.freecad.org/index.php?sid=5f84150e79db8842e277b042077097ff forum] and someone will look into it.
+These pages are in the early stage of development. If you can't find the information you are looking for, or have found useful information somewhere we have not linked to, then please leave a comment on the [https://forum.freecad.org/ forum] and someone will look into it.
+
+== Current developer resources ==
+
+* [https://freecad.github.io/DevelopersHandbook/ Developers Handbook]: Current guide for development setup, roadmap, design guidance, code formatting, code review, maintainer procedures and technical orientation.
+* [https://freecad.github.io/SourceDoc/ Source documentation]: Generated API and source documentation for FreeCAD. The source is maintained in the [https://github.com/FreeCAD/SourceDoc FreeCAD/SourceDoc] repository.
+* [https://github.com/FreeCAD/Addon-Academy Addon Academy]: Documentation, examples and guides for developing FreeCAD addons.
+* [https://github.com/FreeCAD/lens-docs Lens documentation]: Documentation for Ondsel Lens, a free/libre product data management system designed for FreeCAD and FreeCAD-based software.
 
 == Developer Documentation == <!--T:32-->
 
@@ -33,8 +40,8 @@ The developer documentation comprises the following sections:
 * [[Third_Party_Libraries|Third Party Libraries]]
 * [[Third_Party_Tools|Third Party Tools]]
 * [[Start up and Configuration|Start up and Configuration]]
-* [[Start_up_and_Configuration|Source documentation]]
-* Use [[https://github.com/FreeCAD/FreeCAD/issues|GitHub]] when you have a problem or think you may have found a bug
+* [https://freecad.github.io/SourceDoc/ Source documentation]
+* Use [https://github.com/FreeCAD/FreeCAD/issues GitHub] when you have a problem or think you may have found a bug
 
 === Packaging === <!--T:19-->
 
@@ -65,6 +72,7 @@ The developer documentation comprises the following sections:
 * Understanding [[The_FreeCAD_source_code|The FreeCAD source code]]
 * [[Tracker#Submitting_patches|Submitting patches]]
 * Add [[Gui_Command|Features]] or a [[Workbench_creation|Workbench]] to FreeCAD
+* [https://github.com/FreeCAD/Addon-Academy Addon Academy] for addon development documentation, examples and guides
 * [[Branding|Branding]] or ''how to give FreeCAD a unique look''
 * [[Artwork|Artwork]] we made for FreeCAD, that you can freely reuse.
 * [[Artwork_Guidelines|Artwork guidelines]] standards for icons
@@ -110,7 +118,7 @@ OpenCascade is a software development platform for 3D surface and solid modeling
 * [http://opencascade.wikidot.com/romansarticles Roman Lygin's tutorials]
 * [https://dev.opencascade.org/cdoc/overview/html/index.html Full Online Documentation]
 * [https://dev.opencascade.org/doc/refman/html/index.html Reference Manual]
-* [http://opencascade.wikidot.com The openCascade wiki] (currently containing ?? Chinese spam)
+* [http://opencascade.wikidot.com The OpenCascade wiki]
 
 ==== File format ==== <!--T:27-->
 


### PR DESCRIPTION
## Summary

Follow-up to the closed PR #341 and the maintainer feedback that the Developer Hub information itself needed a fuller update.

This revision updates `wiki/Developer_hub.wikitext` for #329 by:

- making the FreeCAD Developers Handbook the primary new-contributor entry point
- adding a current-resource section for the Developers Handbook, FreeCAD source repository, SourceDoc, Addon Academy and Lens documentation
- pointing build/setup guidance to the current Developers Handbook getting-started page
- adding current technical/source orientation and Addon Academy links to the modification section
- replacing the dated Module Developer's Guide chapter/PDF block with a shorter supplementary reference
- replacing the old FreeCAD 1.0 roadmap link with the current Developers Handbook roadmap plus the wiki roadmap
- removing the obsolete IRC/Gitter community row and adding GitHub issues/pull requests
- fixing the stale forum URL, malformed GitHub issue link, SourceDoc link and OpenCascade link/casing

Refs #329.

## Validation

- Verified issue #329 is still open and labeled as a bounty/reward issue.
- Checked for competing Developer Hub PRs and did not find another active PR for #329.
- Checked the current linked resources:
  - `https://freecad.github.io/DevelopersHandbook/`
  - `https://freecad.github.io/SourceDoc/`
  - `https://freecad.github.io/Addon-Academy/`
  - `https://github.com/FreeCAD/FreeCAD`
  - `https://github.com/FreeCAD/lens-docs`
- Ran `git diff --check origin/main...HEAD -- wiki/Developer_hub.wikitext`.

No private data, credentials, signing material or payment details are included.
