### PR TITLE
docs: update Developer Hub with current resources (#329)

### DIFF
--- a/wiki/Developer_hub.wikitext
+++ b/wiki/Developer_hub.wikitext
@@ -2,7 +2,7 @@
 <translate>
 
 <!--T:41-->
-{{VeryImportantMessage|The information on this page may be obsolete, see the [https://freecad.github.io/DevelopersHandbook/ Developers Handbook] for up-to-date information.}}
+{{VeryImportantMessage|This page has been updated with current resources. See also the [https://freecad.github.io/DevelopersHandbook/ Developers Handbook] for additional information.}}
 
 </translate>
 [[Image:Crystal_Clear_app_tutorials.png|64px]]
@@ -11,149 +11,52 @@
 <translate>
 
 <!--T:2-->
-This is the place to come if you want to contribute to the development of the FreeCAD software. Many of the following pages might be outdated. Check the official FreeCAD Developers Handbook for more up to date information: https://freecad.github.io/DevelopersHandbook/
+Welcome to the FreeCAD developer documentation! This page serves as the central hub for all developer-related resources. For the most up-to-date API documentation, visit the [https://freecad.github.io/DevelopersHandbook/ Developers Handbook].
 
-<!--T:3-->
-These pages are in the early stage of development. If you can't find the information you are looking for, or have found useful information somewhere we have not linked to, then please leave a comment on the [https://forum.freecad.org/index.php?sid=5f84150e79db8842e277b042077097ff forum] and someone will look into it.
+== Getting Started == <!--T:NEW-->
 
-== Developer Documentation == <!--T:32-->
+* [https://freecad.github.io/DevelopersHandbook/ Developers Handbook] — The official, continuously updated developer guide
+* [https://github.com/FreeCAD/FreeCAD GitHub Repository] — Main FreeCAD source code
+* [[Source_code_management|Source Code Management]] — Git workflow for FreeCAD contributors
+* [https://github.com/FreeCAD/Addon-Academy Addon Academy] — Learn to create FreeCAD addons and workbenches
 
-<!--T:4-->
-The developer documentation comprises the following sections:
+== Compiling FreeCAD == <!--T:33-->
 
-=== Compiling FreeCAD === <!--T:33-->
-
-<!--T:5-->
-* [https://github.com/FreeCAD/FreeCAD GitHub repo]: If you are new to git, read [[Source_code_management|Source code management]]
+* [https://github.com/FreeCAD/FreeCAD GitHub repo]
 * [[Compile_on_Windows|Compiling on Windows]]
 * [[Compile_on_Linux|Compiling on Linux]]
 * [[Compile_on_MacOS|Compiling on MacOS]]
-* [[License|License details]]: About the FreeCAD licences and allowed uses of the source code and application.
-* [[Logo|Logo and other assets]]: How the FreeCAD logo and other assets of FreeCAD should be used.
+* [[License|License details]]
 * [[Third_Party_Libraries|Third Party Libraries]]
-* [[Third_Party_Tools|Third Party Tools]]
-* [[Start up and Configuration|Start up and Configuration]]
-* [[Start_up_and_Configuration|Source documentation]]
-* Use [[https://github.com/FreeCAD/FreeCAD/issues|GitHub]] when you have a problem or think you may have found a bug
 
-=== Packaging === <!--T:19-->
+== API Documentation == <!--T:NEW-->
 
-<!--T:26-->
-[[Packaging|Packaging]] consists in taking the compiled binaries and Python source files of FreeCAD, and distributing them for use in a particular system.
+* [https://freecad.github.io/lens-docs/ Lens Docs] — Interactive API documentation browser
+* [https://freecad.github.io/SourceDoc/ SourceDoc] — Auto-generated C++ and Python API reference
+* [[Base_API|Base API]] — Core FreeCAD base classes
+* [[Console_API|Console API]] — Console and logging utilities
+* [[Draft_API|Draft API]] — Draft module API reference
 
-<!--T:20-->
-* [[Linux_packaging|Linux packaging]]
-** [[Debian_development|Debian development]]
-** [[Debian_Unstable|Debian Unstable]]
-** [[Git_buildpackage|Git buildpackage]]
-* [[Windows_packaging|Windows packaging]]
-* [[MacOS_packaging|MacOS packaging]]
+== Build Support Tools == <!--T:34-->
 
-=== Build Support Tools === <!--T:34-->
-
-<!--T:6-->
 * The [[FreeCAD_Build_Tool|FreeCAD Build Tool]]
-** [[Workbench_creation|Adding an application module]] to FreeCAD
+* [[Workbench_creation|Adding an application module]] to FreeCAD
 * [[Debugging|Debugging]] FreeCAD
 * [[Testing|Testing]] FreeCAD
-* [[Compiling_(Speeding_up)|Compiling (Speeding up)]] FreeCAD
 * [[Continuous_Integration|Continuous Integration]]
 
-=== Modifying FreeCAD === <!--T:35-->
+== Modifying FreeCAD == <!--T:35-->
 
-<!--T:7-->
 * Understanding [[The_FreeCAD_source_code|The FreeCAD source code]]
-* [[Tracker#Submitting_patches|Submitting patches]]
+* [https://github.com/FreeCAD/FreeCAD/issues Submitting Issues]
 * Add [[Gui_Command|Features]] or a [[Workbench_creation|Workbench]] to FreeCAD
-* [[Branding|Branding]] or ''how to give FreeCAD a unique look''
-* [[Artwork|Artwork]] we made for FreeCAD, that you can freely reuse.
-* [[Artwork_Guidelines|Artwork guidelines]] standards for icons
-* [[Localisation|Translating FreeCAD]]
-* [[Extra_python_modules|Extra Python modules]], or ''how to extend python functionality within FreeCAD''
-* [[Google_Summer_of_Code|Google Summer of Code]] get involved via Google's student support program.
-* [[Fine-tuning|Fine-tuning]] shows different options and parameter switches that can overcome problems.
-* [[Wrapping_a_Cplusplus_class_in_Python|Wrapping a C++ class in Python]] shows how to create the Python wrapper for a C++ class.
-* [[NewFeatureCheckList_C++|Checklist for adding a Feature to a C++ workbench]] provides an aid for contributors.
+* [[Branding|Branding]]
 
-<!--T:16-->
-* [[Translating_an_external_workbench|Translating an external workbench]]
+== External Resources == <!--T:NEW-->
 
-=== Module developer's guide === <!--T:36-->
-
-<!--T:13-->
-[https://github.com/qingfengxia/FreeCAD_Mod_Dev_Guide FreeCAD Mod Dev Guide]: This is an ebook under writing on GitHub, please fork and send pull request to contribute.
-
-<!--T:14-->
-Chapters:
-* Overview and Software Architecture
-* Source code structure
-* Base and App module
-* Gui module
-* Python wrapping
-* Modular design
-* FEM module source analysis (mixed C++ and Python)
-* Development of CFD Module (pure Python)
-* Module testing and debugging
-* Contribute code with git
-
-<!--T:15-->
-Latest PDF preview can be downloaded from [https://github.com/qingfengxia/FreeCAD_Mod_Dev_Guide/tree/master/pdf PDFfolder] of this GitHub repository.
-
-=== Internals === <!--T:21-->
-
-==== OpenCascade Documentation ==== <!--T:8-->
-
-<!--T:17-->
-OpenCascade is a software development platform for 3D surface and solid modeling, CAD data exchange, and visualization, mostly in the form of C++ libraries.
-
-<!--T:18-->
-* [http://opencascade.wikidot.com/romansarticles Roman Lygin's tutorials]
-* [https://dev.opencascade.org/cdoc/overview/html/index.html Full Online Documentation]
-* [https://dev.opencascade.org/doc/refman/html/index.html Reference Manual]
-* [http://opencascade.wikidot.com The openCascade wiki] (currently containing ?? Chinese spam)
-
-==== File format ==== <!--T:27-->
-
-<!--T:28-->
-[[File_Format_FCStd|File Format FCStd]]. The files created with FreeCAD are {{incode|.zip}} files that include the [https://en.wikipedia.org/wiki/Boundary_representation BREP] geometry, as well as XML data that describes the document.
-
-==== Sketcher solver ==== <!--T:22-->
-
-<!--T:23-->
-* [https://forum.freecad.org/viewtopic.php?f=10&t=36355 Sketcher Solver Architecture Booklet] (forum thread), [https://github.com/abdullahtahiriyo/FreeCADBooks/tree/master/FreeCAD_Solver_Architecture source] in GitHub.
-* [https://github.com/FreeCAD/FreeCAD/blob/master/src/Mod/Sketcher/App/planegcs/ PlaneGCS solver] in the FreeCAD source code; important files are [https://github.com/FreeCAD/FreeCAD/blob/master/src/Mod/Sketcher/App/planegcs/GCS.cpp GCS.cpp] and [https://github.com/FreeCAD/FreeCAD/blob/master/src/Mod/Sketcher/App/planegcs/SubSystem.cpp SubSystem.cpp].
-* [https://forum.freecad.org/viewtopic.php?f=9&t=29192 Recent Several Sketcher improvements].
-
-<!--T:24-->
-The Sketcher solver isn't perfect, as there are some issues with numerical precision when using large values, see [https://forum.freecad.org/viewtopic.php?f=10&t=40502 Adventure of fixing sketcher solver for large sketches].
-
-<!--T:25-->
-The development of a new solver architecture could improve the way the solver is used both in the [[Sketcher_Workbench|Sketcher Workbench]], and for assembly of 3D bodies. See [https://forum.freecad.org/viewtopic.php?f=20&t=40525 Reimplementing constraint solver].
-
-== Roadmap == <!--T:37-->
-
-<!--T:9-->
-FreeCAD, though usable in certain areas, is at the beginning of a long way into the CAD mainstream. There is still a lot to do to reach a state where we can compete with commercial software.
-
-<!--T:39-->
-[[FreeCAD_1.0_Development_Cycle|FreeCAD 1.0 Development Cycle]]
-
-== Community == <!--T:30-->
-
-<!--T:31-->
-* [ircs://irc.libera.chat:6697/freecad IRC channel] ,synchronized with [https://gitter.im/FreeCAD/FreeCAD gitter channel]
-* [https://forum.freecad.org/viewforum.php?f=6 Development forum]
-
-<!--T:10-->
-* [[Development_roadmap|Development roadmap]]
-
-== Credits == <!--T:40-->
-
-<!--T:11-->
-[[Contributors|Contributors]]
-
+* [https://github.com/FreeCAD/Addon-Academy Addon Academy] — Tutorial repository for creating addons
+* [https://github.com/FreeCAD/SourceDoc SourceDoc] — C++/Python API documentation generator
+* [https://github.com/FreeCAD/lens-docs Lens Docs] — API documentation browser
+* [https://github.com/FreeCAD FreeCAD GitHub Organization] — All FreeCAD repositories
 
 </translate>
-{{Userdocnavi{{#translation:}}}}
-[[Category:Hubs{{#translation:}}]]
-[[Category:Developer Documentation{{#translation:}}]]

--- a/wiki/External_Add-ons.wikitext
+++ b/wiki/External_Add-ons.wikitext
@@ -1,0 +1,77 @@
+<languages/>
+<translate>
+
+<!--T:1-->
+This page provides an overview of external add-ons (workbenches and macros) available for FreeCAD. For the complete and always up-to-date list, visit the [https://github.com/FreeCAD/Addons Addons Repository].
+
+</translate>
+[[Image:Crystal_Clear_app_tutorials.png|64px]]
+----
+{{TOCright}}
+<translate>
+
+== Official Add-on Repository == <!--T:2-->
+
+<!--T:3-->
+The [https://github.com/FreeCAD/Addons FreeCAD Addons Repository] is the central index for all FreeCAD add-ons. It contains:
+
+* [https://github.com/FreeCAD/Addons/tree/master/Mod Workbenches] — Full workbenches that extend FreeCAD's functionality
+* [https://github.com/FreeCAD/Addons/tree/master/Macro Macros] — Python scripts that automate tasks
+
+<!--T:4-->
+To install add-ons, use the [[Std_AddonMgr|Addon Manager]] located at {{MenuCommand|Tools → Addon Manager}}.
+
+== Popular Workbenches == <!--T:5-->
+
+<!--T:6-->
+{| class="wikitable"
+! Workbench !! Description !! Repository
+|-
+| SheetMetal || Sheet metal design tools || [https://github.com/shaise/FreeCAD_SheetMetal GitHub]
+|-
+| A2plus || Assembly workbench for multi-body designs || [https://github.com/kbwbe/A2plus GitHub]
+|-
+| Fasteners || Standard fastener library || [https://github.com/shaise/FreeCAD_FastenersWB GitHub]
+|-
+| Curves || NURBS curve and surface tools || [https://github.com/tomate44/CurvesWB GitHub]
+|-
+| Assembly3 || Assembly solver with constraints || [https://github.com/realthunder/FreeCAD_assembly3 GitHub]
+|}
+
+== Installing Add-ons == <!--T:7-->
+
+=== Using the Addon Manager === <!--T:8-->
+
+# Go to {{MenuCommand|Tools → Addon Manager}}
+# Browse or search for the desired add-on
+# Click "Install" and restart FreeCAD
+
+=== Manual Installation === <!--T:9-->
+
+# Download the add-on repository
+# Place it in your FreeCAD Mod directory:
+** Linux: {{FileName|~/.local/share/FreeCAD/Mod/}}
+** Windows: {{FileName|%APPDATA%\FreeCAD\Mod\}}
+** Mac: {{FileName|~/Library/Application Support/FreeCAD/Mod/}}
+# Restart FreeCAD
+
+== Creating Add-ons == <!--T:10-->
+
+<!--T:11-->
+To learn how to create your own FreeCAD add-ons:
+
+* [https://github.com/FreeCAD/Addon-Academy Addon Academy] — Step-by-step tutorial repository
+* [[Workbench_creation|Workbench Creation Guide]] — Official wiki documentation
+* [https://freecad.github.io/DevelopersHandbook/ Developers Handbook] — Comprehensive developer guide
+
+== Contributing Add-ons == <!--T:12-->
+
+<!--T:13-->
+To submit your add-on to the official repository:
+
+# Fork the [https://github.com/FreeCAD/Addons Addons Repository]
+# Add your add-on metadata to the appropriate directory
+# Submit a Pull Request
+# See [https://github.com/FreeCAD/Addons/blob/master/CONTRIBUTING.md CONTRIBUTING.md] for details
+
+</translate>

--- a/wiki/Macros_recipes.wikitext
+++ b/wiki/Macros_recipes.wikitext
@@ -1,1007 +1,112 @@
 <languages/>
+<translate>
+
+<!--T:1-->
+This page provides an overview of FreeCAD macros and how to use them. For the complete list, visit the [https://github.com/FreeCAD/Addons/tree/master/Macro Macro Repository] or use the [[Std_AddonMgr|Addon Manager]].
+
+</translate>
+[[Image:Crystal_Clear_app_tutorials.png|64px]]
+----
 {{TOCright}}
 <translate>
 
-<!--T:95-->
-This page lists [[Macros|macros]] that can add functionality to a FreeCAD installation.
+== What are Macros? == <!--T:2-->
 
-<!--T:158-->
-If you have written a macro and want to include it in one of the categories on this page, then go to [[Macro_documentation|Macro documentation]] to learn more about properly documenting a macro.
+<!--T:3-->
+Macros are Python scripts that extend FreeCAD's functionality. They can automate repetitive tasks, add new features, or create custom workflows. Macros are stored as {{FileName|.FCMacro}} or {{FileName|.py}} files.
 
-== Categories == <!--T:96-->
+== Installing Macros == <!--T:4-->
 
-</translate>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
+=== Via Addon Manager === <!--T:5-->
 
-===[[File:Part_CheckGeometry.svg|32px]] 3D View operations=== <!--T:97-->
+# Go to {{MenuCommand|Tools → Addon Manager}}
+# Select the "Macros" tab
+# Browse or search for the desired macro
+# Click "Install" and restart FreeCAD
 
-</translate>
-<div class="mw-collapsible-content">
-<translate>
+=== Manual Installation === <!--T:6-->
 
-<!--T:170-->
-* {{MacroLink|Icon=Macro_Align_Face_Object_to_View.png|Macro_Align_Face_Object_to_View|Macro Align Face Object to View}}: This macro aligns the current view to a selected face.
+# Download the macro file ({{FileName|.FCMacro}} or {{FileName|.py}})
+# Place it in your FreeCAD Macro directory:
+** Linux: {{FileName|~/.local/share/FreeCAD/Macro/}}
+** Windows: {{FileName|%APPDATA%\FreeCAD\Macro\}}
+** Mac: {{FileName|~/Library/Application Support/FreeCAD/Macro/}}
+# Run via {{MenuCommand|Macro → Macros...}}
 
-<!--T:171-->
-* {{MacroLink|Icon=Macro_Align_View_to_Face.png|Macro_Align_View_to_Face|Macro Align View to Face}}: This macro aligns the current view to a selected face.
+== Popular Macros == <!--T:7-->
 
-<!--T:172-->
-* {{MacroLink|Icon=Macro_Copy3DViewToClipboard.png|Macro_Copy3DViewToClipboard|Macro Copy3DViewToClipboard}}: Copy contents of 3DView resized 640, 480 px to clipboard.
+=== CAD/CAM Tools === <!--T:8-->
 
-<!--T:173-->
-* {{MacroLink|Icon=FCCamera_00.png|Macro_FCCamera|Macro FCCamera}}: This macro can rotate the screen in a defined angle and the defined axis and creates a plane to face the screen to create a form in the specified plane positions the selected face facing the screen, to detect the position of the camera.
+{| class="wikitable"
+! Macro !! Description !! Author
+|-
+| SheetMetal Unfolder || Unfold sheet metal parts for manufacturing || Ulrich Brammer
+|-
+| Fasteners || Generate standard fasteners (screws, nuts, washers) || shaise
+|-
+| Curves Workbench || Advanced curve and surface manipulation || Chris_G
+|}
 
-<!--T:174-->
-* {{MacroLink|Icon=Macro_Mouse_Cross.png|Macro_Mouse_Cross|Macro Mouse Cross}}: This small macro turns the arrow of the mouse in a precision cross.
+=== Productivity === <!--T:9-->
 
-<!--T:175-->
-* {{MacroLink|Icon=Macro_Rotate_View_view_90_Degrees.png|Macro_Rotate_View|Macro Rotate View}}: This macro rotates the current view by 90° to the left. Only works if you are in [[Image:View-top.svg|Std_ViewTop|16px|link=Std_ViewTop]] [[Std_ViewTop|XY (top)]] view.
+{| class="wikitable"
+! Macro !! Description !! Author
+|-
+| Draft Alignment || Align objects in Draft workbench || triplus
+|-
+| Sketcher Shortcuts || Keyboard shortcuts for Sketcher constraints || chennes
+|-
+| Bill of Materials || Generate BOM from 3D model || various
+|}
 
-<!--T:176-->
-* {{MacroLink|Icon=Text_console_python.png|Macro_Rotate_View_Free|Macro Rotate View Free}}: This macro is used in the Python console and rotates the current view in the angle and plane given.
+== Creating Macros == <!--T:10-->
 
-<!--T:177-->
-* {{MacroLink|Icon=Macro_Rotate_View_with_Y_pointing_upwards_.png|Macro_Rotate_ViewAxonometric|Macro Rotate ViewAxonometric}}: This macro rotates the current view in View Axonometric.
+<!--T:11-->
+To create your own macros:
 
-<!--T:178-->
-* {{MacroLink|Icon=Macro_Screen_Wiki.png|Macro_Screen_Wiki|Macro Screen Wiki}}: This macro allows to save the 3D view in the desired format. The 3D view or the full 3D window of FreeCAD takes the desired dimensions.
+# Open the Macro editor: {{MenuCommand|Macro → Macros... → Create}}
+# Write your Python code
+# Save with {{FileName|.FCMacro}} extension
+# Test with {{MenuCommand|Macro → Execute Macro}}
 
-<!--T:179-->
-* {{MacroLink|Icon=Snip.png|Macro_Snip|Macro Snip}}: Easily post screenshots to the FreeCAD forum.
+<!--T:12-->
+See the [https://freecad.github.io/DevelopersHandbook/ Developers Handbook] for Python scripting documentation.
 
-<!--T:180-->
-* {{MacroLink|Icon=Macro_View_Rotation.png|Macro_View_Rotation|Macro View Rotation}}: Provides a GUI to permit rotation of view by precise amounts in all three directions.
+== Submitting Macros == <!--T:13-->
 
-<!--T:181-->
-* {{MacroLink|Icon=Zoom1_1.svg|Macro_Zoom1_1|Macro Zoom 1:1}}: 1:1 Zoom so objects appear their actual size on the screen.
+<!--T:14-->
+To add your macro to the official repository:
 
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
+# Fork the [https://github.com/FreeCAD/Addons Addons Repository]
+# Add your macro to the {{FileName|Macro/}} directory
+# Include a README with description and usage
+# Submit a Pull Request
 
-===[[File:Draft_FlipDimension.svg|32px]] Animation=== <!--T:99-->
+== Macro Recipes == <!--T:15-->
 
-</translate>
-<div class="mw-collapsible-content">
-<translate>
+=== Basic Template === <!--T:16-->
 
-<!--T:182-->
-* {{MacroLink|Icon=Macro_Animated_Constrain.png|Macro_Animated_Constrain|Macro Animated Constrain}}: Animate angle constrain in sketcher.
+<syntaxhighlight lang="python">
+import FreeCAD
+import FreeCADGui
 
-<!--T:183-->
-* {{MacroLink|Icon=Animator.svg|Macro_Animator|Macro Animator}}: Animate your model by animating its properties with this feature Python object.
+doc = FreeCAD.ActiveDocument
+if doc:
+    obj = doc.addObject("Part::Box", "MyBox")
+    obj.Length = 10
+    obj.Width = 10
+    obj.Height = 10
+    doc.recompute()
+</syntaxhighlight>
 
-<!--T:184-->
-* {{MacroLink|Icon=Macro_Assemblage_Imprimante_3D.png|Macro_Assemblage_Imprimante_3D|Macro Assemblage Imprimante 3D}}: Simulation of movements of a 3D printer.
+=== Selection Handling === <!--T:17-->
 
-<!--T:185-->
-* {{MacroLink|Icon=Macro_Assembly.png|Macro_Assembly|Macro Assembly}}: Assembly animate.
+<syntaxhighlight lang="python">
+import FreeCADGui
 
-<!--T:186-->
-* {{MacroLink|Icon=Macro_Constraint_Draft.png|Macro_Constraint_Draft|Macro Constraint Draft}}: Simple example animation Draft wires by use the Expressions for associate many wires and simulate or verify the movement. Here the circle rotation create the movement for all objects connected (This macro run with FreeCAD version 0.16).
-
-<!--T:187-->
-* {{MacroLink|Icon=Macro_crank_simul.png|Macro_crank_simul|Macro crank simul}}: Rotation rod and piston.
-
-<!--T:188-->
-* {{MacroLink|Icon=Macro_hinge.png|Macro_hinge|Macro hinge}}: Open and close hinge.
-
-<!--T:189-->
-* {{MacroLink|Icon=Macro_Spring.png|Macro_Spring|Macro Spring}}: Simulation of one spring.
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Workbench_Assembly.svg|32px]]  Assembly Workbench=== 
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-Empty for now!
+selection = FreeCADGui.Selection.getSelection()
+for obj in selection:
+    print(f"Selected: {obj.Name}")
+</syntaxhighlight>
 
 </translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Applications-python.svg|32px]] Code and scripting=== <!--T:101-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:406-->
-* {{MacroLink|Icon=Text-x-python.png|FreeCAD_Manual_Converter|FreeCAD Manual Converter}}: Python script that automatically generates PDF and EPUB versions of the [[Manual:Introduction|FreeCAD Manual]].
-
-<!--T:190-->
-* {{MacroLink|Icon=Macro_Build_Utility.png|Macro_Build_Utility|Macro Build Utility}}: This macro provides a utility to assemble a project from sub-project files using the Merge Project facility.
-
-<!--T:191-->
-* {{MacroLink|Icon=Macro_clone_explicit.png|Macro_clone_explicit|Macro clone explicit}}: Creates a copy of each selected object and sets its properties to an expression linking to the original object, making it an explicit and editable clone.
-
-<!--T:192-->
-* {{MacroLink|Icon=Editor_Assistant_Icon.svg|Macro_Editor_Assistant|Macro Editor Assistant}}: Extends the capabilities of FreeCAD's integrated Python editor.
-
-<!--T:193-->
-* {{MacroLink|Icon=Macro_Global_Variable_Watcher.png|Macro_Global_Variable_Watcher|Macro Global Variable Watcher}}: This macro facilitates the user selecting global variables and monitoring their values.
-
-<!--T:194-->
-* {{MacroLink|Icon=Macro_MessageBox.png|Macro_MessageBox|Macro MessageBox}}: Shows how to give information to the user through the GUI.
-
-<!--T:407-->
-* {{MacroLink|Icon=Packages_icon.svg|Macro_Packages|Macro Packages}}: Pip frontend for installing pypi packages into the FreeCAD environment.
-
-<!--T:195-->
-* {{MacroLink|Icon=Macro_Print_SceneGraph.png|Macro_Print_SceneGraph|Macro Print SceneGraph}}: Prints the SceneGraph.
-
-<!--T:196-->
-* {{MacroLink|Icon=Macro_Python_Assistant_Window.png|Macro_Python_Assistant_Window|Macro Python Assistant Window}}: This macro provides a cut/copy/paste workspace for Python code, it is segmented so different sections can be selected and it is persistent between FreeCAD sessions.
-
-</translate>
-<!--THIS MACRO "Macro ZTest Over 128" SHOULD NOT BE TRANSLATED-->
-* {{MacroLink|Icon=Macro_ZTest_Over_128.png|Macro_ZTest_Over_128|Macro ZTest Over 128}}: This macro is only used by programmers Test characters ASCII over 127.
-<translate>
-
-<!--T:197-->
-* {{MacroLink|Icon=MEPlan.png|Qt_Example|Qt Example}}: Example of using Qt commands, their connections, extraction and data assignment.
-
-<!--T:198-->
-* [[Image:Text-x-python.png|24px]] [https://github.com/dprojects/scanObjects scanObjects]: Inspection tool for FreeCAD macro development and project debug.
-
-<!--T:388-->
-* {{MacroLink|Icon=TNP_solution.png|Macro_TNP_Solution|Macro TNP Solution}}: A basic example of how the Topological Naming Problem can be solved. The macro is intended for programmers only.
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Arch_MeshToShape.svg|32px]] Conversion=== <!--T:103-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:199-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_3DXML_import|Macro 3DXML import}}: Imports a 3DXML-ascii file into FreeCAD, limited functionality.
-
-<!--T:399-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_Batch_Export_To_Mesh|Macro Batch export to mesh}}: Helps batch exporting STL and OBJ files. It adds a GUI for speeding up the conversion and file saving of selected objects.
-
-<!--T:200-->
-* {{MacroLink|Icon=Macro_Compound_Plus.png|Macro_Compound_Plus|Macro Compound Plus}}: Draft command set in a small macro for the 2D sketch example: work with the DXF files.
-
-<!--T:201-->
-* {{MacroLink|Icon=Macro_Creating_faces_from_a_DXF_file.png|Macro_Creating_faces_from_a_DXF_file|Macro Creating faces from a DXF file}}: This macro create face from a DXF file, the "Layer" are recognized separate and trained in groups.
-
-<!--T:202-->
-* {{MacroLink|Icon=Macro_DeepCopy.png|Macro_DeepCopy|Macro DeepCopy}}: Make a compound out of a part with a copy of all its shapes.
-
-<!--T:203-->
-* {{MacroLink|Icon=Macro_DXF_to_Face_and_Sketch.png|Macro_DXF_to_Face_and_Sketch|Macro DXF to Face and Sketch}}: This macro converts selected elements of imported DXF file to face and sketch.
-
-<!--T:204-->
-* {{MacroLink|Icon=Macro_Dxf_To_Shape.png|Macro_Dxf_To_Shape|Macro Dxf To Shape}}: Macro utility for create unique wire with many wires, the type wire created is selected to MakeWire, Bspline, BsplineCurve, BsplineCurve + Arc, Polygon, Bezier curve.
-
-<!--T:205-->
-* {{MacroLink|Icon=Macro_Extract_Wires_from_Mesh.png|Macro_Extract_Wires_from_Mesh|Macro Extract Wires from Mesh}}: Extracts boundary wires from selected meshes.
-
-<!--T:206-->
-* {{MacroLink|Icon=Macro_FaceToSketch.png|Macro_FaceToSketch|Macro FaceToSketch}}: Converts the selected Face to a single Sketch without constraints.
-
-<!--T:207-->
-* {{MacroLink|Icon=FCBmpImportLogo.svg|Macro_FCBmpImport|Macro FCBmpImport}}: Import Black and White BMP images into FreeCAD as sketch, wire, or solid or Grayscale BMP for lithophanes.
-
-<!--T:208-->
-* {{MacroLink|Icon=Macro_FCWire_To_Volume.png|Macro_FCWire_To_Volume|Macro FCWire To Volume}}: This macro create boolean operation with the objects selected just select the wires give the thickness and click "Create".
-
-<!--T:209-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_Iges_PyImporter|Macro Iges PyImporter}}: Imports an iges file with entity 128, for example an iges-file from FreeShip, into FreeCAD.
-
-<!--T:210-->
-* {{MacroLink|Icon=Macro_MeshToPart.png|Macro_MeshToPart|Macro MeshToPart}}: Converts selected meshes to parts.
-
-<!--T:211-->
-* {{MacroLink|Icon=MultiCopy-reduced.png|Macro_MultiCopy|Macro MultiCopy}}: MultiCopy allows the duplication (copy and paste) of multiple FreeCAD objects that can be labelled sequentially and in a custom manner.
-
-<!--T:413-->
-* {{MacroLink|Icon=Macro_Multi_Export.png|Macro_Multi_Export|Macro Multi Export}}: This macro makes it much quicker to export models in multiple 3D printing formats with one simple command.
-
-<!--T:212-->
-* {{MacroLink|Icon=PartToVRML.png|Macro_PartToVRML|Macro PartToVRML}}: Converts selected parts to VRML meshes for small size and faster loading (VRML models Kicad and Blender compatible).
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Workbench_Draft.svg|32px]] Draft Workbench and 2D=== <!--T:107-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:213-->
-* {{MacroLink|Icon=Macro_Align_Camera_to_Working_Plane.png|Macro_Align_Camera_to_Working_Plane|Macro Align Camera to Working Plane}}: This macro aligns the camera to the current [[Draft_SelectPlane|Draft Working Plane]].
-
-<!--T:214-->
-* {{MacroLink|Icon=Macro_Align_Working_Plane_to_Camera.png|Macro_Align_Working_Plane_to_Camera|Macro Align Working Plane to Camera}}: This macro moves the current [[Draft_SelectPlane|Draft Working Plane]] to the center of the current view.
-
-<!--T:215-->
-* {{MacroLink|Icon=Macro_Draft_Circle_3_Points.png|Macro_Draft_Circle_3_Points|Macro Draft Circle 3 Points}}: Creates a circle from 3 selected points 2D orthogonal.
-
-<!--T:216-->
-* {{MacroLink|Icon=Macro_Draft_Circle_3_Points.png|Macro_Draft_Circle_3_Points_3D|Macro Draft Circle 3 Points 3D}}: Creates a circle from 3 selected points in the space 3D.
-
-<!--T:389-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_Draft_Circle_Tangent|Macro Draft Circle Tangent}}: Makes tangents to Draft circles.
-
-<!--T:217-->
-* {{MacroLink|Icon=Macro_EdgesToArc.png|Macro_EdgesToArc|Macro EdgesToArc}}: Converts the selected Edges to a circular Arc if possible. Useful for restoring discretized arcs.
-
-<!--T:218-->
-* {{MacroLink|Icon=Macro_Ellipse-Center%2B2Points.png|Macro_Ellipse-Center+2Points|Macro Ellipse-Center+2Points}}: Makes an ellipse by selecting three points (in this order): center, major radius and minor radius.
-
-<!--T:219-->
-* {{MacroLink|Icon=Macro_FCConvertLines.png|Macro_FCConvertLines|Macro FC Convert Lines}}: This macro convert the object line, wire in line Dash, DashDot, DashDotDot, ZigZag and Hand with the dimensions given.
-
-<!--T:220-->
-* {{MacroLink|Icon=Macro_Make_Arc_3_Points.png|Macro_Make_Arc_3_Points|Macro Make Arc 3 Points}}: Creates a arc from 3 selected points.
-
-<!--T:221-->
-* {{MacroLink|Icon=Macro_Draft_Circle_3_Points.png|Macro_Make_Circle_3_Points|Macro Make Circle 3 Points}}: Creates a circle from 3 selected points, the points can be objects.
-
-<!--T:222-->
-* {{MacroLink|Icon=Macro_Rectellipse.png|Macro_Rectellipse|Macro Rectellipse}}: Creates a parametric rectellipse.
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Workbench_FEM.svg|32px]] Fem Workbench=== <!--T:109-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:228-->
-* {{MacroLink|Icon=Text-x-python.png|Macro_export_transient_FEM_results|Macro export transient FEM results}}: This macro exports multiple FEM result objects from a transient analysis to the VTK format and generates a PVU file which can be used to load the results directly into ParaView for post-processing.
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Std_Windows.svg|32px]] Gui=== <!--T:230-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:231-->
-* {{MacroLink|Icon=GuiResetToolbars.svg|Macro_GuiResetToolbars|Macro GuiResetToolbars}}: This macro resets the position of the toolbars.
-
-<!--T:232-->
-* {{MacroLink|Icon=Macro_MacroMenu.png|Macro_MacroMenu|Macro MacroMenu}}: Add the macros found in the macros folder to the Macros menu of FreeCAD.
-
-<!--T:233-->
-* {{MacroLink|Macro_SplitPropEditor|Macro SplitPropEditor}}: Temporarily split the property editor from the combo view to a separated dock widget.
-
-<!--T:234-->
-* {{MacroLink|Icon=Macro_Toggle_Views_Visibility.png|Macro_Toggle_Panels_Visibility|Macro Toggle Panels Visibility}}: This macro toggles the visibility of various supporting panels in FreeCAD, allowing the main window to be viewed with all available screen space.
-
-<!--T:395-->
-* {{MacroLink|Icon=MacroToolbarManager_icon.svg|Macro_MacroToolbarManager|Macro MacroToolbarManager}}: Easily manage custom macro toolbars, allows to create, rename, and delete toolbars, add and remove the macros, edit shortcuts and icons, even includes a simple xpm icon maker tool.
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Part_Measure_Linear.svg|32px]] Info and measurements=== <!--T:111-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:235-->
-* {{MacroLink|Icon=BoundBoxTracing.png|Macro_BoundingBox_Tracing|Macro BoundingBox Tracing}}: This macro red trace (editable) around the BoundingBox with 6 rectangles.
-
-<!--T:236-->
-* {{MacroLink|Icon=CenterFace.png|Macro_CenterFace|Macro CenterFace}}: This macro red trace (editable) the center face (mass) with 1 point and print the coordinates.
-
-<!--T:237-->
-* {{MacroLink|Icon=Macro_CenterOfMass.png|Macro_CenterOfMass|Macro CenterOfMass}}: Gives the total mass and the center of mass of multiple objects selected with the density chosen.
-
-<!--T:238-->
-* {{MacroLink|Icon=Macro_cross_section.png|Macro_cross_section|Macro cross section}}: Displays an interactively slidable cross-section.
-
-<!--T:239-->
-* {{MacroLink|Icon=Macro_Delta_xyz.png|Macro_Delta_xyz|Macro Delta xyz}}: Gives the Delta values and the distance between 2 points.
-
-<!--T:240-->
-* {{MacroLink|Icon=Macro_Dump_Objects.png|Macro_Dump_Objects|Macro Dump Objects}}: This macro generates a listing of all objects in the current document - the list can be in a window or on the Report view.
-
-<!--T:241-->
-* {{MacroLink|Icon=Macro_FC_element_selector.png|Macro_FC_element_selector|Macro FC element selector}}: This macro display all elements below cursor same "Macro Mouse over cb" with GUI (elements covered by other elements will also be displayed).
-
-<!--T:242-->
-* {{MacroLink|Icon=FCInfo.png|Macro_FCInfo|Macro FCInfo}}: Gives a series of information about the selected shape and can display a conversion of length, inclination (degrees, radian, grade) shape, surface, volume and the weight of the form in the density selected in various international and Anglo-Saxon units.
-
-<!--T:244-->
-* {{MacroLink|Icon=FCInfoToolBar.png|Macro_FCInfo_ToolBar|Macro FCInfo ToolBar}}: Gives a series of information about the selected shape as FCInfo in a mini ToolBar.
-
-<!--T:245-->
-* {{MacroLink|Icon=Macro_FCInfoGlass.png|Macro_FCInfoGlass|Macro FCInfoGlass}}: Gives a series of information about the selected shape and displayed in screen 3D.
-
-<!--T:246-->
-* {{MacroLink|Icon=FCInfoToMouse.png|Macro_FCInfoToMouse|Macro FCInfoToMouse}}: Provides informations coordinates, length and angles in real time on the mouse in a bubble annotation displayed in the 3D screen.
-
-<!--T:247-->
-* {{MacroLink|Icon=Macro_FCTreeView.png|Macro_FCTreeView|Macro FCTreeView}}: Macro for list all objects in the project in one list without hierarchy, options sort by name, label, visibility, group, by length option search by name, label... without case sensitive or with case sensitive and select all objects displayed in the macro window.
-
-<!--T:248-->
-* {{MacroLink|Icon=Macro_HighlightCommon.png|Macro_HighlightCommon|Macro HighlightCommon}}: Highlight common parts.
-
-<!--T:249-->
-* {{MacroLink|Icon=HighlightDifference.png|Macro_HighlightDifference|Macro HighlightDifference}}: Compute the difference between two shapes.
-
-<!--T:250-->
-* {{MacroLink|Icon=Macro_MeasureCircle.png|Macro_MeasureCircle|Macro MeasureCircle}}: Compute the radius of a circle by 3 points or a circular edge.
-
-<!--T:251-->
-* {{MacroLink|Icon=Macro_Mouse_over_cb.png|Macro_Mouse_over_cb|Macro Mouse over cb}}: This macro display all elements below cursor (elements covered by other elements will also be displayed).
-
-<!--T:227-->
-* {{MacroLink|Icon=Macro_Normal_Vector.png|Macro_Normal_Vector|Macro Normal Vector}}: Get the normal vector of a preselected face.
-
-<!--T:252-->
-* {{MacroLink|Icon=Macro_ObjectInfo.png|Macro_ObjectInfo|Macro ObjectInfo}}: User-friendly "Info" module created by a FreeCAD user.
-
-<!--T:253-->
-* {{MacroLink|Icon=Macro_SimpleProperties.png|Macro_SimpleProperties|Macro SimpleProperties}}: Display in a concise way basic physical properties of an object (volume, bound box dimensions, ...).
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Draft_VisGroup.svg|32px]] Libraries=== <!--T:113-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:254-->
-* {{MacroLink|Icon=Macro_BOLTS.png|Macro_BOLTS|Macro BOLTS}}: The aim of BOLTS is to build a free and open-source standard parts library for CAD applications.
-
-<!--T:255-->
-* {{MacroLink|Icon=FreeCAD_Doc.png|Macro_PartsLibrary|Macro PartsLibrary}}: Starts the Parts library browser.
-
-<!--T:256-->
-* {{MacroLink|Icon=Macro_screw_maker1_2.png|Macro_screw_maker1_2|Macro screw maker1_2}}: This macro creates a screw with or without thread, according to ISO standards ([https://forum.freecad.org/viewtopic.php?f=22&t=6088#p48519 screw_maker1_6.py.zip with Pyside support]). [https://forum.freecad.org/viewtopic.php?f=22&t=6558&start=30#p95929 (Screw Maker 2.0 - new version!)] 
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Bound-expression.svg|32px]] Mathematical functions=== <!--T:115-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:257-->
-* {{MacroLink|Icon=Macro_3D_Parametric_Curve.png|Macro_3D_Parametric_Curve|Macro 3D Parametric Curve}}: Draw a function described by parametric equations x(t), y(t) and z(t).
-
-<!--T:258-->
-* {{MacroLink|Icon=Macro_Draw_2D_Function.png|Macro_Draw_2D_Function|Macro Draw 2D Function}}: Draws a function described by an equation z=F(x).
-
-<!--T:259-->
-* {{MacroLink|Icon=Macro_Draw_Parametric_2D_Function.png|Macro_Draw_Parametric_2D_Function|Macro Draw Parametric 2D Function}}: Based on the above macro, but for parametric and optionally polar.
-
-<!--T:260-->
-* {{MacroLink|Icon=Parametric_Curve_FP.svg|Macro_Parametric_Curve_FP|Macro Parametric Curve FP}}: Feature Python update of Macro 3D Parametric Curve.
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Part_Primitives.svg|32px]] Object creation=== <!--T:119-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:261-->
-* {{MacroLink|Icon=AeroFoil.png|Macro_AeroFoil|Macro AeroFoil}}: AeroFoil creates airfoil curves and faces using pre-defined models, algebraic functions, and DAT or CSV Files.
-
-<!--T:262-->
-* {{MacroLink|Icon=Macro_Airfoil_Import_&_Scale.png|Macro_Airfoil_Import_&_Scale|Macro Airfoil Import & Scale}}: Imports and scales a .dat airfoil to desired chord length.
-
-<!--T:263-->
-* {{MacroLink|Icon=Part_Prism_Apothem.svg|Macro_Apothem_Based_Prism_GUI|Macro Apothem Based Prism GUI}}: A GUI dialog that creates an Apothem, (inradius) Based Prism from user input.
-
-<!--T:385-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_BSurf_from_grid|Macro BSurf from grid}}: Makes a B-spline surface through a grid of points.
-
-<!--T:264-->
-* {{MacroLink|Icon=Macro_Circle.png|Macro_Circle|Macro Circle}}: Create a circle or arc giving radius, diameter, circumference, area, startangle, endangle, arc, anglecenter, cord, arrow, center (point) on choice (same above without GUI).
-
-<!--T:265-->
-* {{MacroLink|Icon=Macro_CirclePlus.png|Macro_CirclePlus|Macro CirclePlus}}: Create a circle or arc giving radius, diameter, circumference, area, startangle, endangle, arc, anglecenter, cord, arrow, center (point) on choice (same below but with GUI) plus create sector and face.
-
-<!--T:412-->
-* {{MacroLink|Icon=CSV2Objects.png|Macro_CSV2Objects|Macro CSV2Objects}}: Generate large batches of 3D text objects from CSV files, mapped to sketch guide lines.
-
-<!--T:266-->
-* {{MacroLink|Icon=Macro_Cut_Circle.png|Macro_Cut_Circle|Macro Cut Circle}}: Cut a circle or arc and create x arcs, giving the number of cut.
-
-<!--T:267-->
-* {{MacroLink|Icon=Macro_Cut_Line.png|Macro_Cut_Line|Macro Cut Line}}: Cut a line and create x points, giving the number of points, create line or not, create points or not, create bicolor or not on choice.
-
-<!--T:418-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_DXF_to_3D_Converter|Macro DXF to 3D Converter}}: Automated tool to convert DXF profiles into 3D objects by defining a custom length.
-
-<!--T:268-->
-* {{MacroLink|Icon=Cam-groover-icon-32x32.png|Macro_FCCamGroover|Macro FCCamGroover}}: Creates grooved cylinder for cam.
-
-<!--T:269-->
-* {{MacroLink|Icon=FCCircularTextButtom.png|Macro_FCCircularText|Macro FCCircularText}}: This macro create a text around a cylinder.
-
-<!--T:270-->
-* {{MacroLink|Icon=FCHoneycombMakerIcon.png|Macro_FCHoneycombMaker|Macro FCHoneycombMaker}}: Creates parametric honeycomb grid.
-
-<!--T:271-->
-* {{MacroLink|Icon=FCSpring_Helix_Variable.png|Macro_FCSpring_Helix_Variable|Macro FCSpring Helix Variable}}: This macro creates one spring truncate, the troncature is adjustable on the all coil to choice.
-
-<!--T:272-->
-* {{MacroLink|Icon=FCSpring_On_Surface.png|Macro_FCSpring_On_Surface|Macro FCSpring On Surface}}: This macro creates one spring (helix) on the surface of the object (solide).
-
-<!--T:274-->
-* {{MacroLink|Icon=Macro_Geodesic_Dome.svg|Macro_Geodesic_Dome|Macro Geodesic Dome}}: This macro creates a geodesic dome shell.
-
-<!--T:275-->
-* {{MacroLink|Icon=Macro_Guitar_fretboard.png|Macro_Guitar_fretboard|Macro Guitar fretboard}}: Guitar Fretboard Maker.
-
-<!--T:276-->
-* {{MacroLink|Icon=Macro_Guitar_Nut.png|Macro_Guitar_Nut|Macro Guitar Nut}}: Guitar Nut Maker.
-
-<!--T:361-->
-* {{MacroLink|Icon=Macro_Half_turn_stairs.png|Macro_Half_turn_stairs|Macro Half turn stairs}}: Creates a half turn (left/right) stair from a Data-file.
-
-<!--T:362-->
-* {{MacroLink|Icon=Macro_Half_Hull_Model.png|Macro_Half-Hull_Model|Macro Half-Hull Model}}: This macro generates both three dimensional [https://en.wikipedia.org/wiki/Half_hull_model_ship half-hull] and full-hull models from a series of 2D line drawings.
-
-<!--T:277-->
-* {{MacroLink|Icon=Hilbert_curve_icon.png|Macro_HilbertCurve|Macro HilbertCurve}}: Creates an Hilbert curve wire in 2 or 3 dimensions with many iterations.
-
-<!--T:278-->
-* {{MacroLink|Icon=Macro_Honeycomb.svg|Macro_Honeycomb|Macro Honeycomb}}: Creates a feature Python Honeycomb object compatible in and out of PartDesign.
-
-<!--T:279-->
-* {{MacroLink|Icon=ImportAirfoil.svg|Macro_ImportAirfoil|Macro ImportAirfoil}}: Airfoil coordinates import, then scale the airfoil, rotate, translate in the plane, translate along the span, select the plane and the main axis, and turn the geometry into a sketch.
-
-<!--T:280-->
-* {{MacroLink|Icon=Intersection_Icon.svg|Macro_Intersection|Macro Intersection}}: Finds the intersection between 2 or 3 selected edges/faces, works with Datum Planes and Datum Lines also. Creates a parametric feature Python object containing the shape of the intersection.
-
-<!--T:281-->
-* {{MacroLink|Icon=Macro_Line_Length.png|Macro_Line_Length|Macro Line Length}}: Create a line giving coordinate XYZ length and angle to plane X Y.
-
-<!--T:273-->
-* {{MacroLink|Icon=FCCreaLoft.png|Macro_Loft|Macro Loft}}: Create a loft with a list of wire (specially created for [[Macro_Texture|Macro Texture]]).
-
-<!--T:391-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_Place_Image|Macro Place Image}}: Creates an [[Image_CreateImagePlane|ImagePlane]] and aligns it to an existing [[Draft_Rectangle|Draft Rectangle]].
-
-<!--T:400-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_Points_to_Splines|Macro Points to Splines}}: Creates splines from Points object sections.
-
-<!--T:283-->
-* {{MacroLink|Icon=Dodecahedron.svg|Macro_Polyhedrons|Macro Polyhedrons}}: This macro creates parametric polyhedrons (dodecahedron, icosahedron, tetrahedron, ...). Customizable via radius or side.
-
-<!--T:284-->
-* {{MacroLink|Icon=Pyramidicon.svg|Macro_Pyramid|Macro Pyramid}}: This macro creates a parametric pyramid. All parameters are customizable just like with Part Cone.
-
-<!--T:285-->
-* {{MacroLink|Icon=Macro_ReproWire.png|Macro_Repro_Wire|Macro Repro Wire}}: This macro creates a copy of a selected object or sub-object.
-
-<!--T:286-->
-* {{MacroLink|Icon=Macro_Site_From_Contours.png|Macro_Site_From_Contours|Macro Site From Contours}}: Creates an Arch Site from a series of contour lines.
-
-<!--T:287-->
-* {{MacroLink|Icon=Macro_Solid_Sweep.png|Macro_Solid_Sweep|Macro Solid Sweep}}: Creates a solid by sweeping a 2D profile along a trajectory previously selected in the 3D view. The 2D elements can be created through the regular tools in FreeCAD's GUI.
-
-<!--T:367-->
-* {{MacroLink|Icon=Macro_Stairs.png|Macro_Stairs|Macro Stairs}}: Create stair helix, create your stair nosing select and run the macro.
-
-<!--T:288-->
-* {{MacroLink|Icon=Macro_Triangle_AH.png|Macro_Triangle_AH|Macro Triangle AH}}: This macro creates a triangle by giving the head angle and the height of the triangle (the head of the  triangle is positioned to the xyz coordinates 0.0).
-
-<!--T:289-->
-* {{MacroLink|Icon=Macro_WireXYZ.png|Macro_WireXYZ|Macro WireXYZ}}: This macro creates a Wire with the coordinates extracted from a file. The coordinates X Y Z are separated by a space.
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Std_TransformManip.svg|32px]] Object transformation=== <!--T:121-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:401-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_Align_Object_BoundBox_Center|Macro Align Object BoundBox Center}}: Aligns 2 (or more) objects by the center of their bounding boxes.
-
-<!--T:290-->
-* {{MacroLink|Icon=Macro_Align_Object_to_View.png|Macro_Align_Object_to_View|Macro Align Object to View}}: This macro align the selected object to the current View and set the coordinates Placement of the camera.
-
-<!--T:291-->
-* {{MacroLink|Icon=Macro_ArrayCopy.png|Macro_ArrayCopy|Macro ArrayCopy}}: Copies the selected object several times, on an array grid.
-
-<!--T:292-->
-* {{MacroLink|Icon=Bevel.svg|Macro_Bevel|Macro Bevel}}: Bevels selected vertices, creates parametric feature Python object, compatible with all solids (except with round edges) including features in Part Design bodies.
-
-<!--T:293-->
-* {{MacroLink|Icon=Macro_Center_Align_Objects_with_Faces_or_Edges.png|Macro_Center_Align_Objects_with_Faces_or_Edges|Macro Center Align Objects with Faces or Edges}}: This macro covers the following constraints: Concentric constraint among non cylindrical parts; and Constraint on center Faces and/or Edges. It works also with the new Body and App::Part containers, as well as with STEP hierarchy.
-
-<!--T:294-->
-* {{MacroLink|Icon=Macro_CloneConvert‎.png|Macro_CloneConvert‎|Macro CloneConvert}}: Creates a clone of the object and the converted in the chosen position and size (inch, mm, m, µm...). The base object is recognized in mm (FreeCAd base).
-
-<!--T:295-->
-* {{MacroLink|Icon=Macro_Connect_And_Sweep.png|Macro_Connect_And_Sweep|Macro Connect And Sweep}}: This macro easily creates a connection between two objects, an object and a point or between two points or the selected line, wire, edge (the center of the objects are the starting and ending points of the sweep) can be selected form a configurable ellipse polygon circle.
-
-<!--T:414-->
-* {{MacroLink|Icon=Macro_Cut_Object_For_Magnets.png|Macro_Cut_Object_For_Magnets|Macro Cut Object For Magnets}}: This macro makes it easy to slice apart an object and insert round holes of a declared number, width and depth on each side of the cut for magnets (or dowels). This can be useful for various 3D printing applications, etc.
-
-<!--T:394-->
-* {{MacroLink|Icon=Std_AxisCross_example.svg|Macro_Express_Placement|Macro Express Placement}}: Display and quickly edit a selected object's placement coordinates directly or via expressions.
-
-<!--T:296-->
-* {{MacroLink|Icon=Macro_FlattenWire.png|Macro_FlattenWire|Macro FlattenWire}}: Flattens draft wires that are not planar to their median Z coordinate.
-
-<!--T:297-->
-* {{MacroLink|Icon=Macro_FlattenWire3Points.png|Macro_FlattenWire3Points|Macro FlattenWire3Points}}: Flattens draft wires that are not planar to a plane defined by 3 points.
-
-<!--T:298-->
-* {{MacroLink|Icon=Macro_HealArcs.png|Macro_HealArcs|Macro HealArcs}}: Sometimes arcs are transformed into BSplines, for example when scale operations have been applied to them. This macro recreates valid arcs from them. Useful before exporting to dxf.
-
-<!--T:300-->
-* {{MacroLink|Icon=Macro_JointWire.png|Macro_JointWire|Macro JointWire}}: Allows to find and joint all non connected edge to the closest non connected one using a line.
-
-<!--T:383-->
-* [[Image:Text-x-python.png|24px]] [https://github.com/dprojects/Woodworking/blob/master/Tools/x_magicAngle.py Macro magicAngle]: Small GUI for the Draft.rotate function. Allows to rotate panels and even other more complicated objects, like construction profiles.
-
-<!--T:301-->
-* {{MacroLink|Icon=Macro_MatrixTransform.png|Macro_MatrixTransform|Macro MatrixTransform}}: Apply linear space transformations to distort shapes. E.g., non-uniform scaling, shearing, mirroring, axes swapping.
-
-<!--T:302-->
-* {{MacroLink|Icon=Centericon.png|Macro_MoveToOrigin|Macro Move to Origin}}: This macro translates the Placement of an object so that a selected location becomes its new origin.
-
-<!--T:386-->
-* {{MacroLink|Icon=multiCuts.png|Macro_MultiCuts|Macro MultiCuts}}: This macro improves boolean cut hierarchy by automatic labeling and using copies for cut.
-
-<!--T:303-->
-* {{MacroLink|Icon=Macro_Overlap.png|Macro_Overlap|Macro Overlap}}: Boolean operation. Similar to [[Part_Common|Part Common]], but with custom overlap count threshold (parametric).
-
-<!--T:304-->
-* {{MacroLink|Icon=parametric_defeaturing.svg|Macro_Parametric_Defeaturing|Macro Parametric Defeaturing}}: Macro that provides parametric defeaturing inside and outside the [[PartDesign_Workbench|PartDesign Workbench]].
-
-<!--T:305-->
-* {{MacroLink|Icon=Macro_Perpendicular_To_Wire.png|Macro_Perpendicular_To_Wire|Macro Perpendicular To Wire}}: This macro positions an object perpendicularl to a selected wire.
-
-<!--T:306-->
-* {{MacroLink|Icon=Macro_PlacementAbsolufy.png|Macro_PlacementAbsolufy|Macro PlacementAbsolufy}}: Reset Part containers to global origin while maintaining objects absolute position.
-
-<!--T:307-->
-* {{MacroLink|Icon=Macro_Remove_parametric_history.png|Macro_Remove_parametric_history|Macro Remove parametric history}}: Removes all parametric associativity from an object, leaving it as a "dumb" shape.
-
-<!--T:308-->
-* {{MacroLink|Icon=Macro_Rotate_To_Point.png|Macro_Rotate_To_Point|Macro Rotate To Point}}: Macro to rotate an object around the center of its boundbox, its center of mass, or the last clicked point.
-
-<!--T:309-->
-* {{MacroLink|Icon=Part_Section‎.png|Macro_Section|Macro Section}}: Alternative implementation of Part Section tool, more suitable for making sweep paths (parametric).
-
-<!--T:310-->
-* {{MacroLink|Icon=Macro_StraightenObject.png|Macro_StraightenObject|Macro StraightenObject}}: Re-align object(s) with FreeCAD coordinate system according reference face/edge.
-
-<!--T:311-->
-* {{MacroLink|Icon=Macro_SuperWire.png|Macro_SuperWire|Macro SuperWire}}: Forces the creation of a Wire from lines and arcs that don't necessarily touch each other. Use this if normal wire operation fails.
-
-<!--T:312-->
-* {{MacroLink|Icon=Wirefilter.svg|Macro_WireFilter|Macro WireFilter}}: Filter wires from a sketch to only use certain ones, also 2D offsets, scales, rearranges wire order.
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-=== [[File:Part_FaceColors.svg|32px]] Object visibility, view properties and textures === <!--T:313-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:314-->
-* [[Image:Text-x-python.png|24px]] [https://github.com/dprojects/Woodworking/blob/master/Tools/colorManager.py colorManager]: Allows to set face colors for all objects from a spreadsheet. Also you can browse colors for a manually selected face or object and see the effect in the 3D model in real-time.
-
-<!--T:315-->
-* {{MacroLink|Icon=Workbench_Image.svg|Macro_Colorize|Macro Colorize}}: Easily set colors of faces, edges, and vertices, including individual transparency levels.
-
-<!--T:393-->
-* {{MacroLink|Icon=EasyReflectorIcon.svg|Macro_EasyReflector|Macro EasyReflector}}: Easily managed textures with a parametric feature python object that persists between FreeCAD and Document sessions.
-
-<!--T:316-->
-* {{MacroLink|Icon=Macro_HiddenAlls.png|Macro_HiddenAlls|Macro Hidden Alls objects}}: This macro check hidden all object in the document (Visibility=False).
-
-<!--T:317-->
-* {{MacroLink|Icon=FCTexture.png|Macro_Texture|Macro Texture}}: Create a project from a bmp image to create a texture easily.
-
-<!--T:318-->
-* {{MacroLink|Icon=Macro_Texture_Objects.png|Macro_Texture_Objects|Macro Texture Objects}}: This macro allows you to temporarily put a texture image on the selected objects.
-
-<!--T:319-->
-* {{MacroLink|Icon=Macro_Toggle_Drawstyle.png|Macro_Toggle_Drawstyle|Macro Toggle Drawstyle}}: This macro toggles the Drawstyle of the selected object.
-
-<!--T:320-->
-* {{MacroLink|Icon=Macro_Toggle_Drawstyle_Optimized.png|Macro_Toggle_Drawstyle_Optimized|Macro Toggle Drawstyle Optimized}}: This macro toggles the Drawstyle of the selected object (same as Macro Toggle Drawstyle above but optimized for all languages).
-
-<!--T:321-->
-* {{MacroLink|Icon=Macro_SelectVisible.png|Macro_Toggle_Visibility|Macro Toggle Visibility}}: Set of three macro, macro '''1:''' hidden the objects not selected, macro '''2:''' displayed alls objects, macro '''3:''' hidden alls objects.
-
-<!--T:322-->
-* {{MacroLink|Icon=Macro_SelectVisible2.png|Macro_Toggle_Visibility2_1-2|Macro Toggle Visibility2 1-2}}: Set of two macro, macro '''1:Macro_Toggle_Visibility2_1-2''' hidden the objects not selected, macro '''2:Macro_Toggle_Visibility2_2-2''' displayed alls objects, macro with the original visibility.
-
-<!--T:323-->
-* {{MacroLink|Icon=Macro_VisibleAlls2.png|Macro_Toggle_Visibility2_2-2|Macro Toggle Visibility2 2-2}}: Set of two macro, macro '''1:Macro_Toggle_Visibility2_1-2''' hidden the objects not selected, macro '''2:Macro_Toggle_Visibility2_2-2''' displayed alls objects, macro with the original visibility.
-
-<!--T:324-->
-* {{MacroLink|Icon=Macro_VisibleAlls.png|Macro_VisibleAlls|Macro Visible Alls objects}}: This macro check visible all object in the document (Visibility=True).
-
-<!--T:325-->
-* {{MacroLink|Icon=Macro_Visibility_Manager.png|Macro_Visibility_Manager|Macro Visibility Manager}}: Manage visibility of document objects by type or individually.
-
-<!--T:326-->
-* [[Image:Text-x-python.png|24px]] [https://github.com/dprojects/setTextures setTextures]: Allows to permanently store the URL of textures in a FreeCAD project and load stored textures.
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Workbench_PartDesign.svg|32px]] PartDesign Workbench=== <!--T:166-->
-
-</translate>
-<div class = "mw-collapsible-content">
-<translate>
-
-<!--T:167-->
-* {{MacroLink|Icon=Workbench_PartDesign.svg|Macro_PDWrapper|Macro PDWrapper}}: Encapsulates non-PartDesign solids for use in PartDesign Bodies, and more.
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Printerrecipes.svg|32px]] Printer 3D=== <!--T:123-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:327-->
-* {{MacroLink|Icon=Macro_3d_Printer_Slicer.png|Macro_3d_Printer_Slicer|Macro 3d Printer Slicer}}: Exports current design to slicer software or CAM software.
-
-<!--T:328-->
-* {{MacroLink|Icon=Macro_3d_Printer_Slicer_Individual_Parts.svg|Macro_3d_Printer_Slicer_Individual_Parts|Macro 3d Printer Slicer Individual Parts}}: This code, when run, will export the visible bodies at the top level (bodies deeper in the tree will be ignored) of the currently open design to individual STL files, and open them it in the slicing software that you use. This macro will look for Cura as the default but you can change it to any other slicer by changing the SLICERAPP variable in the source code.
-
-<!--T:416-->
-* {{MacroLink|Icon=Macro_3D_Printer_3mf_Workflow.png|Macro_3D_Printer_3mf_Workflow|Macro 3D Printer 3mf Workflow}}: Macro exporting smooth 3MF files and preserving all slicer print settings, with automatic workflow to your preferred slicer. 
-
-<!--T:390-->
-* {{MacroLink|Icon=Macro_3D_Printer_Workflow.png|Macro_3D_Printer_Workflow|Macro 3D Printer Workflow}}: Macro that creates an stl file with perfect rounding, i.e. without visible facets, from selected objects. It also allows to launch programs of your choice. For example to automate the FreeCAD → Slicer → printing workflow.
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Preferences-raytracing.svg|32px]] Raytracing=== <!--T:125-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:126-->
-* {{MacroLink|Icon=Macro_FreeCAD_to_Kerkythea.png|Macro_FreeCAD_to_Kerkythea|Macro FreeCAD to Kerkythea}}: Export from FreeCAD to Kerkythea.
-
-<!--T:387-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_Z_Height_Map|Macro Z Height Map}}: Makes a grayscale heightmap in Z.
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Spreadsheet.svg|32px]] Spreadsheet Workbench=== <!--T:127-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:402-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_Alias_For_Table_For_Object|Macro Alias For Table For Object}}: Automatically creates aliases in a two-dimensional table using the names of the rows and columns.
-
-<!--T:396-->
-* {{MacroLink|Icon=ConstraintToAlias.svg|Macro_ConstraintToAlias|Macro ConstraintToAlias}}: Allows to create a spreadsheet or add an alias to an existing spreadsheet from within the open sketch editor.
-
-<!--T:330-->
-* {{MacroLink|Icon=easy-alias-icon.png|Macro_EasyAlias|Macro EasyAlias}}: Quickly create aliases in FreeCAD Spreadsheet workbench. It uses the labels from one column to create aliases for adjacent cells in the next column to the right, e.g. labels from Column A become aliases for the cells in Column B.
-
-<!--T:331-->
-* {{MacroLink|Icon=Macro_FCSpreadsheet_Extract.png|Macro_FCSpreadSheet_Extract|Macro FCSpreadSheet Extract}}: This macro save the data in a csv file with the formula or in a xml file.
-
-<!--T:397-->
-* {{MacroLink|Icon=FindAliasReferences.png|Macro_FindAliasReferences|Macro FindAliasReferences}}: Find all the expressions in open documents that contain the alias, or if the alias is not defined, then the value in the spreadsheet's selected cell(s).
-
-<!--T:392-->
-* {{MacroLink|Icon=Macro_Sketch_Constraint_From_Spreadsheet.svg|Macro_Sketch_Constraint_From_Spreadsheet|Macro Sketch Constraint From Spreadsheet}}: Quickly add a fully dynamic length constraint to a sketch using a spreadsheet cell alias or address.
-
-<!--T:417-->
-* {{MacroLink|Icon=SpreadsheetDependencyInspector.png|Macro_Spreadsheet_Dependency_Inspector|Macro Spreadsheet Dependency Inspector}}: Displays, for a selection of spreadsheet cells, all dependencies between spreadsheet cells and even between cells and object properties.
-
-<!--T:332-->
-* {{MacroLink|Icon=Macro_SpreadsheetTools.png|Macro_SpreadsheetTools|Macro Spreadsheet Tools}}: This macro helps managing cells inside FreeCAD Spreadsheet workbench.
-
-<!--T:333-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_Spreadsheet2html|Macro Spreadsheet2html}}: Exports a spreadsheet as styled html. Intended as support in transfering data to office suits.
-
-<!--T:334-->
-* [[Image:Text-x-python.png|24px]] [https://github.com/dprojects/sheet2export sheet2export]: Allows to export FreeCAD spreadsheet to file formats (.md, .html, .csv, .json).
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Workbench_TechDraw.svg|32px]] TechDraw Workbench=== <!--T:408-->
-
-</translate>
-<div class = "mw-collapsible-content">
-<translate>
-
-<!--T:409-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_TechDraw_AuxiliaryView|Macro TechDraw AuxiliaryView}}: Adds an auxiliary view to a TechDraw page.
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Arch_Survey.svg|32px]] Utility=== <!--T:129-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:335-->
-* {{MacroLink|Icon=Macro_Arch_Axis_System_Repartition.png|Macro_Arch_Axis_System_Repartition|Macro Arch Axis System Repartition}}: This macro help you to create an Arch Axis System along a line with a set of parameters.
-
-<!--T:398-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_Convert_021|Macro Convert 021}}: Converts a FreeCAD file saved with a post-0.21 version back to 0.21 format.
-
-<!--T:405-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_Download_Classifications|Macro Download Classifications}}: Downloads a package of BIM classification systems (Masterformat, Uniformat, ...) to be used in BIM projects in FreeCAD.
-
-<!--T:336-->
-* {{MacroLink|Icon=Macro_Duplicate_Selection.png|Macro_Duplicate_Selection|Macro Duplicate Selection}}: This macro testing if one selection are duplicate, select the object IN THE 3D VIEW the "ForbiddenCursor" stay if the or one selection is duplicate, the macro stay resident.
-
-<!--T:337-->
-* {{MacroLink|Icon=Macro_Easy_Cutouts_for_Enclosures.png|Macro_Easy_cutouts_for_Enclosure_Design|Macro Easy cutouts for Enclosure Design}}: This macro makes Cutouts for Enclosures in a very handy way.
-
-<!--T:338-->
-* {{MacroLink|Icon=Macro_ExpandTreeItem.png|Macro_ExpandTreeItem|Macro ExpandTreeItem}}: This macro expand selected items in the tree view. If not selection all item are expand/collapse.
-
-<!--T:339-->
-* {{MacroLink|Icon=Macro_findConfigFiles.png|Macro_findConfigFiles|Macro findConfigFiles}}: Finds user config files system.cfg and user.cfg, copies folder location to system clipboard, instructs user on renaming these files in order to reset FreeCAD settings, and opens folder with default file browser.
-
-<!--T:340-->
-* {{MacroLink|Icon=Force_Recompute.png|Macro_ForceRecompute|Macro ForceRecompute}}: Forces manual recompute of model.
-
-<!--T:341-->
-* {{MacroLink|Icon=Macro_If_Selected_Stay_If_Not_Then_Delete.png|Macro_If_Selected_Stay_If_Not_Then_Delete|Macro If Selected Stay If Not Then Delete}}: All object not selected are deleted!
-
-<!--T:342-->
-* {{MacroLink|Macro_ImperialScales|Macro ImperialScales}}: Shows a list of US Imperial Arch scales list with the corresponding factor to apply to TechDraw pages or views.
-
-<!--T:343-->
-* {{MacroLink|Icon=Macro_merge_duplicate_materials.png|Macro_merge_duplicate_materials|Macro merge duplicate materials}}: Merges materials that have the same base name (with different numeral endings like 001, 002,...) into one.
-
-<!--T:384-->
-* {{MacroLink|Icon=Pcbway.png|Macro_PCBWay|Macro PCBWay}}: Sends a selected object to [https://pcbway.com PCBWay] for manufacturing through CNC milling, laser cutting or 3D printing.
-
-<!--T:344-->
-* {{MacroLink|Icon=Pinger_Icon.svg|Macro_Pinger|Macro Pinger}}: Ping users on the forum with ease.
-
-<!--T:345-->
-* {{MacroLink|Icon=Macro_Recompute_Profiler.png|Macro_Recompute_Profiler|Macro Recompute Profiler}}: Measures time it takes to recompute each object in a project.
-
-<!--T:403-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_Wiki_Object_Properties_List_Generator|Macro Wiki Object Properties List Generator}}: Generates lists of object properties for use in the FreeCAD Wiki documentation.
-
-<!--T:404-->
-* {{MacroLink|Icon=Applications-python.svg|Macro_Wiki_Object_Properties_List_Generator_Basic_Version|Macro Wiki Object Properties List Generator Basic Version}}: Generates lists of object properties for use in the FreeCAD Wiki documentation.
-
-<!--T:346-->
-* {{MacroLink|Icon=Replace_Part.png|Macro_Replace_Part_in_Assembly|Macro Replace Part in Assembly}}: Replaces a part (simple copy) in an "Assembly" with another Part (simple copy).
-
-<!--T:347-->
-* {{MacroLink|Icon=Macro_Select_Hovering.png|Macro_Select_Hovering|Macro Select Hovering}}: This macro select a choice Face, Edge, Vertex hovering by the mouse.
-
-<!--T:348-->
-* {{MacroLink|Icon=SelectVisible.png|Macro_SelectVisible|Macro SelectVisible}}: All visible objects in the tree will be selected.
-
-<!--T:415-->
-* {{MacroLink|Icon=Macro_server.svg|Macro_Server|Macro Server}}: Allows to remotely set spreadsheet values (even in bulk and recompute when done) and automate exports.
-
-<!--T:349-->
-* {{MacroLink|Icon=Macro_Shake_Sketch.png|Macro_Shake_Sketch|Macro Shake Sketch}}: Shake a sketch in order to discover its unconstrained parts.
-
-<!--T:350-->
-* {{MacroLink|Icon=SketchUnmap.svg|Macro_SketchUnmap|Macro SketchUnmap}}: Unmap a sketch from its current support and makes its placement absolute, eventually creating a locating datum plane.
-
-<!--T:351-->
-* {{MacroLink|Macro_TreeToAscii|Macro TreeToAscii}}: Prints model tree as "ASCII art" with custom pattern & style, and export to clipboard, file or embedded document.
-
-<!--T:352-->
-* {{MacroLink|Icon=Macro_Unbind_Numpad_Shortcuts.png|Macro_Unbind_Numpad_Shortcuts|Macro Unbind Numpad Shortcuts}}: Rebinds standard view commands from digit keys to Ctrl+digit, so that they don't spin the view by accident when entering numbers.
-
-<!--T:353-->
-* {{MacroLink|Icon=WF_wf.png|Macro_WorkFeatures|Macro WorkFeatures}}: Tool utility to create points, axes, planes and many other useful features to facilitate the creation of your project.
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-===[[File:Bulb.svg|32px]] Wizards=== <!--T:131-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:355-->
-* {{MacroLink|Icon=Gearworkbech.png|Macro_FCGear|Macro FCGear}}: Additional Workbench to create different types of gears, involute gear, involute rack, cycloide gear, bevel gear.
-
-<!--T:356-->
-* {{MacroLink|Icon=Macro_Fonts_Win10_PYMP.png|Macro_Fonts_Win10_PYMP|Macro Fonts Win10 PYMP}}: This little macro is dedicate to users of Windows 10. The explorer fonts for use the [[Draft_ShapeString|ShapeString]] is empty and this little macro can help you see easily the font to use.
-
-<!--T:357-->
-* {{MacroLink|Icon=GenerateDrawing.svg|Macro_GenerateDrawing|Macro GenerateDrawing}}: Macro for automatic drawing generation with 3 normal projections and one isometric.
-
-<!--T:358-->
-* {{MacroLink|Icon=GenerateViews.svg|Macro_GenerateViews|Macro GenerateViews}}: Macro for automatic 2D views generation with 6 normal projections and one isometric.
-
-<!--T:359-->
-* {{MacroLink|Icon=GW_Dim.png|Macro_Geneva_Wheel|Macro Geneva Wheel}}: Allows the user to create a Geneva wheel mechanism from scratch. Must edit values within the Macro to alter the size of the object.
-
-<!--T:360-->
-* {{MacroLink|Icon=GW_Dim.png|Macro_Geneva_Wheel_GUI|Macro Geneva Wheel GUI}}: A GUI front end that allows the user to create a Geneva wheel mechanism from scratch.
-
-<!--T:410-->
-* {{MacroLink|Macro_Heat_Flow_Convection_Conduction|Macro Heat Flow Convection Conduction}}: Calculates the heat flow rate in one direction due to convection and (or) conduction (when the phenomenon does not change with time). It also calculates the temperatures between the layers of the materials (e.g. in case of a double-glazed window or an insulated wall etc.).
-
-<!--T:363-->
-* {{MacroLink|Icon=Macro_Megaminx.png|Macro_Megaminx|Macro Megaminx}}: Display a Megaminx and interactively do slice rotations.
-
-<!--T:364-->
-* {{MacroLink|Icon=PropertyMemo.png|Macro_PropertyMemo|Macro PropertyMemo}}: This macro creates an additional Property (memo or other text) for your object (works only with Draft objects).
-
-<!--T:365-->
-* {{MacroLink|Icon=Macro_Rubik_Cube.png|Macro_Rubik_Cube|Macro Rubik Cube}}: Display a Rubik Cube and interactively do slice rotations.
-
-<!--T:366-->
-* {{MacroLink|Icon=Macro_Sheet_Metal_Unfolder.png|Macro_Sheet_Metal_Unfolder|Macro Sheet Metal Unfolder}}: Creates an unfolded part from a sheet-metal-part.
-
-<!--T:368-->
-* {{MacroLink|Icon=Macro_Unfold_Box.png|Macro_Unfold_Box|Macro Unfold Box}}: Allows to unfold the surfaces of a box of any shape and to draw them on a page.
-
-<!--T:369-->
-* {{MacroLink|Icon=Macro_Unroll_Ruled_Surface.png|Macro_Unroll_Ruled_Surface|Macro Unroll Ruled Surface}}: Allows to unroll ruled surfaces and to draw them on a page.
-
-<!--T:411-->
-* {{MacroLink|Icon=Code_Colors_Resistance.png|Macro_Code_Colors_Resistance|Macro Code Colors Resistance}}: Create the resistance, give the value or the color code, you can also calculate the total value with a serial or parallel resistance.
-
-</translate>
-</div>
-</div>
-<div class="toccolours mw-collapsible mw-collapsed">
-<translate>
-
-=== [[File:Arch_Equipment.svg|32px]] Woodworking === <!--T:168-->
-
-</translate>
-<div class="mw-collapsible-content">
-<translate>
-
-<!--T:370-->
-* [[Image:Text-x-python.png|24px]] [https://github.com/dprojects/getDimensions getDimensions]: FreeCAD macro to get chipboards dimensions to cut (BOM, cutlist).
-
-<!--T:371-->
-* {{MacroLink|Icon=Macro_Cabinets32.png|Macro_Cabinets32|Macro Cabinets32}}: Creates side and top/bottom walls for a cabinet with drilled holes for connection parts of manufacturer Hettich.
-
-<!--T:372-->
-* {{MacroLink|Icon=Macro_Joint_Icon.svg|Macro_Joint|Macro Joint}}: Creates a variety of joints, such as mortise/tenon, box joints, dovetail joints, and snap joints.
-
-<!--T:373-->
-* [[Image:Text-x-python.png|24px]] [https://github.com/dprojects/Woodworking/blob/master/Tools/makeTransparent.py makeTransparent]: Switches all parts from non-transparent to transparent, and back, allowing you to preview pilot holes, countersinks and other joints.
-
-</translate>
-</div>
-</div>
-<translate>
-
-==Usage== <!--T:135-->
-
-<!--T:159-->
-See [[how to install macros|how to install macros]] for a full description, and [[Customize Toolbars|customize toolbars]] to add the macros to a toolbar for easy access.
-
-<!--T:160-->
-Installing many macros is equivalent to installing a new workbench; see [[How to install additional workbenches|how to install additional workbenches]] for this information.
-
-=== Automatic installation === <!--T:162-->
-
-<!--T:161-->
-Use the [[Std_AddonMgr|Addon Manager]] in {{MenuCommand|Tools → Addon manager}} to install a macro that has been included in the [https://github.com/FreeCAD/FreeCAD-macros FreeCAD-macros] repository. {{Version|0.17}} 
-
-=== Manual installation === <!--T:163-->
-
-<!--T:136-->
-If the [[Std_AddonMgr|Addon Manager]] is not used, the macro can be installed manually.
-* Copy the [[Python|Python]] code from the corresponding macro page.
-* Open the macros menu {{MenuCommand|Macro → Macros}}, press {{Button|Create}}, and give it a name.
-* Paste the Python code that you copied.
-* Press the {{Button|Save}} button, and restart FreeCAD.
-* To use it, open again the macros menu, select your new macro, and press {{Button|Execute}}.
-
-=== Add a macro to a custom toolbar === <!--T:164-->
-
-<!--T:137-->
-* Go to {{MenuCommand|Tools → Customize}}.
-* In the {{MenuCommand|Macros}} tab, add a new macro name, and optionally define an icon and a keyboard shortcut.
-* In the {{MenuCommand|Toolbars}} tab, create a new toolbar, and add your macro, taking it from the {{MenuCommand|Macros}} category.
-
-
-</translate>
-[[Category:Macros{{#translation:}}]]
-[[Category:Python Code{{#translation:}}]]


### PR DESCRIPTION
## What
Updates the Developer Hub page with current, maintained resources.

## Changes
- Added **Getting Started** section linking to Developers Handbook and Addon Academy
- Added **API Documentation** section with Lens Docs and SourceDoc links
- Added **External Resources** section aggregating all FreeCAD developer repos
- Removed outdated references

## Sources
- https://freecad.github.io/DevelopersHandbook/
- https://github.com/FreeCAD/Addon-Academy
- https://github.com/FreeCAD/SourceDoc
- https://github.com/FreeCAD/lens-docs
