### PR TITLE
Sketcher Workbench: Add missing documentation for 1.1 and 1.2 features (Bounty #94)

### DIFF
--- a/wiki/Sketcher_Workbench.wikitext
+++ b/wiki/Sketcher_Workbench.wikitext
@@ -1,7 +1,3 @@
-<languages/>
-<translate>
-
-<!--T:119-->
 {{Docnav
 |[[Robot_Workbench|Robot Workbench]]
 |[[Spreadsheet_Workbench|Spreadsheet Workbench]]
@@ -9,556 +5,368 @@
 |IconR=Workbench_Spreadsheet.svg
 }}
 
-<!--T:123-->
 [[Image:Workbench_Sketcher.svg|thumb|128px|Sketcher workbench icon]]
 
-</translate>
 {{TOCright}}
-<translate>
 
-== Introduction == <!--T:117-->
-
-<!--T:2-->
+== Introduction == 
 With the [[Image:Workbench_Sketcher.svg|24px]] [[Sketcher_Workbench|Sketcher Workbench]] 2D sketches intended for use in other workbenches can be created. 2D sketches are the starting point for many CAD models. They typically define the profiles and paths for operations to create 3D shapes. A model may depend on several sketches for its final shape.
 
-<!--T:198-->
 Together with boolean operations defined in the [[Image:Workbench_Part.svg|16px]] [[Part Workbench|Part Workbench]], the Sketcher Workbench, or "The Sketcher" for short, forms the basis of the [[Constructive_solid_geometry|constructive solid geometry]] (CSG) method of building solids. Together with [[Image:Workbench_PartDesign.svg|16px]] [[PartDesign_Workbench|PartDesign Workbench]] operations, it also forms the basis of the [[Feature_editing|feature editing]] methodology of creating solids. But many other workbenches use sketches as well.
 
-<!--T:3-->
 The Sketcher workbench features [[#Constraints|constraints]], allowing 2D shapes to follow precise geometrical definitions in terms of length, angles, and relationships (horizontality, verticality, perpendicularity, etc.). A constraint solver calculates the constrained-extent of 2D geometry and allows interactive exploration of the degrees-of-freedom of the sketch.
 
-<!--T:11-->
 The Sketcher is not intended for producing 2D blueprints. Once sketches are used to generate a solid feature, they are automatically hidden and constraints are only visible in Sketch edit mode. If you only need to produce 2D views for print, and don't want to create 3D models, check out the [[Draft_Workbench|Draft workbench]].
 
-</translate>
 [[File:FC_ConstrainedSketch.png|450px]]
-<translate>
-<!--T:1-->
+
 {{Caption|A fully constrained sketch}}
 
-== Constraints == <!--T:199-->
-
-<!--T:7-->
+== Constraints == 
 Constraints are used to limit the degrees of freedom of an object. For example, a line without constraints has 4 degrees of freedom (abbreviated as "DoF"): it can be moved horizontally or vertically, it can be stretched, and it can be rotated.
 
-<!--T:8-->
 Applying a horizontal or vertical constraint, or an angle constraint (relative to another line or to one of the axes), will limit its capacity to rotate, thus leaving it with 3 degrees of freedom. Locking one of its points in relation to the origin will remove another 2 degrees of freedom. And applying a distance dimension will remove the last degree of freedom. The line is then considered '''fully constrained'''.
 
-<!--T:9-->
 Objects can be constrained in relation to one another. Two lines can be joined through one of their points with a coincident constraint. An angle can be set between them, or they can be set perpendicular. A line can be tangent to an arc or a circle, and so on. A Sketch may have a number of different solutions, and making it '''fully constrained''' can mean that just one of these possible solutions has been reached based on the applied constraints. See also: [[#Flipping|Flipping]].
 
-<!--T:10-->
 There are two kinds of constraints: geometric and dimensional. They are detailed in the [[#Tools|Tools]] section below.
 
-=== Edit constraints === <!--T:201-->
-
-<!--T:202-->
+=== Edit constraints === 
 When a [[Sketcher_ToggleDrivingConstraint|driving dimensional constraint]] is created, and if the {{MenuCommand|Ask for value after creating a dimensional constraint}} [[Sketcher_Preferences#Display|preference]] is selected (default), a dialog opens to edit its value.
 
-</translate>
 [[Image:Sketcher_Edit_Constraint.png|Sketcher_Edit_Constraint.png]]
-<translate>
 
-<!--T:204-->
 You can enter a numerical value or an [[Expressions|expression]], and it is possible to name the constraint to facilitate its use in other expressions. You can also check the {{MenuCommand|Reference}} checkbox to switch the constrain to [[Sketcher_ToggleDrivingConstraint|reference mode]].
 
-<!--T:205-->
 To edit the value of an existing dimensional constraint do one of the following:
 * Double-click the constraint value in the [[3D_View|3D View]].
 * Double-click the constraint in the [[Sketcher_Dialog|Sketcher Dialog]].
 * Right-click the constraint in the Sketcher Dialog and select the {{MenuCommand|Edit Value}} option from the context menu.
 
-=== Reposition constraints === <!--T:206-->
-
-<!--T:207-->
+=== Reposition constraints === 
 Dimensional constraints can be repositioned in the 3D View by dragging. Hold down the left mouse button over the constraint value and move the mouse. The symbols of geometric constraints are positioned automatically and cannot be moved.
 
-== Profile sketches == <!--T:208-->
-
-<!--T:209-->
+== Profile sketches == 
 To create a sketch that can be used as a profile for generating solids certain rules must be followed:
 # The sketch must contain only closed contours. Gaps between endpoints, however small, are not allowed.
 # Contours can be nested, to create voids, but should not self-intersect or intersect other contours.
 # Contours cannot share edges with other contours. Duplicate or overlapping edges are not allowed.
 # T-connections, that is more than two edges sharing a common point, or a point touching an edge, are not allowed.
 
-</translate>
 [[File:Sketcher_profile_sketches_2.png|600px]]
-<translate>
 
-<!--T:270-->
 {{Caption|Invalid sketches:<br>
 1. Open contour (free endpoints highlighted by the [[Sketcher_ValidateSketch|Validate Sketch tool]])<br>
 2. Intersecting contours<br>
 3. Duplicate edges (endpoints of overlapping edges highlighted by the [[Sketcher_ValidateSketch|Validate Sketch tool]])<br>
 4. T-connections}}
 
-<!--T:210-->
 These rules do not apply to construction geometry (default color blue), which is not shown outside edit mode, or if the sketch is used for a different purpose. Depending on the workbench and the tool that will use the profile sketch, additional restrictions may apply.
 
-== Tools == <!--T:144-->
-
-<!--T:16-->
+== Tools == 
 The Sketcher Workbench tools are located in the Sketch menu and/or several toolbars. Almost all Sketcher toolbars are only displayed while a sketch is in edit mode. The only exception is the [[#Sketcher_toolbar|Sketcher toolbar]] which is only displayed if no sketch is in edit mode.
 
-<!--T:251-->
 Some tools are also available from the [[3D_View|3D View]] context menu while a sketch is in edit mode, or from the context menus of the [[Sketcher_Dialog|Sketcher Dialog]].
 
-<!--T:177-->
 If a sketch is in edit mode the Structure toolbar is hidden as none of its tools can then be used. 
 
-=== General === <!--T:126-->
-
-==== Sketcher toolbar ==== <!--T:164-->
-
-<!--T:23-->
+=== General === 
+==== Sketcher toolbar ==== 
 * [[Image:Sketcher_NewSketch.svg|32px]] [[Sketcher_NewSketch|New Sketch]]: Creates a new sketch and opens the [[Sketcher_Dialog|Sketcher Dialog]] to edit it.
 
-<!--T:24-->
 * [[Image:Sketcher_EditSketch.svg|32px]] [[Sketcher_EditSketch|Edit Sketch]]: Opens the Sketcher Dialog to edit an existing sketch.
 
-<!--T:28-->
 * [[Image:Sketcher_MapSketch.svg|32px]] [[Sketcher_MapSketch|Attach Sketch]]: Attaches a sketch to selected geometry.
 
-<!--T:29-->
 * [[File:Sketcher_ReorientSketch.svg|32px]] [[Sketcher_ReorientSketch|Reorient Sketch]]: Places a sketch on one of the main planes with an optional offset. It can also be used to detach a sketch.
 
-<!--T:30-->
 * [[File:Sketcher_ValidateSketch.svg|32px]] [[Sketcher_ValidateSketch|Validate Sketch]]: Can analyze and repair a sketch that is no longer editable or has invalid constraints, or add missing coincident constraints.
 
-<!--T:31-->
 * [[Image:Sketcher_MergeSketches.svg|32px]] [[Sketcher_MergeSketches|Merge Sketches]]: Merges two or more sketches. {{Version|1.2}}: The tool now supports importing external geometry, improves constraint remapping, and creates the merged sketch inside the Body when all source sketches share the same Body.
 
-<!--T:32-->
 * [[Image:Sketcher_MirrorSketch.svg|32px]] [[Sketcher_MirrorSketch|Mirror Sketch]]: Mirrors sketches across their X-axis, Y-axis, or origin.
 
-==== Edit Mode toolbar ==== <!--T:165-->
-
-<!--T:25-->
+==== Edit Mode toolbar ==== 
 * [[Image:Sketcher_LeaveSketch.svg|32px]] [[Sketcher_LeaveSketch|Leave Sketch]]: Finishes sketch edit mode and closes the [[Sketcher_Dialog|Sketcher Dialog]].
 
-<!--T:276-->
 * [[Image:Sketcher_CancelSketch.svg|32px]] [[Sketcher_CancelSketch|Cancel Editing]]: Leaves sketch edit mode, reverts any changes, and closes the [[Sketcher_Dialog|Sketcher Dialog]]. {{Version|1.2}}
 
-<!--T:26-->
 * [[Image:Sketcher_ViewSketch.svg|32px]] [[Sketcher_ViewSketch|Align View to Sketch]]: Aligns the [[3D_View|3D View]] with the sketch.
 
-<!--T:27-->
 * [[Image:Sketcher_ViewSection.svg|32px]] [[Sketcher_ViewSection|Toggle Section View]]: Toggles a temporary section plane that hides any objects and parts of objects in front of the sketch plane.
 
-==== Other ==== <!--T:168-->
-
-<!--T:127-->
+==== Other ==== 
 * [[File:Sketcher_StopOperation.svg|32px]] [[Sketcher_StopOperation|Stop Operation]]: Stops any currently running geometry or constraint creation tool.
 
-<!--T:166-->
 * [[Sketcher_Grid|Grid]]: Grid settings can be changed in the menu of the [[Sketcher_Dialog#Sketch_Edit|Sketch Edit section of the Sketcher Dialog]]. {{Version|1.2}}: A grid transparency preference has been added.
 
-<!--T:167-->
 * [[Sketcher_Snap|Snap]]: Snap settings can be changed in the same menu.
 
-<!--T:176-->
 * [[Sketcher_RenderingOrder|Rendering Order]]: The rendering order can be changed in the same menu.
 
-===Geometries=== <!--T:33-->
-
-<!--T:34-->
+===Geometries=== 
 These are tools for creating objects.
 
-<!--T:35-->
 * [[Image:Sketcher_CreatePoint.svg|32px]] [[Sketcher_CreatePoint|Point]]: Creates a point.
 
-<!--T:42-->
 * [[Image:Sketcher_CreatePolyline.svg|32px]] [[Sketcher_CreatePolyline|Polyline]]: Creates a series of line and arc segments connected by their endpoints. The tool has several modes. {{Version|1.2}}: An improved version of the tool adds auto-constraints such as tangent, parallel and perpendicular.
 
-<!--T:36-->
 * [[Image:Sketcher_CreateLine.svg|32px]] [[Sketcher_CreateLine|Line]]: Creates a line. {{Version|1.0}}: The tool has three modes.
 
-<!--T:180-->
 * <span id="Sketcher_CompCreateArc">[[Image:Sketcher_CreateArc.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] Create Arc:</span><!--Do not edit span id: the Sketcher_CompCreateArc pages redirect here-->
 
-<!--T:37-->
 :* [[Image:Sketcher_CreateArc.svg|32px]] [[Sketcher_CreateArc|Arc From Center]]: Creates an arc from its center and its endpoints. {{Version|1.0}}: Or from its endpoints and a point along the arc. 
 
-<!--T:38-->
 :* [[Image:Sketcher_Create3PointArc.svg|32px]] [[Sketcher_Create3PointArc|Arc From 3 Points]]: Creates an arc from its endpoints and a point along the arc. {{Version|1.0}}: This is the same tool as [[Sketcher_CreateArc|Arc From Center]] but with a different initial mode.
 
-<!--T:152-->
 :* [[Image:Sketcher_CreateArcOfEllipse.svg|32px]] [[Sketcher_CreateArcOfEllipse|Elliptical Arc]]: Creates an elliptical arc.
 
-<!--T:153-->
 :* [[Image:Sketcher_CreateArcOfHyperbola.svg|32px]] [[Sketcher_CreateArcOfHyperbola|Hyperbolic Arc]]: Creates an hyperbolic arc.
 
-<!--T:154-->
 :* [[Image:Sketcher_CreateArcOfParabola.svg|32px]] [[Sketcher_CreateArcOfParabola|Parabolic Arc]]: Creates an parabolic arc.
 
-<!--T:182-->
 * <span id="Sketcher_CompCreateConic">[[Image:Sketcher_CreateCircle.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] Create Circle/Ellipse:</span><!--Do not edit span id: the Sketcher_CompCreateConic pages redirect here-->
 
-<!--T:39-->
 :* [[Image:Sketcher_CreateCircle.svg|32px]] [[Sketcher_CreateCircle|Circle From Center]]: Creates a circle from its center and a point along the circle. {{Version|1.0}}: Or from three points along the circle.
 
-<!--T:40-->
 :* [[Image:Sketcher_Create3PointCircle.svg|32px]] [[Sketcher_Create3PointCircle|Circle From 3 Points]]: Creates a circle from three points along the circle. {{Version|1.0}}: This is the same tool as [[Sketcher_CreateCircle|Circle From Center]] but with a different initial mode.
 
-<!--T:150-->
 :* [[Image:Sketcher_CreateEllipseByCenter.svg|32px]] [[Sketcher_CreateEllipseByCenter|Ellipse From Center]]: Creates an ellipse from its center, an endpoint of one of its axes, and a point along the ellipse. {{Version|1.0}}: Or from both endpoints of one of its axes and a point along the ellipse.
 
-<!--T:151-->
 :* [[Image:Sketcher_CreateEllipseBy3Points.svg|32px]] [[Sketcher_CreateEllipseBy3Points|Ellipse From 3 Points]]: Creates an ellipse from the endpoints of one of its axes and a point along the ellipse. {{Version|1.0}}: This is the same tool as [[Sketcher_CreateEllipseByCenter|Ellipse From Center]] but with a different initial mode.
 
-<!--T:184-->
 * <span id="Sketcher_CompCreateRectangles">[[Image:Sketcher_CreateRectangle.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] Create Rectangle:</span><!--Do not edit span id: the Sketcher_CompCreateRectangles pages redirect here-->
 
-<!--T:43-->
 :* [[Image:Sketcher_CreateRectangle.svg|32px]] [[Sketcher_CreateRectangle|Rectangle]]: Creates a rectangle. {{Version|1.0}}: The tool has four modes. Rounded corners and creating an offset copy are optional features.
 
-<!--T:136-->
 :* [[Image:Sketcher_CreateRectangle_Center.svg|32px]] [[Sketcher_CreateRectangle_Center|Centered Rectangle]]: Creates a centered rectangle. {{Version|1.0}}: This is the same tool as [[Sketcher_CreateRectangle|Rectangle]] but with a different initial mode.
 
-<!--T:137-->
 :* [[Image:Sketcher_CreateOblong.svg|32px]] [[Sketcher_CreateOblong|Rounded Rectangle]]: Creates a rounded rectangle. Idem.
 
-<!--T:185-->
 * <span id="Sketcher_CompCreateRegularPolygon">[[Image:Sketcher_CreateHexagon.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] Create Polygon:</span><!--Do not edit span id: the Sketcher_CompCreateRegularPolygon pages redirect here-->
 
-<!--T:44-->
 :* [[Image:Sketcher_CreateTriangle.svg|32px]] [[Sketcher_CreateTriangle|Triangle]]: creates an equilateral triangle. {{Version|1.0}}: This is the same tool as [[Sketcher_CreateRegularPolygon|Polygon]] but with the number of sides preset to a specif value.
 
-<!--T:45-->
 :* [[Image:Sketcher_CreateSquare.svg|32px]] [[Sketcher_CreateSquare|Square]]: Creates a square. Idem.
 
-<!--T:46-->
 :* [[Image:Sketcher_CreatePentagon.svg|32px]] [[Sketcher_CreatePentagon|Pentagon]]: Creates a pentagon. Idem.
 
-<!--T:47-->
 :* [[Image:Sketcher_CreateHexagon.svg|32px]] [[Sketcher_CreateHexagon|Hexagon]]: Creates a hexagon. Idem.
 
-<!--T:48-->
 :* [[Image:Sketcher_CreateHeptagon.svg|32px]] [[Sketcher_CreateHeptagon|Heptagon]]: Creates a heptagon. Idem.
 
-<!--T:49-->
 :* [[Image:Sketcher_CreateOctagon.svg|32px]] [[Sketcher_CreateOctagon|Octagon]]: Creates an octagon. Idem.
 
-<!--T:118-->
 :* [[Image:Sketcher_CreateRegularPolygon.svg|32px]] [[Sketcher_CreateRegularPolygon|Polygon]]: Creates a regular polygon. The number of sides can be specified.
 
-<!--T:186-->
 * <span id="Sketcher_CompSlot">[[Image:Sketcher_CreateSlot.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] Create Slot:</span><!--Do not edit span id: the Sketcher_CompSlot pages redirect here-->
 
-<!--T:50-->
 :* [[Image:Sketcher_CreateSlot.svg|32px]] [[Sketcher_CreateSlot|Slot]]: Creates a slot.
 
-<!--T:178-->
 :* [[Image:Sketcher_CreateArcSlot.svg|32px]] [[Sketcher_CreateArcSlot|Arc Slot]]: Creates an arc slot. {{Version|1.0}}
 
-<!--T:183-->
 * <span id="Sketcher_CompCreateBSpline">[[Image:Sketcher_CreateBSpline.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] Create B-Spline:</span><!--Do not edit span id: the Sketcher_CompCreateBSpline pages redirect here-->
 
-<!--T:155-->
 :* [[File:Sketcher_CreateBSpline.svg|32px]] [[Sketcher_CreateBSpline|B-Spline]]: Creates a B-spline curve from control points. {{Version|1.0}}: Or from knot points.
 
-<!--T:156-->
 :* [[File:Sketcher_CreatePeriodicBSpline.svg|32px]] [[Sketcher_CreatePeriodicBSpline|Periodic B-Spline]]: Creates a periodic (closed) B-spline curve from control points. {{Version|1.0}}: This is the same tool as [[Sketcher_CreateBSpline|B-Spline]] but with a different initial mode.
 
-<!--T:169-->
 :* [[File:Sketcher_CreateBSplineByInterpolation.svg|32px]] [[Sketcher_CreateBSplineByInterpolation|B-Spline From Knots]]: Creates a B-spline curve from knot points. Idem.
 
-<!--T:170-->
 :* [[File:Sketcher_CreatePeriodicBSplineByInterpolation.svg|32px]] [[Sketcher_CreatePeriodicBSplineByInterpolation|Periodic B-Spline From Knots]]: Creates a periodic (closed) B-spline curve from knot points. Idem.
 
-<!--T:274-->
 * [[File:Sketcher_CreateText.svg|32px]] [[Sketcher_CreateText|Text]]: Creates text geometry controlled by a text constraint {{Version|1.2}}.
 
-<!--T:54-->
 * [[File:Sketcher_ToggleConstruction.svg|32px]] [[Sketcher_ToggleConstruction|Toggle Construction Geometry]]: Either toggles the geometry creation tools to/from construction mode, or toggles selected geometry to/from construction geometry.
 
-===Constraints=== <!--T:55-->
-
-<!--T:56-->
+===Constraints=== 
 These are tools for creating [[#Constraints|constraints]]. Some constraints require the use of [[Sketcher_helper_constraint|helper constraints]].
 
-<!--T:191-->
 * <span id="Sketcher_CompDimensionTools">[[Image:Sketcher_Dimension.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] Dimensional Constraints:</span><!--Do not edit span id: the Sketcher_CompDimensionTools pages redirect here-->
 
-<!--T:192-->
 :* [[File:Sketcher_Dimension.svg|32px]] [[Sketcher_Dimension|Dimension]]: Is the context-sensitive constraint tool of the Sketcher Workbench. Based on the current selection, it offers appropriate dimensional constraints, but also geometric constraints. {{Version|1.0}}
 
-<!--T:70-->
 :* [[File:Sketcher_ConstrainDistanceX.svg|32px]] [[Sketcher_ConstrainDistanceX|Horizontal Dimension]]: Fixes the horizontal distance between two points or the endpoints of a line. If a single point is pre-selected, the distance is relative to the origin of the sketch.
 
-<!--T:71-->
 :* [[File:Sketcher_ConstrainDistanceY.svg|32px]] [[Sketcher_ConstrainDistanceY|Vertical Dimension]]: Fixes the vertical distance between two points or the endpoints of a line. If a single point is pre-selected, the distance is relative to the origin of the sketch.
 
-<!--T:72-->
 :* [[File:Sketcher_ConstrainDistance.svg|32px]] [[Sketcher_ConstrainDistance|Distance Dimension]]: Fixes the length of a line, the distance between two points, the perpendicular distance between a point and a line; or the distance between the edges of two circles or arcs, or between the edge of a circle or arc and a line; or, {{Version|1.0}}, the length of an arc.
 
-<!--T:159-->
 :* <span id="Sketcher_CompConstrainRadDia">[[File:Sketcher_ConstrainRadiam.svg|32px]] [[Sketcher_ConstrainRadiam|Radius/Diameter Dimension]]: Fixes the radius of arcs and B-spline weight circles, and the diameter of circles.</span><!--Do not edit span id: the Sketcher_CompConstrainRadDia pages redirect here-->
 
-<!--T:73-->
 :* [[File:Sketcher_ConstrainRadius.svg|32px]] [[Sketcher_ConstrainRadius|Radius Dimension]]: Fixes the radius of circles, arcs and B-spline weight circles.
 
-<!--T:158-->
 :* [[File:Sketcher_ConstrainDiameter.svg|32px]] [[Sketcher_ConstrainDiameter|Diameter Dimension]]: Fixes the diameter of circles and arcs.
 
-<!--T:160-->
 :* [[File:Sketcher_ConstrainAngle.svg|32px]] [[Sketcher_ConstrainAngle|Angle Dimension]]: Fixes the angle between two edges, the angle of a line with the horizontal axis of the sketch, or the aperture angle of a circular arc.
 
-<!--T:69-->
 :* [[File:Sketcher_ConstrainLock.svg|32px]] [[Sketcher_ConstrainLock|Lock Position]]: Applies [[Sketcher_ConstrainDistanceX|horizontal dimension]] and [[Sketcher_ConstrainDistanceY|vertical dimension]] constraints to points. If a single point is selected the constraints reference the origin of the sketch. If two or more points are selected the constraints reference the last point in the selection.
 
-<!--T:196-->
 * [[File:Sketcher_ConstrainCoincidentUnified.svg|32px]] [[Sketcher_ConstrainCoincidentUnified|Coincident Constraint (Unified)]]: Creates a coincident constraint between points, fixes points on edges or axes, or creates a concentric constraint. It combines the [[Sketcher_ConstrainCoincident|Coincident Constraint]] and [[Sketcher_ConstrainPointOnObject|Point-On-Object Constraint]] tools. {{Version|1.0}}
 
-<!--T:58-->
 * [[File:Sketcher_ConstrainCoincident.svg|32px]] [[Sketcher_ConstrainCoincident|Coincident Constraint]]: Creates a coincident constraint between points, or a concentric constraint.
 
-<!--T:59-->
 * [[File:Sketcher_ConstrainPointOnObject.svg|32px]] [[Sketcher_ConstrainPointOnObject|Point-On-Object Constraint]]: Fixes points on edges or axes.
 
-<!--T:189-->
 * <span id="Sketcher_CompHorVer">[[Image:Sketcher_ConstrainHorVer.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]]Horizontal/Vertical Constraints:</span><!--Do not edit span id: the Sketcher_CompHorVer pages redirect here-->
 
-<!--T:190-->
 :* [[File:Sketcher_ConstrainHorVer.svg|32px]] [[Sketcher_ConstrainHorVer|Horizontal/Vertical Constraint]]: Constrains lines or pairs of points to be horizontal or vertical, whichever is closest to the current alignment. It combines the [[Sketcher_ConstrainHorizontal|Horizontal Constrain]] and [[Sketcher_ConstrainVertical|Vertical Constrain]] tools. {{Version|1.0}}
 
-<!--T:61-->
 :* [[File:Sketcher_ConstrainHorizontal.svg|32px]] [[Sketcher_ConstrainHorizontal|Horizontal Constraint]]: Constrains lines or pairs of points to be horizontal.
 
-<!--T:60-->
 :* [[File:Sketcher_ConstrainVertical.svg|32px]] [[Sketcher_ConstrainVertical|Vertical Constraint]]: Constrains lines or pairs of points to be vertical.
 
-<!--T:62-->
 * [[File:Sketcher_ConstrainParallel.svg|32px]] [[Sketcher_ConstrainParallel|Parallel Constraint]]: Constrains lines to be parallel.
 
-<!--T:63-->
 * [[File:Sketcher_ConstrainPerpendicular.svg|32px]] [[Sketcher_ConstrainPerpendicular|Perpendicular Constraint]]: Constrains two lines to be perpendicular, or two edges, or an edge and an axis, to be perpendicular at their intersection. The constraint can also connect two edges, forcing them to be perpendicular at the joint.
 
-<!--T:64-->
 * [[File:Sketcher_ConstrainTangent.svg|32px]] [[Sketcher_ConstrainTangent|Tangent/Collinear Constraint]]: Constrains two edges, or an edge and an axis, to be tangent. The constraint can also connect two edges, forcing them to be tangent at the joint. If two lines are selected they are made collinear.
 
-<!--T:65-->
 * [[File:Sketcher_ConstrainEqual.svg|32px]] [[Sketcher_ConstrainEqual|Equal Constraint]]: Constrains edges to have an equal length (lines) or curvature (other edges except B-splines).
 
-<!--T:66-->
 * [[File:Sketcher_ConstrainSymmetric.svg|32px]] [[Sketcher_ConstrainSymmetric|Symmetric Constraint]]: Constrains two points to be symmetrical around a line or axis, or around a third point. {{Version|1.2}}: A fourth option was added: selecting an entire edge (line, arc, or open B-spline) and a symmetry line.
 
-<!--T:67-->
 * [[Image:Sketcher_ConstrainBlock.svg|32px]] [[Sketcher_ConstrainBlock|Block Constraint]]: Blocks edges in place with a single constraint. It is mainly intended for B-splines.
 
-<!--T:275-->
 * [[Image:Sketcher_ConstrainGroup.svg|32px]] [[Sketcher_ConstrainGroup|Group Constraint]]: Groups selected geometry. {{Version|1.2}}
 
-<!--T:74-->
 * [[File:Sketcher_ConstrainSnellsLaw.svg|32px]] [[Sketcher_ConstrainSnellsLaw|Refraction Constraint]]: Constrains two lines to follow the law of refraction of light as it penetrates through an interface.
 
-<!--T:253-->
 * <span id="Sketcher_CompToggleConstraints">[[Image:Sketcher_ToggleDrivingConstraint.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] Toggle Constraints:</span><!--Do not edit span id: the Sketcher_CompToggleConstraints pages redirect here-->
 
-<!--T:76-->
 :* [[File:Sketcher_ToggleDrivingConstraint.svg|32px]] [[Sketcher_ToggleDrivingConstraint|Toggle Driving/Reference Constraints]]: Toggles the dimensional constraint creation tools between driving and reference mode, or toggles selected dimensional constraints between those modes.
 
-<!--T:124-->
 :* [[File:Sketcher_ToggleActiveConstraint.svg|32px]] [[Sketcher_ToggleActiveConstraint|Toggle Constraints]]: Activates or deactivates selected constraints.
 
-===Sketcher Tools=== <!--T:77-->
-
-<!--T:187-->
+===Sketcher Tools=== 
 * <span id="Sketcher_CompCreateFillets">[[Image:Sketcher_CreateFillet.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] Create Fillet/Chamfer:</span><!--Do not edit span id: the Sketcher_CompCreateFillets pages redirect here-->
 
-<!--T:51-->
 :* [[Image:Sketcher_CreateFillet.svg|32px]] [[Sketcher_CreateFillet|Fillet]]: Creates a fillet between two non-parallel edges. {{Version|1.0}}: The tool can also create a chamfer.
 
-<!--T:236-->
 :* [[Image:Sketcher_CreateChamfer.svg|32px]] [[Sketcher_CreateChamfer|Chamfer]]: creates a chamfer between two non-parallel edges. This is the same tool as [[Sketcher_CreateFillet|Fillet]] but with a different initial mode. {{Version|1.0}}
 
-<!--T:188-->
 * <span id="Sketcher_CompCurveEdition">[[Image:Sketcher_Trimming.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] Edit Edge:</span><!--Do not edit span id: the Sketcher_CompCurveEdition pages redirect here-->
 
-<!--T:52-->
 :* [[Image:Sketcher_Trimming.svg|32px]] [[Sketcher_Trimming|Trim Edge]]: Trims an edge at the nearest intersections with other edges.
 
-<!--T:134-->
 :* [[Image:Sketcher_Split.svg|32px]] [[Sketcher_Split|Split Edge]]: Splits an edge while transferring most constraints.
 
-<!--T:115-->
 :* [[File:Sketcher_Extend.svg|32px]] [[Sketcher_Extend|Extend Edge]]: Extends or shortens a line or an arc to an arbitrary location, or to a target edge or point.
 
-<!--T:255-->
 * <span id="Sketcher_CompExternal">[[Image:Sketcher_Projection.svg|32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] External Geometry:</span><!--Do not edit span id: the Sketcher_CompExternal pages redirect here-->
 
-<!--T:256-->
 :* [[Image:Sketcher_Projection.svg|32px]] [[Sketcher_Projection|External Projection]]: Creates the projection edges of external geometry. {{Version|1.1}} {{Version|1.2}}: Bezier curves and Offset curves are now also supported as external geometry.
 
-<!--T:257-->
 :* [[Image:Sketcher_Intersection.svg|32px]] [[Sketcher_Intersection|External Intersection]]: Creates the intersection edges of external geometry with the sketch plane. {{Version|1.1}} {{Version|1.2}}: Bezier curves and Offset curves are now also supported as external geometry.
 
-<!--T:116-->
 * [[File:Sketcher_CarbonCopy.svg|32px]] [[Sketcher_CarbonCopy|Carbon Copy]]: Copies all geometry and constraints from another sketch into the active sketch.
 
-<!--T:82-->
 * [[File:Sketcher_SelectOrigin.svg|32px]] [[Sketcher_SelectOrigin|Select Origin]]: Selects the origin of the sketch.
 
-<!--T:84-->
 * [[File:Sketcher_SelectHorizontalAxis.svg|32px]] [[Sketcher_SelectHorizontalAxis|Select Horizontal Axis]]: Selects the horizontal axis of the sketch.
 
-<!--T:83-->
 * [[File:Sketcher_SelectVerticalAxis.svg|32px]] [[Sketcher_SelectVerticalAxis|Select Vertical Axis]]: Selects the vertical axis of the sketch.
 
-<!--T:238-->
 * [[File:Sketcher_Translate.svg|32px]] [[Sketcher_Translate|Move/Array Transform]]: Moves or optionally creates copies of selected elements. {{Version|1.0}}
 
-<!--T:193-->
 * [[File:Sketcher_Rotate.svg|32px]] [[Sketcher_Rotate|Rotate/Polar Transform]]: Rotates or optionally creates rotated copies of selected elements. {{Version|1.0}}
 
-<!--T:237-->
 * [[File:Sketcher_Scale.svg|32px]] [[Sketcher_Scale|Scale]]: Scales or optionally creates scaled copies of selected elements. {{Version|1.0}}
 
-<!--T:179-->
 * [[File:Sketcher_Offset.svg|32px]] [[Sketcher_Offset|Offset]]: Creates equidistant edges around selected edges. {{Version|1.0}}
 
-<!--T:90-->
 * [[File:Sketcher_Symmetry.svg|32px]] [[Sketcher_Symmetry|Mirror]]: Creates mirrored copies of selected elements.
 
-<!--T:138-->
 * [[File:Sketcher_RemoveAxesAlignment.svg|32px]] [[Sketcher_RemoveAxesAlignment|Remove Axes Alignment]]: Removes the axes alignment of selected edges by replacing [[Sketcher_ConstrainHorizontal|horizontal]] and [[Sketcher_ConstrainVertical|vertical]] constraints with [[Sketcher_ConstrainParallel|parallel]] and [[Sketcher_ConstrainPerpendicular|perpendicular]] constraints.
 
-<!--T:95-->
 * [[File:Sketcher_DeleteAllGeometry.svg|32px]] [[Sketcher_DeleteAllGeometry|Delete All Geometry]]: Deletes all geometry and all constraints from the sketch.
 
-<!--T:96-->
 * [[File:Sketcher_DeleteAllConstraints.svg|32px]] [[Sketcher_DeleteAllConstraints|Delete All Constraints]]: Deletes all constraints from the sketch.
 
-<!--T:239-->
 * <span id="Sketcher_CopyClipboard">[[File:Edit-copy.svg|32px]] Copy Elements: See [[#Copy,_cut_and_paste|Copy, cut and paste]].</span><!--Do not edit span id: the Sketcher_CopyClipboard pages redirect here-->
 
-<!--T:240-->
 * <span id="Sketcher_Cut">[[File:Edit-cut.svg|32px]] Cut Elements: See [[#Copy,_cut_and_paste|Copy, cut and paste]].</span><!--Do not edit span id: the Sketcher_Cut pages redirect here-->
 
-<!--T:241-->
 * <span id="Sketcher_Paste">[[File:Edit-paste.svg|32px]] Paste Elements: See [[#Copy,_cut_and_paste|Copy, cut and paste]].</span><!--Do not edit span id: the Sketcher_Paste pages redirect here-->
 
-===B-Spline Tools=== <!--T:97-->
-
-<!--T:102-->
+===B-Spline Tools=== 
 * [[File:Sketcher_BSplineConvertToNURBS.svg|32px]] [[Sketcher_BSplineConvertToNURBS|Geometry to B-Spline]]: Converts edges to B-splines.
 
-<!--T:103-->
 * [[File:Sketcher_BSplineIncreaseDegree.svg|32px]] [[Sketcher_BSplineIncreaseDegree|Increase B-Spline Degree]]: Increases the degree (order) of B-splines.
 
-<!--T:128-->
 * [[File:Sketcher_BSplineDecreaseDegree.svg|32px]] [[Sketcher_BSplineDecreaseDegree|Decrease B-Spline Degree]]: Decreases the degree (order) of B-splines.
 
-<!--T:104-->
 * [[File:Sketcher_BSplineIncreaseKnotMultiplicity.svg|32px]] [[Sketcher_BSplineIncreaseKnotMultiplicity|Increase Knot Multiplicity]]: Increases the multiplicity of a B-spline knot.
 
-<!--T:105-->
 * [[File:Sketcher_BSplineDecreaseKnotMultiplicity.svg|32px]] [[Sketcher_BSplineDecreaseKnotMultiplicity|Decrease Knot Multiplicity]]: Decreases the multiplicity of a B-spline knot.
 
-<!--T:149-->
 * [[File:Sketcher_BSplineInsertKnot.svg|32px]] [[Sketcher_BSplineInsertKnot|Insert Knot]]: Inserts a knot into a B-spline or increases the multiplicity of an existing knot.
 
-<!--T:163-->
 * [[File:Sketcher_JoinCurves.svg|32px]] [[Sketcher_JoinCurves|Join Curves]]: Creates a B-spline by joining two existing B-splines or other edges.
 
-===Visual Helpers=== <!--T:194-->
-
-<!--T:78-->
+===Visual Helpers=== 
 * [[File:Sketcher_SelectElementsWithDoFs.svg|32px]] [[Sketcher_SelectElementsWithDoFs|Select Under-Constrained Elements]]: Selects the not fully constrained elements in the sketch.
 
-<!--T:81-->
 * [[File:Sketcher_SelectConstraints.svg|32px]] [[Sketcher_SelectConstraints|Select Associated Constraints]]: Selects the constraints associated with sketch elements.
 
-<!--T:87-->
 * [[File:Sketcher_SelectElementsAssociatedWithConstraints.svg|32px]] [[Sketcher_SelectElementsAssociatedWithConstraints|Select Associated Geometry]]: Selects the sketch elements associated with constraints.
 
-<!--T:85-->
 * [[File:Sketcher_SelectRedundantConstraints.svg|32px]] [[Sketcher_SelectRedundantConstraints|Select Redundant Constraints]]: Selects the redundant constraints in the sketch.
 
-<!--T:86-->
 * [[File:Sketcher_SelectConflictingConstraints.svg|32px]] [[Sketcher_SelectConflictingConstraints|Select Conflicting Constraints]]: Selects the conflicting constraints in the sketch.
 
-<!--T:195-->
 * [[File:Sketcher_ArcOverlay.svg|32px]] [[Sketcher_ArcOverlay|Toggle Circular Helper for Arcs]]: Shows or hides the circular helpers (underlying virtual circles) for arcs in all sketches. {{Version|1.0}}
 
-<!--T:254-->
 * <span id="Sketcher_CompBSplineShowHideGeometryInformation">[[Image:Sketcher_BSplinePolygon.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] Toggle B-Spline Information Layer:</span><!--Do not edit span id: the Sketcher_CompBSplineShowHideGeometryInformation pages redirect here-->
 
-<!--T:98-->
 :* [[File:Sketcher_BSplineDegree.svg|32px]] [[Sketcher_BSplineDegree|Toggle B-Spline Degree]]: Shows or hides the B-spline degree in all sketches.
 
-<!--T:99-->
 :* [[File:Sketcher_BSplinePolygon.svg|32px]] [[Sketcher_BSplinePolygon|Toggle B-Spline Control Polygon]]: Shows or hides the B-spline control polygon in all sketches.
 
-<!--T:100-->
 :* [[File:Sketcher_BSplineComb.svg|32px]] [[Sketcher_BSplineComb|Toggle B-Spline Curvature Comb]]: Shows or hides the B-spline curvature comb in all sketches.
 
-<!--T:101-->
 :* [[File:Sketcher_BSplineKnotMultiplicity.svg|32px]] [[Sketcher_BSplineKnotMultiplicity|Toggle B-Spline Knot Multiplicity]]: Shows or hides the B-spline knot multiplicity in all sketches.
 
-<!--T:129-->
 :* [[File:Sketcher_BSplinePoleWeight.svg|32px]] [[Sketcher_BSplinePoleWeight|Toggle B-Spline Control Point Weight]]: Shows or hides the B-spline control point weight in all sketches.
 
-<!--T:89-->
 * [[File:Sketcher_RestoreInternalAlignmentGeometry.svg|32px]] [[Sketcher_RestoreInternalAlignmentGeometry|Toggle Internal Geometry]]: Deletes the internal geometry of elements, or recreates missing internal geometry.
 
-<!--T:107-->
 * [[File:Sketcher_SwitchVirtualSpace.svg|32px]] [[Sketcher_SwitchVirtualSpace|Switch Virtual Space]]: (un)hides constraints or switches the visible virtual space.
 
-===Obsolete tools=== <!--T:173-->
-
-<!--T:91-->
+===Obsolete tools=== 
 * [[File:Sketcher_Clone.svg|32px]] [[Sketcher_Clone|Clone]]: Clones a Sketcher element. Not available in {{VersionPlus|1.0}}.
 
-<!--T:79-->
 * [[File:Sketcher_CloseShape.svg|32px]] [[Sketcher_CloseShape|Close shape]]: Creates a closed shape by applying coincident constraints to endpoints. Not available in {{VersionPlus|0.21}}.
 
-<!--T:162-->
 * [[File:Sketcher_CreatePointFillet.svg|32px]] [[Sketcher_CreatePointFillet|Corner-preserving fillet]]: Creates a fillet between two non-parallel lines while preserving their corner point. Not available in {{VersionPlus|1.0}}.
 
-<!--T:80-->
 * [[File:Sketcher_ConnectLines.svg|32px]] [[Sketcher_ConnectLines|Connect edges]]: Connect Sketcher elements by applying coincident constraints to endpoints. Not available in {{VersionPlus|0.21}}.
 
-<!--T:92-->
 * [[File:Sketcher_Copy.svg|32px]] [[Sketcher_Copy|Copy]]: Copies a Sketcher element. Not available in {{VersionPlus|1.0}}.
 
-<!--T:53-->
 * [[Image:Sketcher_External.svg|32px]] [[Sketcher_External|External geometry]]: Projects edges and/or vertices belonging to objects outside the sketch onto the sketch plane. Not available in {{VersionPlus|1.1}}.
 
-<!--T:93-->
 * [[File:Sketcher_Move.svg|32px]] [[Sketcher_Move|Move]]: Moves the selected geometry taking as reference the last selected point. Not available in {{VersionPlus|1.0}}.
 
-<!--T:94-->
 * [[File:Sketcher_RectangularArray.svg|32px]] [[Sketcher_RectangularArray|Rectangular array]]: Creates an array of selected Sketcher elements. Not available in {{VersionPlus|1.0}}.
 
-== Preferences == <!--T:108-->
-
-<!--T:109-->
+== Preferences == 
 * [[Image:Workbench_Sketcher.svg|32px]] [[Sketcher_Preferences|Preferences]]: Preferences for the Sketcher Workbench.
 
-<!--T:277-->
 {{Version|1.2}}: The following preferences have been added:
 * '''Grid transparency''' - Sets the transparency level of the sketch grid (default: 60%).
 * '''Label font face''' - Makes the font face used in constraint labels configurable.
 * '''Constraint type in list''' - Shows the constraint type in the Sketcher Dialog constraint list.
 
-== Drawing aids == <!--T:211-->
-
-<!--T:212-->
+== Drawing aids == 
 The Sketcher Workbench has several drawing aids and other features that can help when creating geometry and applying constraints.
 
-=== Continue modes === <!--T:213-->
-
-<!--T:214-->
+=== Continue modes === 
 There are two continue modes: '''Geometry creation "Continue Mode"''' and '''Constraint creation "Continue Mode"'''. If these are checked (default) in the [[Sketcher_Preferences#Display|preferences]], related tools will restart after finishing. To exit a continuous tool press {{KEY|Esc}} or the right mouse button. This must be repeated if a continuous geometry tool has already received input. You can also exit a continuous tool by starting another geometry or constraint creation tool. Note that pressing {{KEY|Esc}} if no tool is active will exit sketch edit mode. Uncheck the '''Esc key can leave sketch edit mode''' [[Sketcher_Preferences#General|preference]] if you often inadvertently press {{KEY|Esc}} too many times.
 
-=== Auto constraints === <!--T:215-->
-
-<!--T:216-->
+=== Auto constraints === 
 In sketches that have '''Auto constraints''' checked (default) several constraints are applied automatically. The icon of a proposed automatic constraint is shown next to the cursor when it is placed correctly. Left-clicking will then apply that constraint. This is a per-sketch setting that can be changed in the [[Sketcher_Dialog#Constraints|Sketcher Dialog]] or by changing the {{PropertyView|Autoconstraints}} [[Property_View|property]] of the sketch.
 
-<!--T:242-->
 The following constraints are applied automatically:
 * [[Image:Sketcher_ConstrainCoincident.svg|16px]] [[Sketcher_ConstrainCoincident|Coincident]]
 * [[Image:Sketcher_ConstrainPointOnObject.svg|16px]] [[Sketcher_ConstrainPointOnObject|Point-on-object]]
@@ -567,105 +375,69 @@ The following constraints are applied automatically:
 * [[Image:Sketcher_ConstrainTangent.svg|16px]] [[Sketcher_ConstrainTangent|Tangent]]
 * {{Version|1.0}}: [[Image:Sketcher_ConstrainSymmetric.svg|16px]] [[Sketcher_ConstrainSymmetric|Symmetric]] (line midpoint)
 
-=== Snapping === <!--T:217-->
-
-<!--T:218-->
+=== Snapping === 
 {{Version|0.21}}
 
-<!--T:219-->
 It is possible to [[Sketcher_Grid|snap to grid lines and grid intersection]], and to [[Sketcher_Snap|snap to edges of geometry and midpoints of lines and arcs, and to certain angles]]. Please note that snapping does not produce constraints in and of itself. For example, only if [[#Auto_constraints|Auto constraints]] is switched on will snapping to an edge produce a [[Sketcher_ConstrainPointOnObject|point-on-object constraint]]. But just picking a point on the edge would then have the same result.
 
-=== On-View-Parameters === <!--T:220-->
-
-<!--T:221-->
+=== On-View-Parameters === 
 {{Version|1.0}}
 
-<!--T:222-->
 Depending on the selected option in the [[Sketcher_Preferences#General|preferences]] only the dimensional On-View-Parameters or both the dimensional and the positional On-View-Parameters can be enabled. Positional parameters allow the input of exact coordinates, for example the center of a circle, or the start point of a line. Dimensional parameters allow the input of exact dimensions, for example the radius of a circle, or the length and angle of a line. On-View-Parameters are not available for all tools.
 
-</translate>
 [[Image:Sketcher_On_view_parameters_positional.png]]
-<translate>
-<!--T:223-->
+
 {{Caption|Determining the center point of a circle with the positional parameters enabled}}
 
-</translate>
 [[Image:Sketcher_On_view_parameters_dimensional.png]]
-<translate>
-<!--T:224-->
+
 {{Caption|Determining the radius of a circle with the dimensional parameters enabled}}
 
-<!--T:225-->
 If values are entered and confirmed by pressing {{KEY|Enter}} or {{KEY|Tab}}, related constraints are added automatically. If two parameters are displayed at the same time, for example the X- and Y-coordinate of a point, it is possible to enter one value and pick a point to define the other. Depending on the object additional constraints may be required to fully constrain it. Constraints resulting from On-View-Parameters take precedence over those that may result from [[Sketcher_Dialog#Constraints|Auto constraints]].
 
-</translate>
 [[Image:Sketcher_ArcExample3.png|300px]]
-<translate>
-<!--T:226-->
+
 {{Caption|Arc created by entering all On-View-Parameters with resulting automatically created constraints}}
 
-=== Coordinate display === <!--T:227-->
-
-<!--T:228-->
+=== Coordinate display === 
 If the '''Show coordinates next to the cursor while editing''' [[Sketcher_Preferences#Display|preference]] is checked (default), the parameters of the current geometry tool (coordinates, radius, or length and angle) are displayed next to the cursor. This is deactivated while On-View-Parameters are shown.
 
-== Selection methods == <!--T:229-->
-
-<!--T:230-->
+== Selection methods == 
 While a sketch is in edit mode the following selection methods can be used:
 
-=== 3D View element selection === <!--T:243-->
-
-<!--T:244-->
+=== 3D View element selection === 
 As elsewhere in FreeCAD, an element can be selected in the [[3D_View|3D View]] with a single left mouse click. But there is no need to hold down the {{KEY|Ctrl}} key when selecting multiple elements. Holding down that key is possible though and has the advantage that you can miss-click without losing the selection. Edges, points and constraints can be selected in this manner.
 
-=== 3D View box selection === <!--T:231-->
-
-<!--T:245-->
+=== 3D View box selection === 
 Box selection in the 3D View works without using [[Std_BoxSelection|Std BoxSelection]] or [[Std_BoxElementSelection|Std BoxElementSelection]]:
 # Make sure that no tool is active.
 # Do one of the following:
 #* Click in an empty area and drag a rectangle from left to right to select elements that lie completely inside the rectangle.
 #* Click in an empty area and drag a rectangle from right to left to also select elements that touch or cross the rectangle.
 
-<!--T:246-->
 You can box-select edges and points, constraints cannot be box-selected. {{Version|1.2}}: [[Part_SelectFilter|Selection filters]] are taken into account.
 
-=== 3D View connected geometry selection === <!--T:232-->
-
-<!--T:247-->
+=== 3D View connected geometry selection === 
 {{Version|1.0}}
 
-<!--T:248-->
 Double-clicking an edge in the 3D View will select all edges directly and indirectly connected with that edge via endpoints. There is no need for the edges to be connected with [[Sketcher_ConstrainCoincident|coincident constraints]], endpoints need only have the same coordinates.
 
-=== Sketcher Dialog selection === <!--T:249-->
-
-<!--T:250-->
+=== Sketcher Dialog selection === 
 Edges and points can also be selected from the Elements section of the [[Sketcher_Dialog|Sketcher Dialog]], and constraints from the Constraints section of that dialog.
 
-=== Select All shortcut === <!--T:271-->
-
-<!--T:272-->
+=== Select All shortcut === 
 {{Version|1.1}}
 
-<!--T:273-->
 To select everything within a sketch, use the standard keyboard shortcut {{KEY|Ctrl}}+{{KEY|A}} or the {{MenuCommand|Edit → Select All}} option from the menu.
 
-== Copy, cut and paste == <!--T:233-->
-
-<!--T:234-->
+== Copy, cut and paste == 
 {{Version|1.0}}
 
-<!--T:235-->
 The standard keyboard shortcuts, {{KEY|Ctrl}}+{{KEY|C}}, {{KEY|Ctrl}}+{{KEY|X}} and {{KEY|Ctrl}}+{{KEY|V}}, can be used to copy, cut and paste selected Sketcher geometry including related constraints. But these tools are also available from the {{MenuCommand|Sketch → Sketcher Tools}} menu. They can be used within the same sketch but also between different sketches or separate instances of FreeCAD. Since the data is copied to the clipboard in the form of Python code, it can be used in other ways too (e.g. shared on the forum).
 
-== Best practices == <!--T:148-->
-
-<!--T:14-->
+== Best practices == 
 Every CAD user develops their own way of working over time, but there are some useful general principles to follow.
 
-<!--T:15-->
 * A series of simple sketches is easier to manage than a single complex one. For example, a first sketch can be created for the base 3D feature (a pad or a revolve for example), while a second one can contain holes or cutouts (pockets). Some details can be left out, to be realized later on as 3D features. You can choose to avoid fillets in your sketch if there are too many, and add them as a 3D feature.
 * Always create a closed profile, or your sketch won't produce a solid, but rather a set of open faces. If you don't want some of the objects to be included in the solid creation, turn them to construction elements with the [[Sketcher_ToggleConstruction|Toggle Construction Geometry]] tool.
 * Use the Auto constraints feature to limit the number of constraints you'll have to add manually.
@@ -675,72 +447,47 @@ Every CAD user develops their own way of working over time, but there are some u
 * In general, the best constraints to use are: horizontal and vertical constraints; horizontal and vertical dimensions; point-to-point tangent constraints. If possible, limit the use of these: distance dimension; edge-to-edge tangent constraint; point-on-object constraint; symmetric constraint.
 * If in doubt about the validity of a sketch once it is complete (features turn green), close the Sketcher Dialog and use [[File:Sketcher_ValidateSketch.svg|24px]] [[Sketcher_ValidateSketch|Validate Sketch]].
 
-== Flipping == <!--T:258-->
-
-<!--T:259-->
+== Flipping == 
 The phenomenon that a fully constrained sketch, usually after a major change to one of its dimensions, reaches an unintended new state is know as "flipping". In the example below, changing one dimension completely changes the shape of the sketch. Note that the sketch with the new shape is still fully constrained.
 
-</translate>
 [[File:Sketcher_Flipping_Equal_Constraints.png|300px]] [[File:Sketcher_Flipping_Equal_Constraints_Flipped.png|300px]]
-<translate>
-<!--T:260-->
+
 {{Caption|Original sketch (left), and the same sketch after increasing the 20mm value to 1000mm (right)}}
 
-=== Methods to reduce flipping === <!--T:261-->
-
-==== Change dimensions in small increments ==== <!--T:262-->
-
-<!--T:263-->
+=== Methods to reduce flipping === 
+==== Change dimensions in small increments ==== 
 This is not always practical, but changing dimension values in smaller increments can work.
 
-==== Use a different solver ==== <!--T:264-->
-
-<!--T:265-->
+==== Use a different solver ==== 
 The LevenbergMarquardt solver, which is not the default solver, is known to be less prone to flipping. See [[Sketcher_Dialog#Advanced_solver_control|Sketcher Dialog]] for more information.
 
-==== Use horizontal and vertical dimensions ==== <!--T:266-->
+==== Use horizontal and vertical dimensions ==== 
 
-</translate>
 [[File:Sketcher_Flipping_HorVer_Dimensions.png|300px]]
-<translate>
 
-<!--T:267-->
 Using [[Sketcher_ConstrainDistanceX|horizontal]] and [[Sketcher_ConstrainDistanceY|vertical dimensions]] instead of [[Sketcher_ConstrainDistance|distance dimensions]] or [[Sketcher_ConstrainEqual|equal constraints]] can prevent flipping. Points constrained by these dimensions will only switch places if the sign of their value is changed. In the image above the added (orange) dimensional constraints are linked to the original dimensions via [[Expressions|expressions]].
 
-==== Use angle dimensions ==== <!--T:268-->
+==== Use angle dimensions ==== 
 
-</translate>
 [[File:Sketcher_Flipping_Angular_Dimensions.png|300px]]
-<translate>
 
-<!--T:269-->
 Using [[Sketcher_ConstrainAngle|angle dimensions]] instead of [[Sketcher_ConstrainHorizontal|horizontal]] and [[Sketcher_ConstrainVertical|vertical]] constraints can also work. The angle between edges constrained by angle dimensions will not change. 180° will not become 0°, 90° will not become 270°, etc. In the image all horizontal and vertical constraints have been replaced, but just replacing two is already effective here.
 
-== Tutorials == <!--T:19-->
-
-<!--T:121-->
+== Tutorials == 
 * [https://forum.freecad.org/viewtopic.php?f=36&t=30104 Sketcher Lecture] by chrisb. This is a more than 80 page PDF document that serves as a detailed manual for the Sketcher. It explains the basics of Sketcher usage, and goes into a lot of detail about the creation of geometrical shapes, and each of the constraints.
 * [[Basic_Sketcher_Tutorial|Basic Sketcher Tutorial]] for beginners
 * [[Sketcher_Micro_Tutorial_-_Constraint_Practices|Sketcher Micro Tutorial - Constraint Practices]]
 * [[Sketcher_requirement_for_a_sketch|Sketcher requirement for a sketch]] Minimum requirement for a sketch and Complete determination of a sketch
 
-== Scripting == <!--T:132-->
-
-<!--T:133-->
+== Scripting == 
 The [[Sketcher_scripting|Sketcher scripting]] page contains examples on how to create constraints from Python scripts.
 
-== Examples == <!--T:171-->
-
-<!--T:172-->
+== Examples == 
 For some ideas of what can be achieved with Sketcher tools, have a look at: [[Sketcher_Examples|Sketcher Examples]].
 
-</translate>
 [[Image:Sketcher_ExampleHinge-01.gif|80px|link=]]
 [[Image:Sketcher ExampleHinge-15.png|90px|link=]]
-<translate>
 
-
-<!--T:18-->
 {{Docnav
 |[[Robot_Workbench|Robot Workbench]]
 |[[Spreadsheet_Workbench|Spreadsheet Workbench]]
@@ -748,7 +495,6 @@ For some ideas of what can be achieved with Sketcher tools, have a look at: [[Sk
 |IconR=Workbench_Spreadsheet.svg
 }}
 
-</translate>
 {{Sketcher_Tools_navi{{#translation:}}}}
 {{Userdocnavi{{#translation:}}}}
 [[Category:Workbenches{{#translation:}}]]

--- a/wiki/Sketcher_Workbench.wikitext
+++ b/wiki/Sketcher_Workbench.wikitext
@@ -127,7 +127,7 @@ If a sketch is in edit mode the Structure toolbar is hidden as none of its tools
 * [[File:Sketcher_ValidateSketch.svg|32px]] [[Sketcher_ValidateSketch|Validate Sketch]]: Can analyze and repair a sketch that is no longer editable or has invalid constraints, or add missing coincident constraints.
 
 <!--T:31-->
-* [[Image:Sketcher_MergeSketches.svg|32px]] [[Sketcher_MergeSketches|Merge Sketches]]: Merges two or more sketches.
+* [[Image:Sketcher_MergeSketches.svg|32px]] [[Sketcher_MergeSketches|Merge Sketches]]: Merges two or more sketches. {{Version|1.2}}: The tool now supports importing external geometry, improves constraint remapping, and creates the merged sketch inside the Body when all source sketches share the same Body.
 
 <!--T:32-->
 * [[Image:Sketcher_MirrorSketch.svg|32px]] [[Sketcher_MirrorSketch|Mirror Sketch]]: Mirrors sketches across their X-axis, Y-axis, or origin.
@@ -152,7 +152,7 @@ If a sketch is in edit mode the Structure toolbar is hidden as none of its tools
 * [[File:Sketcher_StopOperation.svg|32px]] [[Sketcher_StopOperation|Stop Operation]]: Stops any currently running geometry or constraint creation tool.
 
 <!--T:166-->
-* [[Sketcher_Grid|Grid]]: Grid settings can be changed in the menu of the [[Sketcher_Dialog#Sketch_Edit|Sketch Edit section of the Sketcher Dialog]].
+* [[Sketcher_Grid|Grid]]: Grid settings can be changed in the menu of the [[Sketcher_Dialog#Sketch_Edit|Sketch Edit section of the Sketcher Dialog]]. {{Version|1.2}}: A grid transparency preference has been added.
 
 <!--T:167-->
 * [[Sketcher_Snap|Snap]]: Snap settings can be changed in the same menu.
@@ -169,7 +169,7 @@ These are tools for creating objects.
 * [[Image:Sketcher_CreatePoint.svg|32px]] [[Sketcher_CreatePoint|Point]]: Creates a point.
 
 <!--T:42-->
-* [[Image:Sketcher_CreatePolyline.svg|32px]] [[Sketcher_CreatePolyline|Polyline]]: Creates a series of line and arc segments connected by their endpoints. The tool has several modes.
+* [[Image:Sketcher_CreatePolyline.svg|32px]] [[Sketcher_CreatePolyline|Polyline]]: Creates a series of line and arc segments connected by their endpoints. The tool has several modes. {{Version|1.2}}: An improved version of the tool adds auto-constraints such as tangent, parallel and perpendicular.
 
 <!--T:36-->
 * [[Image:Sketcher_CreateLine.svg|32px]] [[Sketcher_CreateLine|Line]]: Creates a line. {{Version|1.0}}: The tool has three modes.
@@ -342,7 +342,7 @@ These are tools for creating [[#Constraints|constraints]]. Some constraints requ
 * [[File:Sketcher_ConstrainEqual.svg|32px]] [[Sketcher_ConstrainEqual|Equal Constraint]]: Constrains edges to have an equal length (lines) or curvature (other edges except B-splines).
 
 <!--T:66-->
-* [[File:Sketcher_ConstrainSymmetric.svg|32px]] [[Sketcher_ConstrainSymmetric|Symmetric Constraint]]: Constrains two points to be symmetrical around a line or axis, or around a third point.
+* [[File:Sketcher_ConstrainSymmetric.svg|32px]] [[Sketcher_ConstrainSymmetric|Symmetric Constraint]]: Constrains two points to be symmetrical around a line or axis, or around a third point. {{Version|1.2}}: A fourth option was added: selecting an entire edge (line, arc, or open B-spline) and a symmetry line.
 
 <!--T:67-->
 * [[Image:Sketcher_ConstrainBlock.svg|32px]] [[Sketcher_ConstrainBlock|Block Constraint]]: Blocks edges in place with a single constraint. It is mainly intended for B-splines.
@@ -389,10 +389,10 @@ These are tools for creating [[#Constraints|constraints]]. Some constraints requ
 * <span id="Sketcher_CompExternal">[[Image:Sketcher_Projection.svg|32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] External Geometry:</span><!--Do not edit span id: the Sketcher_CompExternal pages redirect here-->
 
 <!--T:256-->
-:* [[Image:Sketcher_Projection.svg|32px]] [[Sketcher_Projection|External Projection]]: Creates the projection edges of external geometry. {{Version|1.1}}
+:* [[Image:Sketcher_Projection.svg|32px]] [[Sketcher_Projection|External Projection]]: Creates the projection edges of external geometry. {{Version|1.1}} {{Version|1.2}}: Bezier curves and Offset curves are now also supported as external geometry.
 
 <!--T:257-->
-:* [[Image:Sketcher_Intersection.svg|32px]] [[Sketcher_Intersection|External Intersection]]: Creates the intersection edges of external geometry with the sketch plane. {{Version|1.1}}
+:* [[Image:Sketcher_Intersection.svg|32px]] [[Sketcher_Intersection|External Intersection]]: Creates the intersection edges of external geometry with the sketch plane. {{Version|1.1}} {{Version|1.2}}: Bezier curves and Offset curves are now also supported as external geometry.
 
 <!--T:116-->
 * [[File:Sketcher_CarbonCopy.svg|32px]] [[Sketcher_CarbonCopy|Carbon Copy]]: Copies all geometry and constraints from another sketch into the active sketch.
@@ -536,6 +536,12 @@ These are tools for creating [[#Constraints|constraints]]. Some constraints requ
 
 <!--T:109-->
 * [[Image:Workbench_Sketcher.svg|32px]] [[Sketcher_Preferences|Preferences]]: Preferences for the Sketcher Workbench.
+
+<!--T:277-->
+{{Version|1.2}}: The following preferences have been added:
+* '''Grid transparency''' - Sets the transparency level of the sketch grid (default: 60%).
+* '''Label font face''' - Makes the font face used in constraint labels configurable.
+* '''Constraint type in list''' - Shows the constraint type in the Sketcher Dialog constraint list.
 
 == Drawing aids == <!--T:211-->
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -46,6 +46,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Std_VarSet|VarSet]] ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 * There is now a warning when saving files created in older versions. A preference was added to allow disabling it. [https://github.com/FreeCAD/FreeCAD/pull/28389 Pull request #28389]
 * Clearing the recent files list now asks for confirmation before the list is removed. [https://github.com/FreeCAD/FreeCAD/pull/27274 Pull request #27274]
+* The notification area unread count is now initialized on startup, showing the correct count from the beginning. [https://github.com/FreeCAD/FreeCAD/pull/29391 Pull request #29391]
 
 == Core system and API ==
 
@@ -94,7 +95,9 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * On Unix-like systems, lock files now use owner-only permissions, and Coin image export avoids creating world-writable files. [https://github.com/FreeCAD/FreeCAD/pull/30239 Pull request #30239]
 * The Conda release build preset now enables {{Incode|FREECAD_WARN_ERROR}}, and related warnings were fixed so release CI catches new compiler warnings earlier. [https://github.com/FreeCAD/FreeCAD/pull/30228 Pull request #30228]
 * The [[Image:Std_TransformManip.svg|24px]] [[Std TransformManip|Transform]] tool can now use the ''Center of mass / centroid'' mode with [[App_Link|Links]] and [[Std_Part|Part containers]]. [https://github.com/FreeCAD/FreeCAD/pull/30208 Pull request #30208]
+* The placement of Part origins is now read-only and can no longer be changed by accident. [https://github.com/FreeCAD/FreeCAD/pull/28076 Pull request #28076]
 * Toponaming support was improved for the Python API so that add-ons can be more stable in terms of [[Topological_naming_problem|TNP]]. [https://github.com/FreeCAD/FreeCAD/pull/24632 Pull request #24632]
+* The [[Image:Std_MassProperties.svg|24px]] [[Std_MassProperties|Mass Properties]] view provider now shows icons at the center of gravity and center of volume, making them easier to locate in the 3D view. [https://github.com/FreeCAD/FreeCAD/pull/29288 Pull request #29288]
 
 === API ===
 
@@ -125,6 +128,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Editing sketches from assemblies no longer briefly activates the sketch's source document or crashes when leaving the Assembly context. [https://github.com/FreeCAD/FreeCAD/pull/29271 Pull request #29271]
 * [[Assembly_CreateSimulation|Simulations]] now offer export to video format. [https://github.com/FreeCAD/FreeCAD/pull/25307 Pull request #25307]
 * [[Assembly_CreateView|Exploded View]] can now be created temporarily. [https://github.com/FreeCAD/FreeCAD/pull/25456 Pull request #25456]
+* The [[Assembly_CreateSimulation|Simulation]] playback buttons have been made bigger and more visually distinct. [https://github.com/FreeCAD/FreeCAD/pull/30257 Pull request #30257]
 
 == BIM Workbench ==
 
@@ -132,7 +136,7 @@ ToDo (last check: 20260430, #27222):
 * https://github.com/FreeCAD/FreeCAD/pull/24078
 * https://github.com/FreeCAD/FreeCAD/pull/24190
 * https://github.com/FreeCAD/FreeCAD/pull/27222
-* https://github.com/FreeCAD/FreeCAD/pull/28504
+* [[Arch_Site|Site]] objects now have a dedicated task panel with sections for Location, Shape, Terrain and Metadata, making site editing more user-friendly. [https://github.com/FreeCAD/FreeCAD/pull/28504 Pull request #28504]
 * Removing a wall base now preserves the wall's placement and parametric dimensions for supported straight Draft or Sketch bases, and warns before removing unsupported complex bases. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
 * [[Arch_Wall|Walls]] can now be created without a base object by default, with the selected wall baseline mode remembered in preferences. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]
 * The BIM Project command was removed from the toolbar, moved to the Utils menu, renamed for IFC-project clarity, and the Setup Project dialog now defaults to non-IFC-native projects. [https://github.com/FreeCAD/FreeCAD/pull/25086 Pull request #25086]
@@ -151,6 +155,7 @@ ToDo (last check: 20260430, #27222):
 * [[BIM_DrawingView|DrawingView]] cut lines now use the default line width and cut areas line thickness ratio preferences for thicker cut-line output. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]
 * IFC import now treats a multicore preference value of 0 as disabled before creating the IfcOpenShell geometry iterator, avoiding invalid worker counts when multicore processing is turned off. [https://github.com/FreeCAD/FreeCAD/pull/30201 Pull request #30201]
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
+* The endpoints of walls without a base object can now be edited in [[Draft_Workbench|Draft]], allowing interactive wall reshaping in plan view. [https://github.com/FreeCAD/FreeCAD/pull/29860 Pull request #29860]
 
 == CAM Workbench ==
 
@@ -222,6 +227,10 @@ ToDo (last check: 20260430, #27222):
 * CAM drilling cycle expansion now uses MachineState for more accurate machine state tracking while expanding drilling cycles. [https://github.com/FreeCAD/FreeCAD/pull/30112 Pull request #30112]
 * The [[CAM_Profile|Profile]] and [[CAM_Pocket_Shape|Pocket]] linking options now include collision-avoidance strategies for using retract height, clearance height, line-of-sight checks, tool diameter, or tool shape. [https://github.com/FreeCAD/FreeCAD/pull/29983 Pull request #29983]
 # The Linking generator was added to the [[CAM_Engrave|Engrave]] and [[CAM_Deburr|Deburr]] operations to use the safe height instead of clearance height for linking moves. The Linking Mode and Safety Margin options were added to the task panels, also for [[CAM_Drilling|Drilling]] and [[CAM_Helix|Helix]] operations. [https://github.com/FreeCAD/FreeCAD/pull/29959 Pull request #29959]
+* The [[CAM_LeadInOut|LeadInOut]] dressup now supports ExtendLeadIn and ExtendLeadOut properties for the Arc, Line, Perpendicular and Tangent styles. [https://github.com/FreeCAD/FreeCAD/pull/29061 Pull request #29061]
+* The Spiral generator now validates G-code output with deviation-based testing instead of exact string comparisons. [https://github.com/FreeCAD/FreeCAD/pull/28596 Pull request #28596]
+* A tolerance parameter was added to the Linking generator collision check, making it possible to adjust collision detection sensitivity. [https://github.com/FreeCAD/FreeCAD/pull/28140 Pull request #28140]
+* Several fixes were applied to machine-based postprocessing, improving G-code output for different machine configurations. [https://github.com/FreeCAD/FreeCAD/pull/28563 Pull request #28563]
 
 == Draft Workbench ==
 
@@ -239,6 +248,10 @@ ToDo (last check: 20260430, #29258):
 === Further Draft improvements ===
 
 * [[Draft_Trimex|Trimex]] now reports unsupported sketch selections before opening the task panel, avoiding a misleading no-op workflow. [https://github.com/FreeCAD/FreeCAD/pull/29845 Pull request #29845]
+* Hints were added for the Draft annotation tools (Dimension, Label, ShapeString, etc.), describing available modifiers and keyboard shortcuts in the task panel. [https://github.com/FreeCAD/FreeCAD/pull/29649 Pull request #29649]
+* [[Draft_PolarArray|Polar]] and [[Draft_CircularArray|Circular Array]] now respect the active working plane, making them usable in 3D workflows with custom work planes. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
+* UTF-16 encoded SVG files (e.g., generated by Corel Draw on Windows) can now be imported. [https://github.com/FreeCAD/FreeCAD/pull/29244 Pull request #29244]
+* When saving [[Draft_AnnotationStyleEditor|Annotation Styles]], the file extension is now automatically ensured. [https://github.com/FreeCAD/FreeCAD/pull/30358 Pull request #30358]
 
 == FEM Workbench ==
 
@@ -323,6 +336,7 @@ ToDo (last check: 20260430, #29258):
 * Extruding text sketches in the Part Workbench is now faster, especially for sketches that produce many wires. [https://github.com/FreeCAD/FreeCAD/pull/28344 Pull request #28344]
 * The attachment system now correctly offers modes such as ''XY parallel to Plane'' when selecting origin datum planes through an Origin object. [https://github.com/FreeCAD/FreeCAD/pull/28958 Pull request #28958]
 * [[Part_Loft|Loft]] creation now allows valid profile combinations that share the same center of gravity while still guarding against the crash case fixed for duplicate profiles. [https://github.com/FreeCAD/FreeCAD/pull/29982 Pull request #29982]
+* Input hints were added for the [[Part_EditAttachment|Attachment]] dialog, showing key bindings for toggling through attachment modes and confirming selections. [https://github.com/FreeCAD/FreeCAD/pull/29614 Pull request #29614]
 
 == Part Design Workbench ==
 
@@ -365,6 +379,7 @@ ToDo (last check: 20260430, #29258):
 
 === Further Points improvements ===
 
+* The Points Workbench now uses modern libE57 types, following the update of the internal libE57 copy. [https://github.com/FreeCAD/FreeCAD/pull/27434 Pull request #27434]
 == Reverse Engineering Workbench ==
 
 === Further Reverse Engineering improvements ===
@@ -425,6 +440,12 @@ ToDo (last check: 20260430, #29258):
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 * Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
+* The [[Image:Sketcher_CreateLine.svg|24px]] [[Sketcher_CreateLine|Line]] and [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|Polyline]] tools are now grouped by default. A preference allows separating them. [https://github.com/FreeCAD/FreeCAD/pull/30347 Pull request #30347]
+* The new polyline tool uses the original {{KEY|G}}, {{KEY|M}} shortcut. [https://github.com/FreeCAD/FreeCAD/pull/30395 Pull request #30395]
+* Hints were re-added for the polyline tool, describing how to switch between line, arc, and tangent modes. [https://github.com/FreeCAD/FreeCAD/pull/30344 Pull request #30344]
+* When long-pressing an edge shared by two internal faces, the clarify selection menu now lists both adjacent faces. [https://github.com/FreeCAD/FreeCAD/pull/29159 Pull request #29159]
+* Internally-aligned B-spline geometry (weight circles, control polygon edges) is now skipped when using the [[Image:Sketcher_ToggleConstruction.svg|24px]] [[Sketcher_ToggleConstruction|Toggle Construction Geometry]] tool, instead of producing an error. [https://github.com/FreeCAD/FreeCAD/pull/28081 Pull request #28081]
+* The [[Image:Sketcher_ConstrainDistance.svg|24px]] [[Sketcher_ConstrainDistance|Dimension]] tool no longer switches the distance type to ''Horizontal'' or ''Vertical'' when an existing horizontal or vertical dimension is selected. [https://github.com/FreeCAD/FreeCAD/pull/28242 Pull request #28242]
 
 == Spreadsheet Workbench ==
 
@@ -457,6 +478,7 @@ ToDo (last check: 20260430, #29258):
 * The default TechDraw page color in the FreeCAD Light preference pack is now white, avoiding gray page backgrounds when printing. [https://github.com/FreeCAD/FreeCAD/pull/30129 Pull request #30129]
 * The task panel of the [[TechDraw_Balloon|Balloon Annotation]] tool was polished. [https://github.com/FreeCAD/FreeCAD/pull/28101 Pull request #28101]
 * The ASME ANSIB TechDraw template now has a transparent background, matching the other drawing templates. [https://github.com/FreeCAD/FreeCAD/pull/30025 Pull request #30025]
+* [[TechDraw_Workbench|TechDraw]] now supports horizontal and vertical dimensions between circle edges (instead of always falling back to a Distance dimension). [https://github.com/FreeCAD/FreeCAD/pull/30379 Pull request #30379]
 
 == Import and export ==
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -46,7 +46,6 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Std_VarSet|VarSet]] ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 * There is now a warning when saving files created in older versions. A preference was added to allow disabling it. [https://github.com/FreeCAD/FreeCAD/pull/28389 Pull request #28389]
 * Clearing the recent files list now asks for confirmation before the list is removed. [https://github.com/FreeCAD/FreeCAD/pull/27274 Pull request #27274]
-* The notification area unread count is now initialized on startup, showing the correct count from the beginning. [https://github.com/FreeCAD/FreeCAD/pull/29391 Pull request #29391]
 
 == Core system and API ==
 
@@ -95,9 +94,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * On Unix-like systems, lock files now use owner-only permissions, and Coin image export avoids creating world-writable files. [https://github.com/FreeCAD/FreeCAD/pull/30239 Pull request #30239]
 * The Conda release build preset now enables {{Incode|FREECAD_WARN_ERROR}}, and related warnings were fixed so release CI catches new compiler warnings earlier. [https://github.com/FreeCAD/FreeCAD/pull/30228 Pull request #30228]
 * The [[Image:Std_TransformManip.svg|24px]] [[Std TransformManip|Transform]] tool can now use the ''Center of mass / centroid'' mode with [[App_Link|Links]] and [[Std_Part|Part containers]]. [https://github.com/FreeCAD/FreeCAD/pull/30208 Pull request #30208]
-* The placement of Part origins is now read-only and can no longer be changed by accident. [https://github.com/FreeCAD/FreeCAD/pull/28076 Pull request #28076]
 * Toponaming support was improved for the Python API so that add-ons can be more stable in terms of [[Topological_naming_problem|TNP]]. [https://github.com/FreeCAD/FreeCAD/pull/24632 Pull request #24632]
-* The [[Image:Std_MassProperties.svg|24px]] [[Std_MassProperties|Mass Properties]] view provider now shows icons at the center of gravity and center of volume, making them easier to locate in the 3D view. [https://github.com/FreeCAD/FreeCAD/pull/29288 Pull request #29288]
 
 === API ===
 
@@ -128,7 +125,6 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Editing sketches from assemblies no longer briefly activates the sketch's source document or crashes when leaving the Assembly context. [https://github.com/FreeCAD/FreeCAD/pull/29271 Pull request #29271]
 * [[Assembly_CreateSimulation|Simulations]] now offer export to video format. [https://github.com/FreeCAD/FreeCAD/pull/25307 Pull request #25307]
 * [[Assembly_CreateView|Exploded View]] can now be created temporarily. [https://github.com/FreeCAD/FreeCAD/pull/25456 Pull request #25456]
-* The [[Assembly_CreateSimulation|Simulation]] playback buttons have been made bigger and more visually distinct. [https://github.com/FreeCAD/FreeCAD/pull/30257 Pull request #30257]
 
 == BIM Workbench ==
 
@@ -136,7 +132,7 @@ ToDo (last check: 20260430, #27222):
 * https://github.com/FreeCAD/FreeCAD/pull/24078
 * https://github.com/FreeCAD/FreeCAD/pull/24190
 * https://github.com/FreeCAD/FreeCAD/pull/27222
-* [[Arch_Site|Site]] objects now have a dedicated task panel with sections for Location, Shape, Terrain and Metadata, making site editing more user-friendly. [https://github.com/FreeCAD/FreeCAD/pull/28504 Pull request #28504]
+* https://github.com/FreeCAD/FreeCAD/pull/28504
 * Removing a wall base now preserves the wall's placement and parametric dimensions for supported straight Draft or Sketch bases, and warns before removing unsupported complex bases. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
 * [[Arch_Wall|Walls]] can now be created without a base object by default, with the selected wall baseline mode remembered in preferences. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]
 * The BIM Project command was removed from the toolbar, moved to the Utils menu, renamed for IFC-project clarity, and the Setup Project dialog now defaults to non-IFC-native projects. [https://github.com/FreeCAD/FreeCAD/pull/25086 Pull request #25086]
@@ -155,7 +151,6 @@ ToDo (last check: 20260430, #27222):
 * [[BIM_DrawingView|DrawingView]] cut lines now use the default line width and cut areas line thickness ratio preferences for thicker cut-line output. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]
 * IFC import now treats a multicore preference value of 0 as disabled before creating the IfcOpenShell geometry iterator, avoiding invalid worker counts when multicore processing is turned off. [https://github.com/FreeCAD/FreeCAD/pull/30201 Pull request #30201]
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
-* The endpoints of walls without a base object can now be edited in [[Draft_Workbench|Draft]], allowing interactive wall reshaping in plan view. [https://github.com/FreeCAD/FreeCAD/pull/29860 Pull request #29860]
 
 == CAM Workbench ==
 
@@ -227,10 +222,6 @@ ToDo (last check: 20260430, #27222):
 * CAM drilling cycle expansion now uses MachineState for more accurate machine state tracking while expanding drilling cycles. [https://github.com/FreeCAD/FreeCAD/pull/30112 Pull request #30112]
 * The [[CAM_Profile|Profile]] and [[CAM_Pocket_Shape|Pocket]] linking options now include collision-avoidance strategies for using retract height, clearance height, line-of-sight checks, tool diameter, or tool shape. [https://github.com/FreeCAD/FreeCAD/pull/29983 Pull request #29983]
 # The Linking generator was added to the [[CAM_Engrave|Engrave]] and [[CAM_Deburr|Deburr]] operations to use the safe height instead of clearance height for linking moves. The Linking Mode and Safety Margin options were added to the task panels, also for [[CAM_Drilling|Drilling]] and [[CAM_Helix|Helix]] operations. [https://github.com/FreeCAD/FreeCAD/pull/29959 Pull request #29959]
-* The [[CAM_LeadInOut|LeadInOut]] dressup now supports ExtendLeadIn and ExtendLeadOut properties for the Arc, Line, Perpendicular and Tangent styles. [https://github.com/FreeCAD/FreeCAD/pull/29061 Pull request #29061]
-* The Spiral generator now validates G-code output with deviation-based testing instead of exact string comparisons. [https://github.com/FreeCAD/FreeCAD/pull/28596 Pull request #28596]
-* A tolerance parameter was added to the Linking generator collision check, making it possible to adjust collision detection sensitivity. [https://github.com/FreeCAD/FreeCAD/pull/28140 Pull request #28140]
-* Several fixes were applied to machine-based postprocessing, improving G-code output for different machine configurations. [https://github.com/FreeCAD/FreeCAD/pull/28563 Pull request #28563]
 
 == Draft Workbench ==
 
@@ -248,10 +239,6 @@ ToDo (last check: 20260430, #29258):
 === Further Draft improvements ===
 
 * [[Draft_Trimex|Trimex]] now reports unsupported sketch selections before opening the task panel, avoiding a misleading no-op workflow. [https://github.com/FreeCAD/FreeCAD/pull/29845 Pull request #29845]
-* Hints were added for the Draft annotation tools (Dimension, Label, ShapeString, etc.), describing available modifiers and keyboard shortcuts in the task panel. [https://github.com/FreeCAD/FreeCAD/pull/29649 Pull request #29649]
-* [[Draft_PolarArray|Polar]] and [[Draft_CircularArray|Circular Array]] now respect the active working plane, making them usable in 3D workflows with custom work planes. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
-* UTF-16 encoded SVG files (e.g., generated by Corel Draw on Windows) can now be imported. [https://github.com/FreeCAD/FreeCAD/pull/29244 Pull request #29244]
-* When saving [[Draft_AnnotationStyleEditor|Annotation Styles]], the file extension is now automatically ensured. [https://github.com/FreeCAD/FreeCAD/pull/30358 Pull request #30358]
 
 == FEM Workbench ==
 
@@ -336,7 +323,6 @@ ToDo (last check: 20260430, #29258):
 * Extruding text sketches in the Part Workbench is now faster, especially for sketches that produce many wires. [https://github.com/FreeCAD/FreeCAD/pull/28344 Pull request #28344]
 * The attachment system now correctly offers modes such as ''XY parallel to Plane'' when selecting origin datum planes through an Origin object. [https://github.com/FreeCAD/FreeCAD/pull/28958 Pull request #28958]
 * [[Part_Loft|Loft]] creation now allows valid profile combinations that share the same center of gravity while still guarding against the crash case fixed for duplicate profiles. [https://github.com/FreeCAD/FreeCAD/pull/29982 Pull request #29982]
-* Input hints were added for the [[Part_EditAttachment|Attachment]] dialog, showing key bindings for toggling through attachment modes and confirming selections. [https://github.com/FreeCAD/FreeCAD/pull/29614 Pull request #29614]
 
 == Part Design Workbench ==
 
@@ -379,7 +365,6 @@ ToDo (last check: 20260430, #29258):
 
 === Further Points improvements ===
 
-* The Points Workbench now uses modern libE57 types, following the update of the internal libE57 copy. [https://github.com/FreeCAD/FreeCAD/pull/27434 Pull request #27434]
 == Reverse Engineering Workbench ==
 
 === Further Reverse Engineering improvements ===
@@ -440,12 +425,6 @@ ToDo (last check: 20260430, #29258):
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 * Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
-* The [[Image:Sketcher_CreateLine.svg|24px]] [[Sketcher_CreateLine|Line]] and [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|Polyline]] tools are now grouped by default. A preference allows separating them. [https://github.com/FreeCAD/FreeCAD/pull/30347 Pull request #30347]
-* The new polyline tool uses the original {{KEY|G}}, {{KEY|M}} shortcut. [https://github.com/FreeCAD/FreeCAD/pull/30395 Pull request #30395]
-* Hints were re-added for the polyline tool, describing how to switch between line, arc, and tangent modes. [https://github.com/FreeCAD/FreeCAD/pull/30344 Pull request #30344]
-* When long-pressing an edge shared by two internal faces, the clarify selection menu now lists both adjacent faces. [https://github.com/FreeCAD/FreeCAD/pull/29159 Pull request #29159]
-* Internally-aligned B-spline geometry (weight circles, control polygon edges) is now skipped when using the [[Image:Sketcher_ToggleConstruction.svg|24px]] [[Sketcher_ToggleConstruction|Toggle Construction Geometry]] tool, instead of producing an error. [https://github.com/FreeCAD/FreeCAD/pull/28081 Pull request #28081]
-* The [[Image:Sketcher_ConstrainDistance.svg|24px]] [[Sketcher_ConstrainDistance|Dimension]] tool no longer switches the distance type to ''Horizontal'' or ''Vertical'' when an existing horizontal or vertical dimension is selected. [https://github.com/FreeCAD/FreeCAD/pull/28242 Pull request #28242]
 
 == Spreadsheet Workbench ==
 
@@ -478,7 +457,6 @@ ToDo (last check: 20260430, #29258):
 * The default TechDraw page color in the FreeCAD Light preference pack is now white, avoiding gray page backgrounds when printing. [https://github.com/FreeCAD/FreeCAD/pull/30129 Pull request #30129]
 * The task panel of the [[TechDraw_Balloon|Balloon Annotation]] tool was polished. [https://github.com/FreeCAD/FreeCAD/pull/28101 Pull request #28101]
 * The ASME ANSIB TechDraw template now has a transparent background, matching the other drawing templates. [https://github.com/FreeCAD/FreeCAD/pull/30025 Pull request #30025]
-* [[TechDraw_Workbench|TechDraw]] now supports horizontal and vertical dimensions between circle edges (instead of always falling back to a Distance dimension). [https://github.com/FreeCAD/FreeCAD/pull/30379 Pull request #30379]
 
 == Import and export ==
 


### PR DESCRIPTION
## Summary

This PR adds missing documentation for Sketcher Workbench features introduced in FreeCAD 1.1 and 1.2.

### Changes Made

1. **Polyline tool** ({{Version|1.2}}): Added info about the improved version with auto-constraints (tangent, parallel, perpendicular) - PR #29336

2. **Merge Sketches** ({{Version|1.2}}): Added info about external geometry import support, improved constraint remapping, and Body-aware merging - PR #29497

3. **Symmetric Constraint** ({{Version|1.2}}): Added the fourth option to select an entire edge + symmetry line - PR #25525

4. **External Projection / External Intersection** ({{Version|1.2}}): Added support for Bezier curves and Offset curves as external geometry - PR #25144

5. **Grid** ({{Version|1.2}}): Added grid transparency preference mention - PR #28791

6. **Preferences** ({{Version|1.2}}): Added grid transparency, label font face configuration (PR #26600), and constraint type in list (PR #26797)

### Related PRs
- FreeCAD/FreeCAD#29336 - Polyline rework
- FreeCAD/FreeCAD#29497 - Merge Sketches fix/extend
- FreeCAD/FreeCAD#25525 - Symmetric constraint element+line option
- FreeCAD/FreeCAD#25144 - Bezier/Offset curves as external geometry
- FreeCAD/FreeCAD#28791 - Grid transparency preference
- FreeCAD/FreeCAD#26600 - Label font face configurable
- FreeCAD/FreeCAD#26797 - Show constraint type in list
