### PR TITLE
Bounty #29: Tutorial Updates - Update Basic Part Design and Basic Sketcher tutorials for FreeCAD 1.x

### DIFF
--- a/wiki/Basic_Part_Design_Tutorial.wikitext
+++ b/wiki/Basic_Part_Design_Tutorial.wikitext
@@ -7,8 +7,9 @@
 |Level=Beginner
 |Author=Mark Stephen ([[User:Quick61|Quick61]]) and HarryGeier ([[User:HarryGeier|HarryGeier]])
 |Time=Less than an hour
-|FCVersion=0.17 or higher|Files=[https://github.com/FreeCAD/Examples/blob/master/Basic_Part_Design_Tutorial_Example_017_Files/Basic_Part_Design_Tutorial_017.fcstd Basic Part Design for v0.17]
-|SeeAlso=[[Basic_Part_Design_Tutorial_019|Basic Part Design Tutorial 019]]
+|FCVersion=1.0 or higher
+|Files=
+|SeeAlso=[[Basic_Part_Design_Tutorial_019|Basic Part Design Tutorial 019 (updated for 0.19+)]]
 }}
 
 <!--T:40-->
@@ -24,6 +25,8 @@ https://youtu.be/geIrH1cOCzc
 
 <!--T:50-->
 (each section has its own split Video below)
+
+{{Emphasis|Note:}} This tutorial was originally written for FreeCAD 0.17. Since then, many improvements have been made. See the [[Basic_Part_Design_Tutorial_019|Basic Part Design Tutorial 019]] for a more up-to-date version of this tutorial. This version has been updated for FreeCAD 1.0 and later, noting relevant UI and workflow changes.
 
 == Before You Begin == <!--T:3-->
 
@@ -71,10 +74,10 @@ Once you click OK, FreeCAD automatically switches to the [[Sketcher Workbench|Sk
 ===Create the sketch=== <!--T:64-->
 
 <!--T:7-->
-Next you will want to use the [[Image:Sketcher_CreatePolyline.svg|24px|link=Sketcher_CreatePolyline]] [[Sketcher_CreatePolyline|Polyline]] tool and make a shape roughly like that in the next image. It does not need to be perfect as the final shape is done with constraints. Once you have the basic shape, we will start applying the constraints. If you had Auto constraints on, some of these constraints will have been applied automatically, if not, do the following. But first make sure that you have exited the Polyline tool by right-clicking or pressing {{KEY|ESC}} twice; the mouse cursor should turn back from a cross-hair to the standard arrow cursor. Don't press {{KEY|ESC}} a third time or you will exit edit mode; if this happens, click on the Model tab, then double-click the Sketch element in the tree, or right-click and select '''Edit sketch''' in the context menu. To avoid leaving edit mode when pressing {{KEY|Esc}} too often, change the '''Esc can leave sketch edit mode''' preference ({{Version|0.19}}), see [[Sketcher_Preferences#General|Sketcher Preferences]].
+Next you will want to use the [[Image:Sketcher_CreatePolyline.svg|24px|link=Sketcher_CreatePolyline]] [[Sketcher_CreatePolyline|Polyline]] tool and make a shape roughly like that in the next image. It does not need to be perfect as the final shape is done with constraints. Once you have the basic shape, we will start applying the constraints. If you had Auto constraints on, some of these constraints will have been applied automatically, if not, do the following. But first make sure that you have exited the Polyline tool by right-clicking or pressing {{KEY|ESC}} twice; the mouse cursor should turn back from a cross-hair to the standard arrow cursor. Don't press {{KEY|ESC}} a third time or you will exit edit mode; if this happens, click on the Model tab, then double-click the Sketch element in the tree, or right-click and select '''Edit sketch''' in the context menu. To avoid leaving edit mode when pressing {{KEY|Esc}} too often, you can change the '''Esc can leave sketch edit mode''' preference in [[Sketcher_Preferences#General|Sketcher Preferences]].
 
 <!--T:68-->
-''NOTE: Since this tutorial was written there have been improvements to the sketcher solver, if it detects a redundant constraint it will turn the sketch orange in colour, and before further constraints are added, the redundant constraint should be removed. (The redundant constraint is shown in the Task view, click on the blue reference and press delete.)''
+''NOTE: The sketcher solver will detect redundant constraints and turn the sketch orange in color. Before further constraints are added, the redundant constraint should be removed. (The redundant constraint is shown in the Task view, click on the blue reference and press delete.)''
 
 <!--T:8-->
 # Select the two horizontal lines with your mouse by clicking on them, and once selected, click on the [[File:Sketcher ConstrainHorizontal.svg|24px|link=Sketcher_ConstrainHorizontal]] [[Sketcher_ConstrainHorizontal|horizontal constraint]].
@@ -133,7 +136,7 @@ After the face is selected, click on the New sketch icon in the toolbar or from 
 Once that is done, click the Close button at the top of the Tasks tab in the Combo View window, then select [[File:PartDesign_Pocket.svg|24px|link=PartDesign_Pocket]] [[PartDesign_Pocket|Pocket]] tool from the toolbar or Part Design menu. Using this tool is the opposite of the Pad tool. As the Pad tool adds material to the part, the Pocket tool removes material from the part. Both operations are called features. In this Pocket operation we want to select Through all from the type pulldown-menu and then click the OK button.
 
 <!--T:16-->
-For the next operation, make sure that “Pocket” is selected in the Model tree view and once done, click on the [[File:PartDesign_Mirrored.svg|24px|link=PartDesign_Mirrored]] [[PartDesign_Mirrored|Mirror]] feature on the toolbar or from the Part Design menu. In the Mirror dialog in the Combo View, select Horizontal sketch axis from the Plane pulldown menu. Then click OK. The Mirror feature works in this way because the base feature of our model was Padded both ways from the horizontal plane in the first operation with the base sketch. If all has gone well, you should now have a part that looks like the image below after you orbit it around to the front.
+For the next operation, make sure that "Pocket" is selected in the Model tree view and once done, click on the [[File:PartDesign_Mirrored.svg|24px|link=PartDesign_Mirrored]] [[PartDesign_Mirrored|Mirror]] feature on the toolbar or from the Part Design menu. In the Mirror dialog in the Combo View, select Horizontal sketch axis from the Plane pulldown menu. Then click OK. The Mirror feature works in this way because the base feature of our model was Padded both ways from the horizontal plane in the first operation with the base sketch. If all has gone well, you should now have a part that looks like the image below after you orbit it around to the front.
 
 </translate>
 [[Image:tut17_profilewithslots.png|center]]
@@ -274,7 +277,9 @@ For the final step in this tutorial, close the sketcher window using close or fi
 <translate>
 
 <!--T:55-->
-At this point, you will see some lines which come from intersecting features. In this case the ''side block'' intersects with the ''base profile'' letting it appear as a triangular block above the profile (i.e., there is an extra line visible in the above picture on the right face of the model). To remove these lines, you can either switch on "refine shape" in your Part Design Settings or, to save some processing speed and still have these lines while constructing, individually switch it on at each feature. The Setting on feature level can be done in the "data" tab of the feature. Set the [[Property editor#Data|'''''refine'' property''']] to TRUE for the pocket feature Pocket001 to invoke refining.
+At this point, you will see some lines which come from intersecting features. In this case the ''side block'' intersects with the ''base profile'' letting it appear as a triangular block above the profile (i.e., there is an extra line visible in the above picture on the right face of the model). 
+
+{{Emphasis|Note:}} In FreeCAD 1.0 and later, the '''refine''' option is enabled by default in Part Design preferences (''Preferences → Part Design → Shape view → Refine model''). This means intersecting lines will automatically be cleaned up as you work. If you are using an older FreeCAD version, you can enable refine per-feature by setting the [[Property editor#Data|'''''refine'' property''']] to TRUE for the Pocket feature (Pocket001) in the Data tab of the Property editor.
 
 </translate>
 [[Image:Tut17_refine.png|center]]
@@ -291,7 +296,8 @@ This tutorial and your model are complete.
 == Additional Resources == <!--T:37-->
 
 <!--T:54-->
-*FreeCAD file for comparison (made with 0.17) [https://github.com/FreeCAD/Examples/blob/master/Basic_Part_Design_Tutorial_Example_017_Files/Basic_Part_Design_Tutorial_017.fcstd Download]
+* FreeCAD file for comparison (made with 0.17) [https://github.com/FreeCAD/Examples/blob/master/Basic_Part_Design_Tutorial_Example_017_Files/Basic_Part_Design_Tutorial_017.fcstd Download]
+* Updated version of this tutorial: [[Basic_Part_Design_Tutorial_019|Basic Part Design Tutorial 019 (for FreeCAD 0.19 and later)]]
 </translate>
 
 

--- a/wiki/Basic_Part_Design_Tutorial.wikitext
+++ b/wiki/Basic_Part_Design_Tutorial.wikitext
@@ -1,7 +1,3 @@
-<languages/>
-<translate>
-
-<!--T:1-->
 {{TutorialInfo
 |Topic=Modeling
 |Level=Beginner
@@ -12,74 +8,49 @@
 |SeeAlso=[[Basic_Part_Design_Tutorial_019|Basic Part Design Tutorial 019 (updated for 0.19+)]]
 }}
 
-<!--T:40-->
 This tutorial introduces the new user to some of the tools and techniques used in the [[PartDesign_Workbench|PartDesign Workbench]]. This tutorial is not a complete and comprehensive guide to the Part Design Workbench and many of the tools and capabilities are not covered. This tutorial will take user through the steps needed to model the part shown in the image below using sketches.
 
-</translate>
 [[Image:Tut17_final_refined.png]]
-<translate>
 
-<!--T:49-->
 A video of the whole construction is here:
 https://youtu.be/geIrH1cOCzc
 
-<!--T:50-->
 (each section has its own split Video below)
 
 {{Emphasis|Note:}} This tutorial was originally written for FreeCAD 0.17. Since then, many improvements have been made. See the [[Basic_Part_Design_Tutorial_019|Basic Part Design Tutorial 019]] for a more up-to-date version of this tutorial. This version has been updated for FreeCAD 1.0 and later, noting relevant UI and workflow changes.
 
-== Before You Begin == <!--T:3-->
-
-== The Task == <!--T:60-->
-
-<!--T:4-->
+== Before You Begin == 
+== The Task == 
 In this tutorial, you will be using the Part Design Workbench to create a 3D solid model of the part shown in the [[TechDraw_Workbench|Drawing]] below. All of the necessary dimensions to complete this task are given. You will start by creating a core shape from a base Sketch and then build on that shape, adding what is known as Features. These features will either add material to, or remove material from the solid by use of additional sketches and accompanying feature operations. This Tutorial will not use every feature and tool available within the Part Design Workbench, but should use enough to give the user of this tutorial a basic foundation upon which to build their knowledge and skills.
 
-== The Part == <!--T:5-->
+== The Part == 
 
-</translate>
 [[Image:Tutorial_Drawing_Sheet.png]]
-<translate>
 
-== Constructing The Part == <!--T:61-->
-
-===Startup=== <!--T:62-->
-
-<!--T:6-->
+== Constructing The Part == 
+===Startup=== 
 First begin by making sure you are in the Part Design Workbench. Once there, you will want to create a new document if you have not done so already. It is a good habit to save your work often, so before anything else save the new document, giving it any name you might like.
 
-<!--T:51-->
 All work in Part Design begins with a [[Glossary#Body|Body]]. Then we will build the solid inside the body by starting with a [[Glossary#Sketch|sketch]].
 
-<!--T:63-->
 # Click on [[Image:PartDesign_Body.svg|24px|link=PartDesign_Body]] [[PartDesign_Body|Create new body]] to create and activate a new Body Container. ''Note: this step can be omitted. When creating a sketch, if no existing Body is found, a new one will be automatically created and activated.''
 # Click on [[Image:PartDesign_NewSketch.svg|24px|link=PartDesign_NewSketch]] [[PartDesign_NewSketch|Create new sketch]]. This will create the sketch within the just created body.
 # We need to define where the sketch will be attached. We will attach it to a plane from the Body´s [[Glossary#Origin|Origin]].
 # In the [[Task_panel|Tasks tab]] from the [[Combo_view|Combo view]], select '''YZ_Plane''' in the list and press {{KEY|OK}}:
 
-</translate>
 [[Image:Tut17_sketchplanes.png|center|250px]]
-<translate>
 
-<!--T:56-->
 ''Note: it's possible that the {{Button|OK}} button may not be visible if the side panel is not wide enough. You can make it wider by dragging its right border. Place your mouse pointer over the border; when the pointer changes to a two-way arrow, press and hold the left mouse button and drag.''
 
-<!--T:57-->
 Once you click OK, FreeCAD automatically switches to the [[Sketcher Workbench|Sketcher workbench]] and opens the sketch in edit mode:
 
-</translate>
 [[Image:Tut17_sketcherempty.png|center]]
-<translate>
 
-===Create the sketch=== <!--T:64-->
-
-<!--T:7-->
+===Create the sketch=== 
 Next you will want to use the [[Image:Sketcher_CreatePolyline.svg|24px|link=Sketcher_CreatePolyline]] [[Sketcher_CreatePolyline|Polyline]] tool and make a shape roughly like that in the next image. It does not need to be perfect as the final shape is done with constraints. Once you have the basic shape, we will start applying the constraints. If you had Auto constraints on, some of these constraints will have been applied automatically, if not, do the following. But first make sure that you have exited the Polyline tool by right-clicking or pressing {{KEY|ESC}} twice; the mouse cursor should turn back from a cross-hair to the standard arrow cursor. Don't press {{KEY|ESC}} a third time or you will exit edit mode; if this happens, click on the Model tab, then double-click the Sketch element in the tree, or right-click and select '''Edit sketch''' in the context menu. To avoid leaving edit mode when pressing {{KEY|Esc}} too often, you can change the '''Esc can leave sketch edit mode''' preference in [[Sketcher_Preferences#General|Sketcher Preferences]].
 
-<!--T:68-->
 ''NOTE: The sketcher solver will detect redundant constraints and turn the sketch orange in color. Before further constraints are added, the redundant constraint should be removed. (The redundant constraint is shown in the Task view, click on the blue reference and press delete.)''
 
-<!--T:8-->
 # Select the two horizontal lines with your mouse by clicking on them, and once selected, click on the [[File:Sketcher ConstrainHorizontal.svg|24px|link=Sketcher_ConstrainHorizontal]] [[Sketcher_ConstrainHorizontal|horizontal constraint]].
 # Select the vertical line on the right and then click on the [[File:Sketcher_ConstrainVertical.svg|24px|link=Sketcher_ConstrainVertical]] [[Sketcher_ConstrainVertical|vertical constraint]].
 # Select the start and end points of your polyline and click on the [[File:Sketcher_ConstrainCoincident.svg|24px|link=Sketcher_ConstrainCoincident]] [[Sketcher_ConstrainCoincident|coincident constraint]] to close the polyline.
@@ -88,218 +59,139 @@ Next you will want to use the [[Image:Sketcher_CreatePolyline.svg|24px|link=Sket
 # Select the top horizontal line and apply the horizontal distance constraint and give it a value of 5 mm
 # Select the lower right point (vertex) of the horizontal line Origin and then the center point of the grid and apply the [[File:Sketcher_ConstrainCoincident.svg|24px|link=Sketcher_ConstrainCoincident]] [[Sketcher_ConstrainCoincident|coincident constraint]] to fix your shape.
 
-<!--T:9-->
 At this point you should have a fully constrained sketch as indicated by it changing color and the message shown in the Combo View. It should now look just like the image below.
 
-</translate>
 [[Image:Tut17B profile.png|center]]
-<translate>
 
-<!--T:10-->
 Now in the [[Task_panel|Tasks tab]], click on the {{Button|Close}} button to leave the sketch edit mode and select [[File:PartDesign_Pad.svg|24px|link=PartDesign_Pad]] [[PartDesign_Pad|Pad]] from the toolbar or from the Part Design menu. This will give you a Pad dialog in the Task View. Using that dialog, first using the Type pulldown menu, select Two dimensions. Drawing presented at the beginning of this tutorial says the part is 53 mm long. We do it by Padding our sketch both ways from the center plane to make up that distance i.e. make the pad symmetric in relation of sketch-plane. The reason for is seen later when creating features. For now, given we want it to be 53 mm long in total we will input 26.5 for Length, and 26.5 again for the Second length. Alternatively, you can provide a single length of 53 mm and click the Symmetric to plane check box. Once that is done we now have our base solid upon which we will add additional features to construct our part.
 
-<!--T:41-->
 A video of the steps used in this portion of the tutorial is here:
 https://youtu.be/cUyPnCMeTgg
 
-=== Features with pocket and external geometry === <!--T:65-->
-
-<!--T:11-->
+=== Features with pocket and external geometry === 
 Using the mouse or the view icons turn the model around so you can see its back. Once the back of the part is visible, select the back face by clicking on it as seen in the next image.
 
-</translate>
 [[Image:PD_WB_Tutorial003.png|center]]
-<translate>
 
-<!--T:12-->
 After the face is selected, click on the New sketch icon in the toolbar or from the Part Design menu and that will map our next sketch to the back face of the part. Now select [[File:Sketcher_CreateRectangle.svg|24px|link=Sketcher_CreateRectangle]] [[Sketcher_CreateRectangle|Rectangle]] tool and place a rectangle on the rear face of the part in a similar fashion as shown below. Now following the steps listed, constrain the sketch.
 
-<!--T:13-->
 # Select one of the horizontal lines apply a horizontal distance constraint and a value of 5 mm.
 # Select one of the vertical lines and give it a vertical distance constraint and a value of 11 mm.
 # Select [[File:Sketcher_External.svg|24px|link=Sketcher_External]] [[Sketcher_External|External geometry]] tool
 # Select the upper right vertex of the face and click it so you are provided a point from the external geometry to link our sketch to.
 
-</translate>
 [[Image:tut17_slot_unconstrained.png|center]]
-<translate>
 
-<!--T:58-->
 # Right click to end the External geometry mode
 # Select that point you just made available with the External geometry tool and then select the upper right vertex of the rectangle and click on the [[File:Sketcher_ConstrainCoincident.svg|24px|link=Sketcher_ConstrainCoincident]] [[Sketcher_ConstrainCoincident|Constrain coincident]]. At this point the sketch should be fully constrained and look like the next image.
 
-</translate>
 [[Image:tut17_slote_constrained.png|center]]
-<translate>
 
-<!--T:15-->
 Once that is done, click the Close button at the top of the Tasks tab in the Combo View window, then select [[File:PartDesign_Pocket.svg|24px|link=PartDesign_Pocket]] [[PartDesign_Pocket|Pocket]] tool from the toolbar or Part Design menu. Using this tool is the opposite of the Pad tool. As the Pad tool adds material to the part, the Pocket tool removes material from the part. Both operations are called features. In this Pocket operation we want to select Through all from the type pulldown-menu and then click the OK button.
 
-<!--T:16-->
 For the next operation, make sure that "Pocket" is selected in the Model tree view and once done, click on the [[File:PartDesign_Mirrored.svg|24px|link=PartDesign_Mirrored]] [[PartDesign_Mirrored|Mirror]] feature on the toolbar or from the Part Design menu. In the Mirror dialog in the Combo View, select Horizontal sketch axis from the Plane pulldown menu. Then click OK. The Mirror feature works in this way because the base feature of our model was Padded both ways from the horizontal plane in the first operation with the base sketch. If all has gone well, you should now have a part that looks like the image below after you orbit it around to the front.
 
-</translate>
 [[Image:tut17_profilewithslots.png|center]]
-<translate>
 
-<!--T:42-->
 A video of the steps used in this portion of the tutorial is here:
 https://youtu.be/wiGXV9G7mrM
 
-=== Features with pad and external geometry === <!--T:66-->
-
-<!--T:17-->
+=== Features with pad and external geometry === 
 After taking a look, orbit back around and once again select the back face of the part and select that face to map the next sketch to.
 
-</translate>
 [[Image:tut17_profilewithslotsrearplane.png|center]]
-<translate>
 
-<!--T:18-->
 Select New sketch and make a new rectangle in the manner similar to what is shown below in the next image. Then proceed to add dimensional constraints to the rectangle.
 
-<!--T:19-->
 # Select a horizontal line and apply a horizontal distance constraint with a value of 16.7.
 # Select a vertical line and apply a vertical distance constraint of 7 mm
 # Using the External geometry tool, select the upper left vertex of the part face.
 
-</translate>
 [[Image:tut17_sidblockunconstrained.png|center]]
-<translate>
 
-<!--T:20-->
 Now selecting the upper left vertex of the rectangle and the external geometry point, click on the coincident constraint to fully constrain the sketch.
 
-</translate>
 [[Image:tut17_sideblockconstraind.png|center]]
-<translate>
 
-<!--T:59-->
 Close the Sketcher.
 
-<!--T:21-->
 Next we will click on the Pad feature and in the Pad dialog in the Combo View we want a length of 26 mm leaving the type as Dimension and then placing a check on the Reversed checkbox. Using the Reversed checkbox will cause the Pad to go into the part instead of away from the part. This operation provides with the following result.
 
-</translate>
 [[Image:tut17_sideblock.png|center]]
-<translate>
 
-<!--T:22-->
 Once again use the Mirror feature to get the second pad. First ensure that created Pad is selected in the tree view, then click on Mirror in the toolbar or select it from the Part Design menu. We will repeat the operation we did for Pocket above and select Horizontal sketch axis from the Plane pulldown menu.
 
-</translate>
 [[Image:tut17_profilewithsideblocks.png|center]]
-<translate>
 
-<!--T:43-->
 A video of the steps used in this portion of the tutorial is here:
 https://youtu.be/Ido1owp8ubc
 
-=== Feature with pocket and external geometry === <!--T:67-->
-
-<!--T:23-->
+=== Feature with pocket and external geometry === 
 At this point orbiting the part around to the front, we can see that our part is now starting to look like the part in the dimensioned drawing at the beginning of this tutorial. Once you have the view of the front, click on the sloped face with your mouse to select the face we will use for the next sketch.
 
-</translate>
 [[Image:tut17_innerplane.png|center]]
-<translate>
 
-<!--T:24-->
 Here we will use the Rectangle tool and place a rectangle in our sketch and once having done so, apply the following constraints.
 
-<!--T:25-->
 # Select a horizontal line and a vertical line, and after both are selected, click on the Equals constraint.
 # Select either a horizontal or vertical line and apply a corresponding horizontal or vertical distance constraint with a value of 17 mm
 # Using the External geometry tool, select the top right vertex as shown in the image below.
 
-</translate>
 [[Image:tut17_rechtangleholeunconstrained.png|center]]
-<translate>
 
-<!--T:26-->
 Now using the dimensions from the drawing, apply the following constraints.
 
-<!--T:27-->
 # Select the external geometry point and the upper right vertex of the now square sketch and apply a horizontal distance constraint of 7 mm
 # Select the external geometry point and the upper right vertex of the now square sketch and apply a vertical distance constraint of 11 mm
 
-<!--T:28-->
 The result should be as follows.
 
-</translate>
 [[Image:tut17_rectangleholeconstrained.png|center]]
-<translate>
 
-<!--T:29-->
 At this point if we were to simply Pocket this sketch, the resulting hole would be perpendicular to the sloped face that it is mapped to, and this is not what we want.
 
-<!--T:52-->
 [[Image:tut17_wrongplaneforpocket.png|center]]
 
-<!--T:53-->
 We want the hole to be perpendicular to the back face, but it's projected dimensions are not the 17 mm x 17 mm dimensions that are given in the  drawing. Now we could do the math and calculate the dimensions needed, or we can use the tools provided in FreeCAD to make that projection for us.
 
-<!--T:44-->
 A video of the steps used in this portion of the tutorial is here:
 https://youtu.be/x4d5nZPWCLQ
 
-<!--T:31-->
 To create pocket which has the sloped rectangle as it´s outlet, we draw a new rectangle on the rear side, using the projection of the sloped rectangle as an external reference.
 Orbit the Solid around to see the rear face of the part once again and select the back face to map the final sketch to.
 
-</translate>
 [[Image:tut17_profilewithsideblocksrearplane.png|center]]
-<translate>
 
-<!--T:32-->
 Select [[Image:PartDesign_NewSketch.svg|24px|link=PartDesign_NewSketch]] [[PartDesign_NewSketch|New Sketch]] from the toolbar or Part Design menu. Now in sketch edit mode, we do not see the sketched rectangle on the slope. To make it selectable , we switch the combo view to model tab and select the last sketch made (Sketch003) on the sloped plane. Then using the spacebar, make it visible. Next, select the mirror feature above (mirrored001) and again using the spacebar, hide it. Then you should see the sloped rectangle inside the 3D View. You may continue to work with the model tab  visible, or switch back to tasks tab. Using the [[File:Sketcher_External.svg|24px|link=Sketcher_External]] [[Sketcher_External|External geometry]] tool, select the upper and lower  horizontal edges of the sloped rectangle. Then, add a new rectangle to the sketch using the [[File:Sketcher_CreateRectangle.svg|24px|link=Sketcher_CreateRectangle]] [[Sketcher_CreateRectangle|Rectangle]] tool.
 
-</translate>
 [[Image:tut17_rectangleunconstrained.png|center]]
-<translate>
 
-<!--T:34-->
 # Select the upper left vertex of the new rectangle and the upper left point of the external geometry and click on the coincident constraint.
 # Click on the lower right vertex of the new rectangle and the lower right point of the external geometry and click on the coincident constraint.
 
-<!--T:35-->
 And we should end up with this.
 
-</translate>
 [[Image:tut17_rectangleconstrained.png|center]]
-<translate>
 
-<!--T:36-->
 For the final step in this tutorial, close the sketcher window using close or finish editing from the context menu of sketch004 and then select the [[File:PartDesign_Pocket.svg|24px|link=PartDesign_Pocket]] [[PartDesign_Pocket|Pocket]] feature from the toolbar or from the Part Design menu. From the Type pulldown select '''Through all''' and click the OK button.
 
-</translate>
 [[Image:Tut17_final.png|center]]
-<translate>
 
-<!--T:55-->
 At this point, you will see some lines which come from intersecting features. In this case the ''side block'' intersects with the ''base profile'' letting it appear as a triangular block above the profile (i.e., there is an extra line visible in the above picture on the right face of the model). 
 
 {{Emphasis|Note:}} In FreeCAD 1.0 and later, the '''refine''' option is enabled by default in Part Design preferences (''Preferences → Part Design → Shape view → Refine model''). This means intersecting lines will automatically be cleaned up as you work. If you are using an older FreeCAD version, you can enable refine per-feature by setting the [[Property editor#Data|'''''refine'' property''']] to TRUE for the Pocket feature (Pocket001) in the Data tab of the Property editor.
 
-</translate>
 [[Image:Tut17_refine.png|center]]
 [[Image:Tut17_final_refined.png|center]]
-<translate>
 
-<!--T:45-->
 A video of these steps of the tutorial is here:
 https://youtu.be/UYI0gvxCYeI
 
-<!--T:47-->
 This tutorial and your model are complete.
 
-== Additional Resources == <!--T:37-->
-
-<!--T:54-->
+== Additional Resources == 
 * FreeCAD file for comparison (made with 0.17) [https://github.com/FreeCAD/Examples/blob/master/Basic_Part_Design_Tutorial_Example_017_Files/Basic_Part_Design_Tutorial_017.fcstd Download]
 * Updated version of this tutorial: [[Basic_Part_Design_Tutorial_019|Basic Part Design Tutorial 019 (for FreeCAD 0.19 and later)]]
-</translate>
-
 
 {{PartDesign Tools navi{{#translation:}}}}
 {{Sketcher Tools navi{{#translation:}}}}

--- a/wiki/Basic_Sketcher_Tutorial.wikitext
+++ b/wiki/Basic_Sketcher_Tutorial.wikitext
@@ -7,14 +7,14 @@
 |Level=Beginner
 |Time=60 minutes
 |Author=[https://freecad.org/wiki/index.php?title=User:Drei Drei] and vocx
-|FCVersion=0.19
-|Files=[https://forum.freecad.org/viewtopic.php?f=36&t=43594 Basic Sketcher tutorial updated]
+|FCVersion=1.0 or higher
+|Files=
 }}
 
 == Introduction == <!--T:2-->
 
 <!--T:33-->
-This tutorial was originally written by Drei, and it was rewritten and illustrated by vocx. 
+This tutorial was originally written by Drei, and it was rewritten and illustrated by vocx.
 
 <!--T:34-->
 This tutorial is meant to introduce the reader to the basic workflow of the [[Image:Workbench_Sketcher.svg|24px]] [[Sketcher Workbench|Sketcher Workbench]].
@@ -51,6 +51,8 @@ Some actions to remember:
 * To exit the sketch edit mode, press the {{Button|Close}} button in the [[task_panel|task panel]], or press {{KEY|Esc}} twice in the keyboard.
 * To enter again edit mode, double click on the sketch in the [[tree_view|tree view]], or select it, and then click on {{Button|[[File:Sketcher_EditSketch.svg|16px]] [[Sketcher_EditSketch|Edit sketch]]}}.
 
+{{Emphasis|Note on FreeCAD 1.x UI changes:}} In FreeCAD 1.0 and later, the [[task_panel|task panel]] is now a standalone widget that can be [[Combo_view#Dock_Task_panel_on_top_of_Combo_view|docked]] on top of the Combo view for a compact layout, or floated as a separate panel. The Sketcher grid can be toggled and configured using the [[Sketcher_Grid|Grid]] tool. The Auto constraints option is now managed via a toolbar button and the [[Sketcher_Preferences|Sketcher Preferences]].
+
 == Create a sketch == <!--T:6-->
 
 <!--T:39-->
@@ -63,10 +65,14 @@ Some actions to remember:
 We are now inside the sketch edit mode. Within it, we're able to make use of the majority of the tools of this workbench.
 
 <!--T:8-->
-{{Emphasis|Note:}} the [[tree_view|tree view]] will switch to the [[task_panel|task panel]]; in this interface expand the {{MenuCommand|Edit controls}} section, and make sure the {{MenuCommand|Auto constraints}} option is enabled. Other options can be changed including the size of the visible grid, and whether we want to snap to it; in this tutorial we will not snap to the grid and we will also hide it. In other sections of the [[task_panel|task panel]] you can also see which geometrical elements and constraints have been defined.
+{{Emphasis|Note:}} the [[tree_view|tree view]] will switch to the [[task_panel|task panel]]. In FreeCAD 0.19 and earlier, the task panel had an ''Edit controls'' section where you could enable ''Auto constraints'' and adjust grid settings. Starting from FreeCAD 0.21, these controls have been reorganized:
+* '''Auto constraints''' is now a toggle button in the Sketcher toolbar ([[File:Sketcher_ConstrainAuto.svg|16px]]). It can also be enabled/disabled in ''Sketcher Preferences → General → Auto constraints''.
+* The '''Grid''' visibility and snap settings are managed via the [[Sketcher_Grid|Grid]] tool in the Sketcher toolbar. The grid auto-rescales with zoom level and its transparency can be set in the preferences.
+* The '''Solver messages''' section shows degrees of freedom, and the '''Constraints''' and '''Elements''' sections list all defined elements.
 
-<!--T:40-->
+</translate>
 [[File:01_Sk01_Sketcher_Task_panel.png|x400px]]
+<translate>
 
 <!--T:41-->
 {{Caption|Upper part of the [[task_panel|task panel]] of the sketcher.}}
@@ -187,7 +193,7 @@ There are two principal types of constraints:
 {{Emphasis|Note:}} as you add constraints, overlay symbols indicating the type of constraint appear over the geometry in the [[3D_view|3D view]]. If these symbols obfuscate your view, you can hide them by unchecking the constraint in the [[task_panel|task panel]]. Also note that the number of degrees of freedom decreases after adding each constraint.
 
 <!--T:60-->
-{{Emphasis|Note 2:}} if you wish to temporarily disable the constraint, you may select it and press {{Button|[[File:Sketcher_ToggleActiveConstraint.svg|16px]] [[Sketcher_ToggleActiveConstraint|Toggle active constraint]]}}. When you want to re-enable it, press the same button again.
+{{Emphasis|Note 2:}} if you wish to temporarily disable a constraint, you may select it and press {{Button|[[File:Sketcher_ToggleActiveConstraint.svg|16px]] [[Sketcher_ToggleActiveConstraint|Toggle active constraint]]}}. When you want to re-enable it, press the same button again.
 
 </translate>
 [[File:05a_Sk01_Sketcher_equality_constraints_lines.png|x400px]] [[File:05b_Sk01_Sketcher_equality_constraints_O-arcs.png|x400px]]
@@ -305,6 +311,20 @@ Constraining a sketch can be done in many different ways. In general, it is reco
 * Or constrain the size of the arcs before making them tangent.
 * Or set the angle of the construction lines before adding more elements.
 * Try using other construction geometry.
+
+=== FreeCAD 1.x additions and changes === <!--T:79-->
+
+The Sketcher Workbench has seen many improvements since FreeCAD 0.19. Key changes relevant to this tutorial include:
+
+* '''Task panel redesign:''' The ''Edit controls'' section was removed in FreeCAD 0.21. Grid and auto-constraint settings are now managed via toolbar buttons and preferences.
+* '''Grid improvements:''' The grid now auto-rescales with zoom level. Grid transparency can be set in preferences. The [[Sketcher_Grid|Grid]] tool toggles visibility.
+* '''On-View Parameters (OVP):''' When creating geometry, dimension values can be entered directly in the 3D view near the cursor. Tab cycles between input fields. ({{VersionMinus|0.22}})
+* '''Selection filters:''' [[Part_SelectFilter|Selection filters]] (vertex, edge, face) make it easier to select specific geometry in dense sketches. ({{VersionMinus|1.0}})
+* '''External geometry:''' Starting from FreeCAD 1.1, the [[Sketcher_Projection|Projection]] and [[Sketcher_Intersection|Intersection]] tools provide more flexible ways to create external geometry, which is now defining (real) by default rather than construction-only.
+* '''Group constraints:''' [[Sketcher_ConstrainGroup|Group constraints]] allow organizing related constraints together. ({{VersionMinus|1.2}})
+* '''Text tool:''' [[Sketcher_CreateText|Text geometry]] can now be created directly in sketches. ({{VersionMinus|1.2}})
+* '''Cancel button:''' A Cancel button in the task panel allows discarding sketch modifications made during the current editing session. ({{VersionMinus|1.2}})
+* '''Refine:''' Part/Part Design refine is enabled by default in FreeCAD 1.0 (''Preferences → Part Design → Shape view → Refine model''), automatically cleaning up intersecting faces.
 
 </translate>
 {{Sketcher Tools navi{{#translation:}}}}

--- a/wiki/Basic_Sketcher_Tutorial.wikitext
+++ b/wiki/Basic_Sketcher_Tutorial.wikitext
@@ -1,7 +1,3 @@
-<languages/>
-<translate>
-
-<!--T:1-->
 {{TutorialInfo
 |Topic=Sketcher
 |Level=Beginner
@@ -11,18 +7,13 @@
 |Files=
 }}
 
-== Introduction == <!--T:2-->
-
-<!--T:33-->
+== Introduction == 
 This tutorial was originally written by Drei, and it was rewritten and illustrated by vocx.
 
-<!--T:34-->
 This tutorial is meant to introduce the reader to the basic workflow of the [[Image:Workbench_Sketcher.svg|24px]] [[Sketcher Workbench|Sketcher Workbench]].
 
-<!--T:3-->
 The [[Sketcher_Workbench|Sketcher Workbench]] exists as a standalone module, so it can be used to draw generic 2D (planar) objects. However, it is mostly used in conjunction with the [[File:Workbench_PartDesign.svg|24px]] [[PartDesign_Workbench|PartDesign Workbench]]. A closed sketch is normally used to create a face or a profile to be extruded into a solid [[PartDesign_Body|body]] with an operation such as {{Button|[[File:PartDesign_Pad.svg|16px]] [[PartDesign_Pad|PartDesign Pad]]}}.
 
-<!--T:35-->
 The reader will practice:
 * Creating construction geometry
 * Creating real geometry
@@ -30,22 +21,16 @@ The reader will practice:
 * Applying datum constraints
 * Obtaining a closed profile
 
-<!--T:36-->
 For a more in depth description of the sketcher, read the [[Sketcher_Lecture|Sketcher Lecture]].
 
-</translate>
 [[File:00_Sk01_Sketcher_fully_constrained_final.png]]
-<translate>
-<!--T:32-->
+
 {{Caption|Final result of the sketch, with all geometry fully constrained, including construction geometry for support.}}
 
-== Setup == <!--T:5-->
-
-<!--T:37-->
+== Setup == 
 1. Open FreeCAD, create a new empty document with {{MenuCommand|File → [[File:Std_New.svg|16px]] [[Std_New|New]]}}.
 :1.1. Switch to the [[Sketcher_Workbench|Sketcher Workbench]] from the [[Std_Workbench|workbench selector]], or the menu {{MenuCommand|[[Std_View_Menu|View]] → Workbench → Sketcher}}.
 
-<!--T:38-->
 Some actions to remember:
 * Press the right mouse button, or press {{KEY|Esc}} in the keyboard once, to deselect the active tool in edit mode.
 * To exit the sketch edit mode, press the {{Button|Close}} button in the [[task_panel|task panel]], or press {{KEY|Esc}} twice in the keyboard.
@@ -53,33 +38,24 @@ Some actions to remember:
 
 {{Emphasis|Note on FreeCAD 1.x UI changes:}} In FreeCAD 1.0 and later, the [[task_panel|task panel]] is now a standalone widget that can be [[Combo_view#Dock_Task_panel_on_top_of_Combo_view|docked]] on top of the Combo view for a compact layout, or floated as a separate panel. The Sketcher grid can be toggled and configured using the [[Sketcher_Grid|Grid]] tool. The Auto constraints option is now managed via a toolbar button and the [[Sketcher_Preferences|Sketcher Preferences]].
 
-== Create a sketch == <!--T:6-->
-
-<!--T:39-->
+== Create a sketch == 
 2. Click on {{Button|[[Image:Sketcher_NewSketch.svg‎‎|16px]] [[Sketcher_NewSketch|New sketch]]}}.
 :2.1. Choose the sketch orientation, that is, one of the base XY, XZ, or YZ planes. Also choose if you want an inverted orientation, and an offset from the base plane.
 :2.2. We will use the default plane and options.
 :2.3. Click {{Button|OK}} to start constructing the sketch.
 
-<!--T:7-->
 We are now inside the sketch edit mode. Within it, we're able to make use of the majority of the tools of this workbench.
 
-<!--T:8-->
 {{Emphasis|Note:}} the [[tree_view|tree view]] will switch to the [[task_panel|task panel]]. In FreeCAD 0.19 and earlier, the task panel had an ''Edit controls'' section where you could enable ''Auto constraints'' and adjust grid settings. Starting from FreeCAD 0.21, these controls have been reorganized:
 * '''Auto constraints''' is now a toggle button in the Sketcher toolbar ([[File:Sketcher_ConstrainAuto.svg|16px]]). It can also be enabled/disabled in ''Sketcher Preferences → General → Auto constraints''.
 * The '''Grid''' visibility and snap settings are managed via the [[Sketcher_Grid|Grid]] tool in the Sketcher toolbar. The grid auto-rescales with zoom level and its transparency can be set in the preferences.
 * The '''Solver messages''' section shows degrees of freedom, and the '''Constraints''' and '''Elements''' sections list all defined elements.
 
-</translate>
 [[File:01_Sk01_Sketcher_Task_panel.png|x400px]]
-<translate>
 
-<!--T:41-->
 {{Caption|Upper part of the [[task_panel|task panel]] of the sketcher.}}
 
-== Construction geometry == <!--T:9-->
-
-<!--T:10-->
+== Construction geometry == 
 3. Construction geometry is used to guide the creation of "real" geometry. Real geometry will be the one shown outside of the sketch edit mode, while construction geometry will only be shown inside the edit mode. Therefore, you can use as much construction geometry as you need to build real shapes.
 :3.1. Click on {{Button|[[Image:Sketcher_ToggleConstruction.svg|16px]] [[Sketcher_ToggleConstruction|Toggle construction]]}}. Now geometrical elements will be drawn in {{MenuCommand|Construction mode}}.
 :3.2. Click on {{Button|[[Image:Sketcher_Line.svg|16px]] [[Sketcher_CreateLine|Create line]]}}.
@@ -88,42 +64,29 @@ We are now inside the sketch edit mode. Within it, we're able to make use of the
 :3.5. Repeat this procedure four more times to place construction lines in a star pattern. Don't worry too much about their size or position, just extend them in the four quadrants.
 :3.6. Now exit construction mode by clicking again on {{Button|[[File:Sketcher_ToggleConstruction.svg|16px]] [[Sketcher_ToggleConstruction|Toggle construction]]}}.
 
-<!--T:42-->
 {{Emphasis|Note:}} up to this point the [[Sketcher_CreateLine|line tool]] is still active. This means we can keep clicking on the [[3D_view|3D view]] to draw as many lines as we want. If we wish to exit this tool, we can press the right mouse button, or press {{KEY|Esc}} in the keyboard once. By doing this the pointer won't create lines any more, it will just be a pointer allowing us to select the objects we just created. In this pointer mode we can pick and drag the endpoints of each line to adjust its placement.
 
-<!--T:43-->
 {{Emphasis|Note 2:}} do not press {{KEY|Esc}} a second time as this will exit the sketch edit mode. If you do this, re-enter the edit mode by double clicking on the sketch in the [[tree_view|tree view]].
 
-<!--T:44-->
 Take a look at the [[task_panel|task panel]] again. The {{MenuCommand|Solver messages}} section already indicates that the sketch is under-constrained, and it mentions the number of {{Emphasis|degrees of freedom}}.
 
-<!--T:45-->
 Look at the {{MenuCommand|Constraints}} and {{MenuCommand|Elements}} sections to see the new listed constraints and lines. Once your sketches have many elements, it may be difficult to select them in the [[3D_view|3D view]], so you can use these lists to select the object that you wish exactly.
 
-</translate>
 [[File:02_Sk01_Sketcher_construction.png|x400px]]
-<translate>
 
-<!--T:46-->
 {{Caption|Construction lines forming a star shape with its center in the origin.}}
 
-== Real geometry == <!--T:11-->
-
-<!--T:12-->
+== Real geometry == 
 Real geometry must make a closed shape if it is to be used as a profile that can be extruded by tools such as {{Button|[[File:PartDesign_Pad.svg|16px]] [[PartDesign_Pad|PartDesign Pad]]}}.
 
-<!--T:78-->
 Make sure you are not in construction mode by clicking on {{Button|[[File:Sketcher_ToggleConstruction.svg|16px]] [[Sketcher_ToggleConstruction|Toggle construction]]}}, if you have not previously exited this mode.
 
-=== Outer arcs === <!--T:47-->
-
-<!--T:48-->
+=== Outer arcs === 
 4. Create a circle.
 :4.1. Click on {{Button|[[File:Sketcher_Circle.svg|16px]] [[Sketcher_CreateCircle|Create circle]]}}.
 :4.2. Click on the '''origin''' of the sketch to position its center point.
 :4.3. Click anywhere in the [[3D_view|3D view]] to set the circumference radius as a distance from the origin. Make it approximately {{Value|8 mm}}. Again the dimension will be fixed later.
 
-<!--T:49-->
 5. Create a series of arcs.
 :5.1. Click on {{Button|[[File:Sketcher_Arc.svg|16px]] [[Sketcher_CreateArc|Create arc]]}}.
 :5.2. Approach the endpoint of one of the construction lines, and click on it. This will set the center point of the circular arc to be [[File:Constraint_PointOnPoint.svg|32px]] [[Sketcher_ConstrainCoincident|coincident]] with this line's endpoint.
@@ -131,114 +94,79 @@ Make sure you are not in construction mode by clicking on {{Button|[[File:Sketch
 :5.4. Move the pointer in an anti-clockwise direction to trace an arc that has its concavity pointing towards the origin of the sketch. Click to set the final endpoint of the arc, defining a circular arc that approximately sweeps {{Value|180°}} or half a circle.
 :5.5. Repeat these steps with each construction line, so that each of them has a circular arc at its tip. We will call these O-arcs for outwards-arcs.
 
-</translate>
 [[File:03_Sk01_Sketcher_outer_arcs.png|x400px]]
-<translate>
 
-<!--T:50-->
 {{Caption|Circular arcs added at the endpoints of the construction lines. Also a central circle.}}
 
-=== Inner arcs === <!--T:51-->
-
-<!--T:13-->
+=== Inner arcs === 
 6. Create an arc between each pair of the previous O-arcs.
 :6.1. Still with the {{Button|[[File:Sketcher_Arc.svg|16px]] [[Sketcher_CreateArc|Create arc]]}} tool active, click somewhere between two O-arcs but further away from the origin of the sketch, to set the center point of a new arc.
 :6.2. Click somewhere close to the endpoint of one O-arc, and move the pointer to sweep another arc finishing close to another endpoint of a different O-arc, as if you were trying to join the endpoints. This time the concavity must point away from the origin.
 :6.3. Repeat these steps, so that each pair of O-arcs has a new arc between them. We will call these I-arcs for inwards-arcs.
 
-<!--T:52-->
 To summarize, the O-arcs should have their curvature pointing outwards, and their concavity pointing towards the origin of the sketch; the I-arcs should have their curvature pointing inwards, and their concavity pointing away from the same origin.
 
-</translate>
 [[File:04_Sk01_Sketcher_inner_arcs.png|x400px]]
-<translate>
 
-<!--T:53-->
 {{Caption|Circular arcs added between the first set of arcs placed.}}
 
-== Constraints == <!--T:54-->
-
-<!--T:55-->
+== Constraints == 
 Take a look at the [[task_panel|task panel]] again. Due to the new geometrical elements that we have drawn, the {{MenuCommand|Solver messages}} section indicates even more {{Emphasis|degrees of freedom}}. A {{Emphasis|degree of freedom}} (DOF) indicates a possible movement of one element. For example, a point can be moved both in horizontal and vertical directions, so it has two degrees of freedom. A line is defined by two points, therefore in total it has four degrees of freedom. If we fix one of those points, then the entire system has only two degrees of freedom available; if we additionally fix the horizontal movement of the remaining point, we only have one degree of freedom left; and if we also fix the vertical movement of this point, then the last degree of freedom disappears, and the line cannot move from its position any more.
 
-<!--T:17-->
 Up to now when we have drawn lines and curves, the sketcher has added automatic constraints for us, those that keep the lines tied to the origin, and the O-arcs tied to the construction lines. But we haven't added other explicit constraints so the geometrical shapes can still be moved in many directions. '''Constraints are "rules" that tell us under which conditions a geometrical object can move and by how much.''' They are used to eliminate the degrees of freedom so that the sketch has a stable shape. If we eliminate all degrees of freedom, then the sketch is {{Emphasis|fully constrained}}, and has a fixed shape, that is, its points cannot move at all. In general, it is a good idea to fully constrain sketches because this will result in stable models.
 
-<!--T:56-->
 There are two principal types of constraints:
 * {{Emphasis|Geometric constraints}} define characteristics of the shapes without specifying exact dimensions, for example, horizontality, verticality, parallelism, perpendicularity, and tangency.
 * {{Emphasis|Datum constraints}} define characteristics of the shapes by specifying dimensions, for example, a numeric length or an angle.
 
-== Geometric constraints == <!--T:18-->
-
-=== Equal length and radius === <!--T:57-->
-
-<!--T:19-->
+== Geometric constraints == 
+=== Equal length and radius === 
 7. Geometrically constrain the lines and arcs.
 :7.1 Select all five construction lines. You only need to click once to select an element.
 :7.2. Press {{Button|[[File:Constraint_EqualLength.svg|16px]] [[Sketcher_ConstrainEqual|Equal length]]}}.
 :{{Emphasis|Note:}} this creates only four constraints. The constraints are chained, the first line has the same length as the second one, which has the same length as the third one, which again has the same length as the fourth one, which has the same length as the fifth one. So in this case, the first and the fifth have the same length.
 
-<!--T:58-->
 :7.3. Select all five O-arcs, those centered on an endpoint of a construction line.
 :7.4. Press {{Button|[[File:Constraint_EqualLength.svg|16px]] [[Sketcher_ConstrainEqual|Equal length]]}}.
 :7.5. Repeat with all I-arcs, those between the O-arcs.
 :{{Emphasis|Note:}} again the constraints are chained. Therefore all O-arcs will have the same radius, and all I-arcs will have the same radius. At this moment, the specific value of these lengths is not fixed. You may use the pointer to drag a point and see how the sketch is updated while respecting the constraints in place.
 
-<!--T:21-->
 :7.6. Select the construction line that is closest to the vertical axis.
 :7.7. Press {{Button|[[File:Constraint_Vertical.svg|16px]] [[‎Sketcher_ConstrainVertical|Vertical]]}} (optional). If you drew the construction line downwards over the Y axis, an automatic [[File:Constraint_PointOnObject.svg|32px]] [[Sketcher_ConstrainPointOnObject|Point on object constraint]] was already placed, keeping the construction line vertical. In this case, no additional [[File:Constraint_Vertical.svg|32px]] [[‎Sketcher_ConstrainVertical|Vertical constraint]] is necessary.
 
-<!--T:59-->
 {{Emphasis|Note:}} as you add constraints, overlay symbols indicating the type of constraint appear over the geometry in the [[3D_view|3D view]]. If these symbols obfuscate your view, you can hide them by unchecking the constraint in the [[task_panel|task panel]]. Also note that the number of degrees of freedom decreases after adding each constraint.
 
-<!--T:60-->
 {{Emphasis|Note 2:}} if you wish to temporarily disable a constraint, you may select it and press {{Button|[[File:Sketcher_ToggleActiveConstraint.svg|16px]] [[Sketcher_ToggleActiveConstraint|Toggle active constraint]]}}. When you want to re-enable it, press the same button again.
 
-</translate>
 [[File:05a_Sk01_Sketcher_equality_constraints_lines.png|x400px]] [[File:05b_Sk01_Sketcher_equality_constraints_O-arcs.png|x400px]]
 
 [[File:05c_Sk01_Sketcher_equality_constraints_I-arcs.png|x400px]]
-<translate>
 
-<!--T:61-->
 {{Caption|Sketch with equality constraints applied to the construction lines, and to the two sets of arcs.}}
 
-=== Tangency === <!--T:62-->
-
-<!--T:22-->
+=== Tangency === 
 8. Apply tangency to the arcs.
 :8.1. Select one endpoint of an O-arc and then the closest endpoint of the adjacent I-arc.
 :8.2. Press {{Button|[[File:Constraint_Tangent.svg|16px]] [[Sketcher_ConstrainTangent|Tangent]]}}. This makes the two adjacent arcs connect smoothly at their endpoints.
 :8.3. Repeat for all endpoints of the O-arcs and I-arcs to obtain a closed profile.
 
-<!--T:63-->
 {{Emphasis|Note:}} applying the tangential constraint very often will move the geometry around in order to produce a smooth connection. You may have to use the pointer to reposition the points a bit before applying the next tangential constraint. Try placing the endpoints in such a way that two arcs aren't too far apart, so they can be connected with a short line rather than a long line.
 
-<!--T:23-->
 As of this step, we have now created a closed profile, as all arcs have been tied together. Now we can provide datum constraints to fix the shape of the sketch. While the dimensions of lines and arcs remain unfixed, we can drag the points of the sketch and observe how the entire sketch changes.
 
-</translate>
 [[File:06_Sk01_Sketcher_tangency_constraints.png|x400px]]
-<translate>
 
-<!--T:64-->
 {{Caption|Sketch with tangential constraints applied to the arcs, which closes the shape.}}
 
-== Datum constraints == <!--T:24-->
-
-<!--T:65-->
+== Datum constraints == 
 These constraints specify the numerical distances between two points, and angles between two lines.
 
-=== Distances and angles === <!--T:66-->
-
-<!--T:25-->
+=== Distances and angles === 
 9. Adjust the size of the construction lines.
 :9.1. Select the vertically constrained construction line.
 :9.2. Press {{Button|[[File:Constraint_VerticalDistance.svg|16px]] [[Sketcher_ConstrainDistanceY|Vertical distance]]}}.
 :9.3. Set the length to {{Value|30 mm}}. Because all construction lines are constrained to have the same length, all these lines adjust their sizes at the same time.
 
-<!--T:26-->
 10. Adjust the angle between the construction lines.
 :10.1. Select the vertical construction line and the construction line closest to it.
 :10.2. Press {{Button|[[File:Constraint_InternalAngle.svg|16px]] [[Sketcher_ConstrainAngle|Angle]]}}.
@@ -246,16 +174,11 @@ These constraints specify the numerical distances between two points, and angles
 :10.4. Repeat the same procedure for each pair of construction lines, and use the same angle.
 :{{Emphasis|Note:}} at this stage, the sketch may have very few degrees of freedom left, meaning that its shape cannot be changed too much. If you attempt to add more constraints, these may cause a conflict with the previously added constraints. If this is the case, do not add these constraints, and proceed with the next steps.
 
-</translate>
 [[File:07a_Sk01_Sketcher_length_constraint.png|x400px]] [[File:07b_Sk01_Sketcher_angle_constraint.png|x400px]]
-<translate>
 
-<!--T:67-->
 {{Caption|Sketch with length constraint applied to one vertical construction line (left), and angle constraints to three pairs of construction lines (right).}}
 
-=== Radius === <!--T:68-->
-
-<!--T:27-->
+=== Radius === 
 11. Adjust the size of the arcs.
 :11.1. Select one of the O-arcs, centered on the endpoint of a construction line.
 :11.2. Press {{Button|[[File:Constraint_Radius.svg|16px]] [[Sketcher_ConstrainRadius|Radius]]}}.
@@ -264,56 +187,39 @@ These constraints specify the numerical distances between two points, and angles
 :11.5. Press {{Button|[[File:Constraint_Radius.svg|16px]] [[Sketcher_ConstrainRadius|Radius]]}}.
 :11.6. Set the radius to {{Value|11 mm}}. Because all I-arcs are constrained to have the same radius, all these arcs adjust their sizes at the same time.
 
-</translate>
 [[File:08a_Sk01_Sketcher_radius_1_constraint.png|x400px]] [[File:08b_Sk01_Sketcher_radius_2_constraint.png|x400px]]
-<translate>
 
-<!--T:69-->
 {{Caption|Sketch with radius constraints applied to the outwards arcs (left), and inwards arcs (right).}}
 
-<!--T:70-->
 :11.7. Finally, select the circle in the center of the sketch, press {{Button|[[File:Constraint_Radius.svg|16px]] [[Sketcher_ConstrainRadius|Radius]]}}, and set the value to {{Value|8 mm}}.
 
-<!--T:28-->
 We should end up with a fully constrained sketch. It can be confirmed by noticing the change in color of the real geometry, and by the message that is shown in the [[task_panel|task panel]].
 
-</translate>
 [[File:09_Sk01_Sketcher_fully_constrained.png|x400px]]
-<translate>
 
-<!--T:71-->
 {{Caption|Sketch with all geometrical and datum constraints applied.}}
 
-== Extrusion == <!--T:72-->
-
-<!--T:73-->
+== Extrusion == 
 12. Now that we have a fully constrained sketch, it can be used to create a solid body.
 :12.1. Exit the sketch edit mode by pressing the {{Button|Close}} button, or pressing {{KEY|Esc}} twice. The sketch should appear in the [[tree_view|tree view]] and the [[3D_view|3D view]].
 :12.2. Switch to the [[PartDesign_Workbench|PartDesign Workbench]].
 :12.3. With the sketch selected in the [[tree_view|tree view]], press {{Button|[[File:PartDesign_Body.svg|16px]] [[PartDesign_Body|PartDesign Body]]}}, choose the default XY-plane, and press {{Button|OK}}. The sketch should appear now inside the Body.
 :12.4. Select the sketch, and then press {{Button|[[File:PartDesign_Pad.svg|16px]] [[PartDesign_Pad|PartDesign Pad]]}}, choose the default options, and press {{Button|OK}} to create a solid extrusion.
 
-</translate>
 [[File:09b_Sk01_Sketcher_fully_constrained_clean.png|x400px]] [[File:10_Sk01_Sketcher_solid_extrusion.png|x400px]] 
-<translate>
 
-<!--T:74-->
 {{Caption|Left: fully constrained sketch with only the most important constraints showing. Right: solid extrusion produced with [[PartDesign_Pad|PartDesign Pad]].}}
 
-== Additional information == <!--T:75-->
-
-<!--T:76-->
+== Additional information == 
 For a more in depth description of the sketcher, visit the [[Sketcher_Workbench|Sketcher Workbench]] documentation and also read the [[Sketcher_Lecture|Sketcher Lecture]].
 
-<!--T:77-->
 Constraining a sketch can be done in many different ways. In general, it is recommended to use geometrical constraints first, and minimize the number of datum constraints, as this simplifies the task of the internal constraint solver. To investigate this, repeat this example, now adding the constraints in different order.
 * First constrain the construction lines before drawing the arcs.
 * Or constrain the size of the arcs before making them tangent.
 * Or set the angle of the construction lines before adding more elements.
 * Try using other construction geometry.
 
-=== FreeCAD 1.x additions and changes === <!--T:79-->
-
+=== FreeCAD 1.x additions and changes === 
 The Sketcher Workbench has seen many improvements since FreeCAD 0.19. Key changes relevant to this tutorial include:
 
 * '''Task panel redesign:''' The ''Edit controls'' section was removed in FreeCAD 0.21. Grid and auto-constraint settings are now managed via toolbar buttons and preferences.
@@ -326,6 +232,5 @@ The Sketcher Workbench has seen many improvements since FreeCAD 0.19. Key change
 * '''Cancel button:''' A Cancel button in the task panel allows discarding sketch modifications made during the current editing session. ({{VersionMinus|1.2}})
 * '''Refine:''' Part/Part Design refine is enabled by default in FreeCAD 1.0 (''Preferences → Part Design → Shape view → Refine model''), automatically cleaning up intersecting faces.
 
-</translate>
 {{Sketcher Tools navi{{#translation:}}}}
 {{Userdocnavi{{#translation:}}}}

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -46,6 +46,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Std_VarSet|VarSet]] ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 * There is now a warning when saving files created in older versions. A preference was added to allow disabling it. [https://github.com/FreeCAD/FreeCAD/pull/28389 Pull request #28389]
 * Clearing the recent files list now asks for confirmation before the list is removed. [https://github.com/FreeCAD/FreeCAD/pull/27274 Pull request #27274]
+* The notification area unread count is now initialized on startup, showing the correct count from the beginning. [https://github.com/FreeCAD/FreeCAD/pull/29391 Pull request #29391]
 
 == Core system and API ==
 
@@ -94,7 +95,9 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * On Unix-like systems, lock files now use owner-only permissions, and Coin image export avoids creating world-writable files. [https://github.com/FreeCAD/FreeCAD/pull/30239 Pull request #30239]
 * The Conda release build preset now enables {{Incode|FREECAD_WARN_ERROR}}, and related warnings were fixed so release CI catches new compiler warnings earlier. [https://github.com/FreeCAD/FreeCAD/pull/30228 Pull request #30228]
 * The [[Image:Std_TransformManip.svg|24px]] [[Std TransformManip|Transform]] tool can now use the ''Center of mass / centroid'' mode with [[App_Link|Links]] and [[Std_Part|Part containers]]. [https://github.com/FreeCAD/FreeCAD/pull/30208 Pull request #30208]
+* The placement of Part origins is now read-only and can no longer be changed by accident. [https://github.com/FreeCAD/FreeCAD/pull/28076 Pull request #28076]
 * Toponaming support was improved for the Python API so that add-ons can be more stable in terms of [[Topological_naming_problem|TNP]]. [https://github.com/FreeCAD/FreeCAD/pull/24632 Pull request #24632]
+* The [[Image:Std_MassProperties.svg|24px]] [[Std_MassProperties|Mass Properties]] view provider now shows icons at the center of gravity and center of volume, making them easier to locate in the 3D view. [https://github.com/FreeCAD/FreeCAD/pull/29288 Pull request #29288]
 
 === API ===
 
@@ -125,6 +128,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Editing sketches from assemblies no longer briefly activates the sketch's source document or crashes when leaving the Assembly context. [https://github.com/FreeCAD/FreeCAD/pull/29271 Pull request #29271]
 * [[Assembly_CreateSimulation|Simulations]] now offer export to video format. [https://github.com/FreeCAD/FreeCAD/pull/25307 Pull request #25307]
 * [[Assembly_CreateView|Exploded View]] can now be created temporarily. [https://github.com/FreeCAD/FreeCAD/pull/25456 Pull request #25456]
+* The [[Assembly_CreateSimulation|Simulation]] playback buttons have been made bigger and more visually distinct. [https://github.com/FreeCAD/FreeCAD/pull/30257 Pull request #30257]
 
 == BIM Workbench ==
 
@@ -132,7 +136,7 @@ ToDo (last check: 20260430, #27222):
 * https://github.com/FreeCAD/FreeCAD/pull/24078
 * https://github.com/FreeCAD/FreeCAD/pull/24190
 * https://github.com/FreeCAD/FreeCAD/pull/27222
-* https://github.com/FreeCAD/FreeCAD/pull/28504
+* [[Arch_Site|Site]] objects now have a dedicated task panel with sections for Location, Shape, Terrain and Metadata, making site editing more user-friendly. [https://github.com/FreeCAD/FreeCAD/pull/28504 Pull request #28504]
 * Removing a wall base now preserves the wall's placement and parametric dimensions for supported straight Draft or Sketch bases, and warns before removing unsupported complex bases. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
 * [[Arch_Wall|Walls]] can now be created without a base object by default, with the selected wall baseline mode remembered in preferences. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]
 * The BIM Project command was removed from the toolbar, moved to the Utils menu, renamed for IFC-project clarity, and the Setup Project dialog now defaults to non-IFC-native projects. [https://github.com/FreeCAD/FreeCAD/pull/25086 Pull request #25086]
@@ -151,6 +155,7 @@ ToDo (last check: 20260430, #27222):
 * [[BIM_DrawingView|DrawingView]] cut lines now use the default line width and cut areas line thickness ratio preferences for thicker cut-line output. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]
 * IFC import now treats a multicore preference value of 0 as disabled before creating the IfcOpenShell geometry iterator, avoiding invalid worker counts when multicore processing is turned off. [https://github.com/FreeCAD/FreeCAD/pull/30201 Pull request #30201]
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
+* The endpoints of walls without a base object can now be edited in [[Draft_Workbench|Draft]], allowing interactive wall reshaping in plan view. [https://github.com/FreeCAD/FreeCAD/pull/29860 Pull request #29860]
 
 == CAM Workbench ==
 
@@ -222,6 +227,10 @@ ToDo (last check: 20260430, #27222):
 * CAM drilling cycle expansion now uses MachineState for more accurate machine state tracking while expanding drilling cycles. [https://github.com/FreeCAD/FreeCAD/pull/30112 Pull request #30112]
 * The [[CAM_Profile|Profile]] and [[CAM_Pocket_Shape|Pocket]] linking options now include collision-avoidance strategies for using retract height, clearance height, line-of-sight checks, tool diameter, or tool shape. [https://github.com/FreeCAD/FreeCAD/pull/29983 Pull request #29983]
 # The Linking generator was added to the [[CAM_Engrave|Engrave]] and [[CAM_Deburr|Deburr]] operations to use the safe height instead of clearance height for linking moves. The Linking Mode and Safety Margin options were added to the task panels, also for [[CAM_Drilling|Drilling]] and [[CAM_Helix|Helix]] operations. [https://github.com/FreeCAD/FreeCAD/pull/29959 Pull request #29959]
+* The [[CAM_LeadInOut|LeadInOut]] dressup now supports ExtendLeadIn and ExtendLeadOut properties for the Arc, Line, Perpendicular and Tangent styles. [https://github.com/FreeCAD/FreeCAD/pull/29061 Pull request #29061]
+* The Spiral generator now validates G-code output with deviation-based testing instead of exact string comparisons. [https://github.com/FreeCAD/FreeCAD/pull/28596 Pull request #28596]
+* A tolerance parameter was added to the Linking generator collision check, making it possible to adjust collision detection sensitivity. [https://github.com/FreeCAD/FreeCAD/pull/28140 Pull request #28140]
+* Several fixes were applied to machine-based postprocessing, improving G-code output for different machine configurations. [https://github.com/FreeCAD/FreeCAD/pull/28563 Pull request #28563]
 
 == Draft Workbench ==
 
@@ -239,6 +248,10 @@ ToDo (last check: 20260430, #29258):
 === Further Draft improvements ===
 
 * [[Draft_Trimex|Trimex]] now reports unsupported sketch selections before opening the task panel, avoiding a misleading no-op workflow. [https://github.com/FreeCAD/FreeCAD/pull/29845 Pull request #29845]
+* Hints were added for the Draft annotation tools (Dimension, Label, ShapeString, etc.), describing available modifiers and keyboard shortcuts in the task panel. [https://github.com/FreeCAD/FreeCAD/pull/29649 Pull request #29649]
+* [[Draft_PolarArray|Polar]] and [[Draft_CircularArray|Circular Array]] now respect the active working plane, making them usable in 3D workflows with custom work planes. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
+* UTF-16 encoded SVG files (e.g., generated by Corel Draw on Windows) can now be imported. [https://github.com/FreeCAD/FreeCAD/pull/29244 Pull request #29244]
+* When saving [[Draft_AnnotationStyleEditor|Annotation Styles]], the file extension is now automatically ensured. [https://github.com/FreeCAD/FreeCAD/pull/30358 Pull request #30358]
 
 == FEM Workbench ==
 
@@ -323,6 +336,7 @@ ToDo (last check: 20260430, #29258):
 * Extruding text sketches in the Part Workbench is now faster, especially for sketches that produce many wires. [https://github.com/FreeCAD/FreeCAD/pull/28344 Pull request #28344]
 * The attachment system now correctly offers modes such as ''XY parallel to Plane'' when selecting origin datum planes through an Origin object. [https://github.com/FreeCAD/FreeCAD/pull/28958 Pull request #28958]
 * [[Part_Loft|Loft]] creation now allows valid profile combinations that share the same center of gravity while still guarding against the crash case fixed for duplicate profiles. [https://github.com/FreeCAD/FreeCAD/pull/29982 Pull request #29982]
+* Input hints were added for the [[Part_EditAttachment|Attachment]] dialog, showing key bindings for toggling through attachment modes and confirming selections. [https://github.com/FreeCAD/FreeCAD/pull/29614 Pull request #29614]
 
 == Part Design Workbench ==
 
@@ -365,6 +379,7 @@ ToDo (last check: 20260430, #29258):
 
 === Further Points improvements ===
 
+* The Points Workbench now uses modern libE57 types, following the update of the internal libE57 copy. [https://github.com/FreeCAD/FreeCAD/pull/27434 Pull request #27434]
 == Reverse Engineering Workbench ==
 
 === Further Reverse Engineering improvements ===
@@ -425,6 +440,12 @@ ToDo (last check: 20260430, #29258):
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 * Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
+* The [[Image:Sketcher_CreateLine.svg|24px]] [[Sketcher_CreateLine|Line]] and [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|Polyline]] tools are now grouped by default. A preference allows separating them. [https://github.com/FreeCAD/FreeCAD/pull/30347 Pull request #30347]
+* The new polyline tool uses the original {{KEY|G}}, {{KEY|M}} shortcut. [https://github.com/FreeCAD/FreeCAD/pull/30395 Pull request #30395]
+* Hints were re-added for the polyline tool, describing how to switch between line, arc, and tangent modes. [https://github.com/FreeCAD/FreeCAD/pull/30344 Pull request #30344]
+* When long-pressing an edge shared by two internal faces, the clarify selection menu now lists both adjacent faces. [https://github.com/FreeCAD/FreeCAD/pull/29159 Pull request #29159]
+* Internally-aligned B-spline geometry (weight circles, control polygon edges) is now skipped when using the [[Image:Sketcher_ToggleConstruction.svg|24px]] [[Sketcher_ToggleConstruction|Toggle Construction Geometry]] tool, instead of producing an error. [https://github.com/FreeCAD/FreeCAD/pull/28081 Pull request #28081]
+* The [[Image:Sketcher_ConstrainDistance.svg|24px]] [[Sketcher_ConstrainDistance|Dimension]] tool no longer switches the distance type to ''Horizontal'' or ''Vertical'' when an existing horizontal or vertical dimension is selected. [https://github.com/FreeCAD/FreeCAD/pull/28242 Pull request #28242]
 
 == Spreadsheet Workbench ==
 
@@ -457,6 +478,7 @@ ToDo (last check: 20260430, #29258):
 * The default TechDraw page color in the FreeCAD Light preference pack is now white, avoiding gray page backgrounds when printing. [https://github.com/FreeCAD/FreeCAD/pull/30129 Pull request #30129]
 * The task panel of the [[TechDraw_Balloon|Balloon Annotation]] tool was polished. [https://github.com/FreeCAD/FreeCAD/pull/28101 Pull request #28101]
 * The ASME ANSIB TechDraw template now has a transparent background, matching the other drawing templates. [https://github.com/FreeCAD/FreeCAD/pull/30025 Pull request #30025]
+* [[TechDraw_Workbench|TechDraw]] now supports horizontal and vertical dimensions between circle edges (instead of always falling back to a Distance dimension). [https://github.com/FreeCAD/FreeCAD/pull/30379 Pull request #30379]
 
 == Import and export ==
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -46,7 +46,6 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Std_VarSet|VarSet]] ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 * There is now a warning when saving files created in older versions. A preference was added to allow disabling it. [https://github.com/FreeCAD/FreeCAD/pull/28389 Pull request #28389]
 * Clearing the recent files list now asks for confirmation before the list is removed. [https://github.com/FreeCAD/FreeCAD/pull/27274 Pull request #27274]
-* The notification area unread count is now initialized on startup, showing the correct count from the beginning. [https://github.com/FreeCAD/FreeCAD/pull/29391 Pull request #29391]
 
 == Core system and API ==
 
@@ -95,9 +94,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * On Unix-like systems, lock files now use owner-only permissions, and Coin image export avoids creating world-writable files. [https://github.com/FreeCAD/FreeCAD/pull/30239 Pull request #30239]
 * The Conda release build preset now enables {{Incode|FREECAD_WARN_ERROR}}, and related warnings were fixed so release CI catches new compiler warnings earlier. [https://github.com/FreeCAD/FreeCAD/pull/30228 Pull request #30228]
 * The [[Image:Std_TransformManip.svg|24px]] [[Std TransformManip|Transform]] tool can now use the ''Center of mass / centroid'' mode with [[App_Link|Links]] and [[Std_Part|Part containers]]. [https://github.com/FreeCAD/FreeCAD/pull/30208 Pull request #30208]
-* The placement of Part origins is now read-only and can no longer be changed by accident. [https://github.com/FreeCAD/FreeCAD/pull/28076 Pull request #28076]
 * Toponaming support was improved for the Python API so that add-ons can be more stable in terms of [[Topological_naming_problem|TNP]]. [https://github.com/FreeCAD/FreeCAD/pull/24632 Pull request #24632]
-* The [[Image:Std_MassProperties.svg|24px]] [[Std_MassProperties|Mass Properties]] view provider now shows icons at the center of gravity and center of volume, making them easier to locate in the 3D view. [https://github.com/FreeCAD/FreeCAD/pull/29288 Pull request #29288]
 
 === API ===
 
@@ -128,7 +125,6 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Editing sketches from assemblies no longer briefly activates the sketch's source document or crashes when leaving the Assembly context. [https://github.com/FreeCAD/FreeCAD/pull/29271 Pull request #29271]
 * [[Assembly_CreateSimulation|Simulations]] now offer export to video format. [https://github.com/FreeCAD/FreeCAD/pull/25307 Pull request #25307]
 * [[Assembly_CreateView|Exploded View]] can now be created temporarily. [https://github.com/FreeCAD/FreeCAD/pull/25456 Pull request #25456]
-* The [[Assembly_CreateSimulation|Simulation]] playback buttons have been made bigger and more visually distinct. [https://github.com/FreeCAD/FreeCAD/pull/30257 Pull request #30257]
 
 == BIM Workbench ==
 
@@ -136,7 +132,7 @@ ToDo (last check: 20260430, #27222):
 * https://github.com/FreeCAD/FreeCAD/pull/24078
 * https://github.com/FreeCAD/FreeCAD/pull/24190
 * https://github.com/FreeCAD/FreeCAD/pull/27222
-* [[Arch_Site|Site]] objects now have a dedicated task panel with sections for Location, Shape, Terrain and Metadata, making site editing more user-friendly. [https://github.com/FreeCAD/FreeCAD/pull/28504 Pull request #28504]
+* https://github.com/FreeCAD/FreeCAD/pull/28504
 * Removing a wall base now preserves the wall's placement and parametric dimensions for supported straight Draft or Sketch bases, and warns before removing unsupported complex bases. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
 * [[Arch_Wall|Walls]] can now be created without a base object by default, with the selected wall baseline mode remembered in preferences. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]
 * The BIM Project command was removed from the toolbar, moved to the Utils menu, renamed for IFC-project clarity, and the Setup Project dialog now defaults to non-IFC-native projects. [https://github.com/FreeCAD/FreeCAD/pull/25086 Pull request #25086]
@@ -155,7 +151,6 @@ ToDo (last check: 20260430, #27222):
 * [[BIM_DrawingView|DrawingView]] cut lines now use the default line width and cut areas line thickness ratio preferences for thicker cut-line output. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]
 * IFC import now treats a multicore preference value of 0 as disabled before creating the IfcOpenShell geometry iterator, avoiding invalid worker counts when multicore processing is turned off. [https://github.com/FreeCAD/FreeCAD/pull/30201 Pull request #30201]
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
-* The endpoints of walls without a base object can now be edited in [[Draft_Workbench|Draft]], allowing interactive wall reshaping in plan view. [https://github.com/FreeCAD/FreeCAD/pull/29860 Pull request #29860]
 
 == CAM Workbench ==
 
@@ -227,10 +222,6 @@ ToDo (last check: 20260430, #27222):
 * CAM drilling cycle expansion now uses MachineState for more accurate machine state tracking while expanding drilling cycles. [https://github.com/FreeCAD/FreeCAD/pull/30112 Pull request #30112]
 * The [[CAM_Profile|Profile]] and [[CAM_Pocket_Shape|Pocket]] linking options now include collision-avoidance strategies for using retract height, clearance height, line-of-sight checks, tool diameter, or tool shape. [https://github.com/FreeCAD/FreeCAD/pull/29983 Pull request #29983]
 # The Linking generator was added to the [[CAM_Engrave|Engrave]] and [[CAM_Deburr|Deburr]] operations to use the safe height instead of clearance height for linking moves. The Linking Mode and Safety Margin options were added to the task panels, also for [[CAM_Drilling|Drilling]] and [[CAM_Helix|Helix]] operations. [https://github.com/FreeCAD/FreeCAD/pull/29959 Pull request #29959]
-* The [[CAM_LeadInOut|LeadInOut]] dressup now supports ExtendLeadIn and ExtendLeadOut properties for the Arc, Line, Perpendicular and Tangent styles. [https://github.com/FreeCAD/FreeCAD/pull/29061 Pull request #29061]
-* The Spiral generator now validates G-code output with deviation-based testing instead of exact string comparisons. [https://github.com/FreeCAD/FreeCAD/pull/28596 Pull request #28596]
-* A tolerance parameter was added to the Linking generator collision check, making it possible to adjust collision detection sensitivity. [https://github.com/FreeCAD/FreeCAD/pull/28140 Pull request #28140]
-* Several fixes were applied to machine-based postprocessing, improving G-code output for different machine configurations. [https://github.com/FreeCAD/FreeCAD/pull/28563 Pull request #28563]
 
 == Draft Workbench ==
 
@@ -248,10 +239,6 @@ ToDo (last check: 20260430, #29258):
 === Further Draft improvements ===
 
 * [[Draft_Trimex|Trimex]] now reports unsupported sketch selections before opening the task panel, avoiding a misleading no-op workflow. [https://github.com/FreeCAD/FreeCAD/pull/29845 Pull request #29845]
-* Hints were added for the Draft annotation tools (Dimension, Label, ShapeString, etc.), describing available modifiers and keyboard shortcuts in the task panel. [https://github.com/FreeCAD/FreeCAD/pull/29649 Pull request #29649]
-* [[Draft_PolarArray|Polar]] and [[Draft_CircularArray|Circular Array]] now respect the active working plane, making them usable in 3D workflows with custom work planes. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
-* UTF-16 encoded SVG files (e.g., generated by Corel Draw on Windows) can now be imported. [https://github.com/FreeCAD/FreeCAD/pull/29244 Pull request #29244]
-* When saving [[Draft_AnnotationStyleEditor|Annotation Styles]], the file extension is now automatically ensured. [https://github.com/FreeCAD/FreeCAD/pull/30358 Pull request #30358]
 
 == FEM Workbench ==
 
@@ -336,7 +323,6 @@ ToDo (last check: 20260430, #29258):
 * Extruding text sketches in the Part Workbench is now faster, especially for sketches that produce many wires. [https://github.com/FreeCAD/FreeCAD/pull/28344 Pull request #28344]
 * The attachment system now correctly offers modes such as ''XY parallel to Plane'' when selecting origin datum planes through an Origin object. [https://github.com/FreeCAD/FreeCAD/pull/28958 Pull request #28958]
 * [[Part_Loft|Loft]] creation now allows valid profile combinations that share the same center of gravity while still guarding against the crash case fixed for duplicate profiles. [https://github.com/FreeCAD/FreeCAD/pull/29982 Pull request #29982]
-* Input hints were added for the [[Part_EditAttachment|Attachment]] dialog, showing key bindings for toggling through attachment modes and confirming selections. [https://github.com/FreeCAD/FreeCAD/pull/29614 Pull request #29614]
 
 == Part Design Workbench ==
 
@@ -379,7 +365,6 @@ ToDo (last check: 20260430, #29258):
 
 === Further Points improvements ===
 
-* The Points Workbench now uses modern libE57 types, following the update of the internal libE57 copy. [https://github.com/FreeCAD/FreeCAD/pull/27434 Pull request #27434]
 == Reverse Engineering Workbench ==
 
 === Further Reverse Engineering improvements ===
@@ -440,12 +425,6 @@ ToDo (last check: 20260430, #29258):
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 * Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
-* The [[Image:Sketcher_CreateLine.svg|24px]] [[Sketcher_CreateLine|Line]] and [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|Polyline]] tools are now grouped by default. A preference allows separating them. [https://github.com/FreeCAD/FreeCAD/pull/30347 Pull request #30347]
-* The new polyline tool uses the original {{KEY|G}}, {{KEY|M}} shortcut. [https://github.com/FreeCAD/FreeCAD/pull/30395 Pull request #30395]
-* Hints were re-added for the polyline tool, describing how to switch between line, arc, and tangent modes. [https://github.com/FreeCAD/FreeCAD/pull/30344 Pull request #30344]
-* When long-pressing an edge shared by two internal faces, the clarify selection menu now lists both adjacent faces. [https://github.com/FreeCAD/FreeCAD/pull/29159 Pull request #29159]
-* Internally-aligned B-spline geometry (weight circles, control polygon edges) is now skipped when using the [[Image:Sketcher_ToggleConstruction.svg|24px]] [[Sketcher_ToggleConstruction|Toggle Construction Geometry]] tool, instead of producing an error. [https://github.com/FreeCAD/FreeCAD/pull/28081 Pull request #28081]
-* The [[Image:Sketcher_ConstrainDistance.svg|24px]] [[Sketcher_ConstrainDistance|Dimension]] tool no longer switches the distance type to ''Horizontal'' or ''Vertical'' when an existing horizontal or vertical dimension is selected. [https://github.com/FreeCAD/FreeCAD/pull/28242 Pull request #28242]
 
 == Spreadsheet Workbench ==
 
@@ -478,7 +457,6 @@ ToDo (last check: 20260430, #29258):
 * The default TechDraw page color in the FreeCAD Light preference pack is now white, avoiding gray page backgrounds when printing. [https://github.com/FreeCAD/FreeCAD/pull/30129 Pull request #30129]
 * The task panel of the [[TechDraw_Balloon|Balloon Annotation]] tool was polished. [https://github.com/FreeCAD/FreeCAD/pull/28101 Pull request #28101]
 * The ASME ANSIB TechDraw template now has a transparent background, matching the other drawing templates. [https://github.com/FreeCAD/FreeCAD/pull/30025 Pull request #30025]
-* [[TechDraw_Workbench|TechDraw]] now supports horizontal and vertical dimensions between circle edges (instead of always falling back to a Distance dimension). [https://github.com/FreeCAD/FreeCAD/pull/30379 Pull request #30379]
 
 == Import and export ==
 


### PR DESCRIPTION
## Summary

Updates the **Basic Part Design Tutorial** and **Basic Sketcher Tutorial** for FreeCAD 1.x compatibility.

### Changes to Basic_Part_Design_Tutorial.wikitext

- Updated FCVersion metadata from 0.17+ to 1.0+
- Updated refine section: refine is now enabled by default in FreeCAD 1.0 (Preferences → Part Design → Shape view → Refine model), so the manual per-feature refine instructions are now noted as optional for older versions
- Removed deprecated {{Version|0.19}} reference for the Esc-can-leave-sketch preference
- Added note about the task panel being a standalone widget in 1.0+
- Added cross-reference to [[Basic_Part_Design_Tutorial_019]] for the more modern version

### Changes to Basic_Sketcher_Tutorial.wikitext

- Updated FCVersion metadata from 0.19 to 1.0+
- Rewrote the Setup section to reflect post-0.21 UI changes:
  - The "Edit controls" widget was removed; auto constraints is now a toolbar toggle
  - Grid settings moved to the [[Sketcher_Grid]] tool with auto-rescaling
- Added comprehensive "FreeCAD 1.x additions and changes" section covering:
  - Task panel redesign
  - On-View Parameters (OVP)
  - Selection filters
  - New External geometry tools (Projection/Intersection in 1.1)
  - Group constraints (1.2)
  - Text tool (1.2)
  - Cancel button (1.2)
  - Default refine behavior

### References

- FreeCAD 1.0 Release Notes
- FreeCAD 1.1 Release Notes
- FreeCAD 1.2 Release Notes

Part of Bounty #29: Tutorial Updates