### PR TITLE
doc: Index missing macros in recipes

### DIFF
--- a/wiki/Macros_recipes.wikitext
+++ b/wiki/Macros_recipes.wikitext
@@ -253,7 +253,7 @@ If you have written a macro and want to include it in one of the categories on t
 * {{MacroLink|Icon=Macro_Ellipse-Center%2B2Points.png|Macro_Ellipse-Center+2Points|Macro Ellipse-Center+2Points}}: Makes an ellipse by selecting three points (in this order): center, major radius and minor radius.
 
 <!--T:219-->
-* {{MacroLink|Icon=Macro_FCConvertLines.png|Macro_FCConvertLines|Macro FC Convert Lines}}: This macro convert the object line, wire in line Dash, DashDot, DashDotDot, ZigZag and Hand with the dimensions given.
+* {{MacroLink|Icon=Macro_FC_Convert_Lines.png|Macro_FC_Convert_Lines|Macro FC Convert Lines}}: This macro convert the object line, wire in line Dash, DashDot, DashDotDot, ZigZag and Hand with the dimensions given.
 
 <!--T:220-->
 * {{MacroLink|Icon=Macro_Make_Arc_3_Points.png|Macro_Make_Arc_3_Points|Macro Make Arc 3 Points}}: Creates a arc from 3 selected points.
@@ -278,6 +278,8 @@ If you have written a macro and want to include it in one of the categories on t
 
 <!--T:228-->
 * {{MacroLink|Icon=Text-x-python.png|Macro_export_transient_FEM_results|Macro export transient FEM results}}: This macro exports multiple FEM result objects from a transient analysis to the VTK format and generates a PVU file which can be used to load the results directly into ParaView for post-processing.
+
+* {{MacroLink|Icon=Macro_GMSH.png|Macro_GMSH|Macro GMSH}}: Simple macro to create FEM Meshes by the Mesh Generator GMSH. It is possible to create linear or bilinear (quadratic) like Beam, Shell and Volume elements.
 
 </translate>
 </div>
@@ -534,11 +536,15 @@ If you have written a macro and want to include it in one of the categories on t
 <!--T:367-->
 * {{MacroLink|Icon=Macro_Stairs.png|Macro_Stairs|Macro Stairs}}: Create stair helix, create your stair nosing select and run the macro.
 
+* {{MacroLink|Icon=TimingGear_icon.png|Macro_TimingGear|Macro TimingGear}}: Creates GT2/GT3/GT5 timing gears to be used with timing belts.
+
 <!--T:288-->
 * {{MacroLink|Icon=Macro_Triangle_AH.png|Macro_Triangle_AH|Macro Triangle AH}}: This macro creates a triangle by giving the head angle and the height of the triangle (the head of the  triangle is positioned to the xyz coordinates 0.0).
 
 <!--T:289-->
 * {{MacroLink|Icon=Macro_WireXYZ.png|Macro_WireXYZ|Macro WireXYZ}}: This macro creates a Wire with the coordinates extracted from a file. The coordinates X Y Z are separated by a space.
+
+* {{MacroLink|Icon=Text-x-python.png|Macro_Wiring_And_Hoses|Macro Wiring And Hoses}}: These macros support the creation and maintenance of Wires and Hoses.
 
 </translate>
 </div>
@@ -568,7 +574,7 @@ If you have written a macro and want to include it in one of the categories on t
 * {{MacroLink|Icon=Macro_Center_Align_Objects_with_Faces_or_Edges.png|Macro_Center_Align_Objects_with_Faces_or_Edges|Macro Center Align Objects with Faces or Edges}}: This macro covers the following constraints: Concentric constraint among non cylindrical parts; and Constraint on center Faces and/or Edges. It works also with the new Body and App::Part containers, as well as with STEP hierarchy.
 
 <!--T:294-->
-* {{MacroLink|Icon=Macro_CloneConvert‎.png|Macro_CloneConvert‎|Macro CloneConvert}}: Creates a clone of the object and the converted in the chosen position and size (inch, mm, m, µm...). The base object is recognized in mm (FreeCAd base).
+* {{MacroLink|Icon=Macro_CloneConvert.png|Macro_CloneConvert|Macro CloneConvert}}: Creates a clone of the object and the converted in the chosen position and size (inch, mm, m, µm...). The base object is recognized in mm (FreeCAd base).
 
 <!--T:295-->
 * {{MacroLink|Icon=Macro_Connect_And_Sweep.png|Macro_Connect_And_Sweep|Macro Connect And Sweep}}: This macro easily creates a connection between two objects, an object and a point or between two points or the selected line, wire, edge (the center of the objects are the starting and ending points of the sweep) can be selected form a configurable ellipse polygon circle.
@@ -657,6 +663,8 @@ If you have written a macro and want to include it in one of the categories on t
 <!--T:316-->
 * {{MacroLink|Icon=Macro_HiddenAlls.png|Macro_HiddenAlls|Macro Hidden Alls objects}}: This macro check hidden all object in the document (Visibility=False).
 
+* {{MacroLink|Icon=Image_Scaling.svg|Macro_Image_Scaling|Macro Image Scaling}}: Scaling of drawings, graphics, diagrams, blueprints and similar 2D images in the Image workbench. It works for images imported as planar images in the 3D space.
+
 <!--T:317-->
 * {{MacroLink|Icon=FCTexture.png|Macro_Texture|Macro Texture}}: Create a project from a bmp image to create a texture easily.
 
@@ -739,7 +747,7 @@ If you have written a macro and want to include it in one of the categories on t
 <translate>
 
 <!--T:126-->
-* {{MacroLink|Icon=Macro_FreeCAD_to_Kerkythea.png|Macro_FreeCAD_to_Kerkythea|Macro FreeCAD to Kerkythea}}: Export from FreeCAD to Kerkythea.
+* {{MacroLink|Icon=Macro_Kerkythea.png|Macro_Kerkythea|Macro FreeCAD to Kerkythea}}: Export from FreeCAD to Kerkythea.
 
 <!--T:387-->
 * {{MacroLink|Icon=Applications-python.svg|Macro_Z_Height_Map|Macro Z Height Map}}: Makes a grayscale heightmap in Z.
@@ -801,6 +809,8 @@ If you have written a macro and want to include it in one of the categories on t
 <!--T:409-->
 * {{MacroLink|Icon=Applications-python.svg|Macro_TechDraw_AuxiliaryView|Macro TechDraw AuxiliaryView}}: Adds an auxiliary view to a TechDraw page.
 
+* {{MacroLink|Icon=Applications-python.svg|Macro_TemplateHelper|Macro TemplateHelper}}: Generates a template to use with the TechDraw workbench, adds a new page with a new template object, and can supply a bill of material (BOM).
+
 </translate>
 </div>
 </div>
@@ -816,11 +826,15 @@ If you have written a macro and want to include it in one of the categories on t
 <!--T:335-->
 * {{MacroLink|Icon=Macro_Arch_Axis_System_Repartition.png|Macro_Arch_Axis_System_Repartition|Macro Arch Axis System Repartition}}: This macro help you to create an Arch Axis System along a line with a set of parameters.
 
+* {{MacroLink|Icon=Text-x-python.png|Macro_at_Startup|Automatically run macro at startup}}: Describes how to run macros automatically when FreeCAD starts.
+
 <!--T:398-->
 * {{MacroLink|Icon=Applications-python.svg|Macro_Convert_021|Macro Convert 021}}: Converts a FreeCAD file saved with a post-0.21 version back to 0.21 format.
 
 <!--T:405-->
 * {{MacroLink|Icon=Applications-python.svg|Macro_Download_Classifications|Macro Download Classifications}}: Downloads a package of BIM classification systems (Masterformat, Uniformat, ...) to be used in BIM projects in FreeCAD.
+
+* {{MacroLink|Icon=Text-x-python.png|Macro_documentation|Macro documentation}}: Describes the guidelines for documenting macros so that they can be included in the Addon Manager.
 
 <!--T:336-->
 * {{MacroLink|Icon=Macro_Duplicate_Selection.png|Macro_Duplicate_Selection|Macro Duplicate Selection}}: This macro testing if one selection are duplicate, select the object IN THE 3D VIEW the "ForbiddenCursor" stay if the or one selection is duplicate, the macro stay resident.


### PR DESCRIPTION
### Synchronize & Fix Macros Recipes Index

This PR synchronizes the main `wiki/Macros_recipes.wikitext` index file, fixing broken wiki page references and adding missing macros that exist on the official wiki.

#### Changes:

1. **Fixed Mismatched Wiki Links**:
   - Corrected `Macro_FCConvertLines` -> `Macro_FC_Convert_Lines`.
   - Corrected `Macro_FreeCAD_to_Kerkythea` -> `Macro_Kerkythea`.
   - Cleaned LTR Unicode marks in `Macro_CloneConvert`.

2. **Indexed Existing Macros**:
   - Added missing entries for macro pages that exist on the wiki but were not listed in the recipes list:
     - `Macro_GMSH` (FEM meshing)
     - `Macro_Image_Scaling` (Image sizing)
     - `Macro_TemplateHelper` (TechDraw template utility)
     - `Macro_TimingGear` (GT2/GT3/GT5 gear generator)
     - `Macro_Wiring_And_Hoses` (Wiring utility)
     - `Macro_at_Startup` (Startup execution guide)
     - `Macro_documentation` (Documentation guide)