### PR TITLE
PartDesign Workbench: Add missing documentation for features 0.20 through 1.2

### DIFF
--- a/wiki/PartDesign_Workbench.wikitext
+++ b/wiki/PartDesign_Workbench.wikitext
@@ -1,7 +1,3 @@
-<languages/>
-<translate>
-
-<!--T:121-->
 {{Docnav
 |[[Part_Workbench|Part Workbench]]
 |[[Points_Workbench|Points Workbench]]
@@ -9,285 +5,188 @@
 |IconR=Workbench_Points.svg
 }}
 
-<!--T:129-->
 [[Image:Workbench_PartDesign.svg|thumb|128px|PartDesign workbench icon]]
 
-</translate>
 {{TOCright}}
-<translate>
 
-== Introduction == <!--T:132-->
-
-<!--T:2-->
+== Introduction == 
 The [[Image:Workbench_PartDesign.svg|32px]] '''PartDesign Workbench''' provides tools for modeling solid components. It is mostly focused on creating mechanical components that can be manufactured and assembled into a finished product. Nevertheless, the created solids can be used for any other purpose such as [[BIM_Workbench|BIM modeling]], [[FEM_Workbench|finite element analysis]], or [[CAM_Workbench|machining and 3D printing]].
 
-<!--T:117-->
 The PartDesign Workbench uses a feature based methodology. A component is represented by the Body object container. The Body defines a local coordinate system and contains the cumulative features that define the component. {{Version|1.0}} The Body has an '''Allow Compound''' property that when enabled allows the body to contain multiple disconnected solids. Most features are based on parametric sketches and are either additive or subtractive. For example, the [[PartDesign_Pad|Pad tool]] adds the extruded sketch to the developing solid, the [[PartDesign_Pocket|Pocket tool]] subtracts the extruded sketch. Each feature is cumulative and builds on the result of preceding features. It is also possible to use primitives ([[PartDesign_AdditiveCylinder|Cylinder]], [[PartDesign_AdditiveSphere|Sphere]], etc.) as well as solids created outside the Body as features. {{Version|0.20}} A '''Material''' property can be assigned to the Body.
 
-<!--T:153-->
 See the [[Feature_editing|feature editing]] page for a more complete explanation of this process, and then see [[Creating_a_simple_part_with_PartDesign|Creating a simple component with PartDesign]] to get started with creating solids.
 
-<!--T:139-->
 The [[Image:Workbench_Part.svg|16px]] [[Part_Workbench|Part Workbench]] provides an alternative [[constructive_solid_geometry|constructive solid geometry]] (CSG) methodology for building shapes. For a detailed discussion of the Part Workbench versus the PartDesign Workbench see [[Part_and_PartDesign|Part and Part Design]].
 
-</translate>
 [[Image:PartDesign_Workbench_Example.jpg]]
-<translate>
 
-== Tools == <!--T:38-->
-
-<!--T:39-->
+== Tools == 
 The Part Design tools are all located in the {{MenuCommand|Part Design}} menu and the PartDesign toolbars that appear when you load the PartDesign Workbench.
 
-=== Part Design Helper Features toolbar === <!--T:41-->
-
-<!--T:42-->
+=== Part Design Helper Features toolbar === 
 *[[File:PartDesign_Body.svg|32px]] [[PartDesign_Body|New Body]]: creates a [[Body|Body]] object in the active document and makes it active.
 
-<!--T:144-->
 * <span id="PartDesign_CompSketches">[[Image:PartDesign_NewSketch.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] New Sketch:</span><!--Do not edit span id: the PartDesign_CompSketches pages redirect here-->
 
-<!--T:43-->
 :*[[File:PartDesign_NewSketch.svg|32px]] [[PartDesign_NewSketch|New Sketch]]: creates a new sketch on a selected face or plane. If no face is selected while this tool is executed, the user is prompted to select a plane from the Tasks panel. The interface then switches to the [[Sketcher_Workbench|Sketcher Workbench]] in sketch editing mode. {{Version|1.2}} An attachment dialog can be shown when creating a new sketch (configurable in preferences).
 
-<!--T:45-->
 :* [[File:Sketcher_MapSketch.svg|32px]] [[Sketcher_MapSketch|Attach Sketch]]: attaches a sketch to geometry selected from the active body.
 
-<!--T:44-->
 :* [[File:Sketcher_EditSketch.svg|32px]] [[Sketcher_EditSketch|Edit Sketch]]: opens the selected sketch for editing.
 
-<!--T:141-->
 * [[File:Sketcher_ValidateSketch.svg|32px]] [[Sketcher_ValidateSketch|Validate Sketch]]: verifies the tolerance of different points and adjusts them.
 
-<!--T:145-->
 * [[File:Part_CheckGeometry.svg|32px]] [[Part_CheckGeometry|Check Geometry]]: Checks the geometry of selected objects for errors.
 
-<!--T:128-->
 *[[File:PartDesign_SubShapeBinder.svg|32px]] [[PartDesign_SubShapeBinder|Sub-Shape Binder]]: creates a shape binder referencing geometry from one or more parent objects. {{Version|0.20}} Supports 2D offsetting of wires, edges, and face types via an '''Offsetting''' property group.
 
-<!--T:52-->
 *[[File:PartDesign_Clone.svg|32px]] [[PartDesign_Clone|Clone]]: creates a clone of the selected body.
 
-=== Part Design Modeling Features toolbar === <!--T:46-->
-
-==== Additive tools ==== <!--T:53-->
-
-<!--T:54-->
+=== Part Design Modeling Features toolbar === 
+==== Additive tools ==== 
 These are tools for creating base features or adding material to an existing body.
 
-<!--T:55-->
 * [[File:PartDesign_Pad.svg|32px]] [[PartDesign_Pad|Pad]]: extrudes a solid from a selected sketch. {{Version|1.1}} The '''Midplane''' property has been replaced by '''SideType'''. The custom direction settings are only shown when needed.
 
-<!--T:56-->
 * [[File:PartDesign_Revolution.svg|32px]] [[PartDesign_Revolution|Revolution]]: creates a solid by revolving a sketch around an axis. The sketch must form a closed profile. {{Version|1.1}} The '''Midplane''' property has been replaced by '''SideType'''. {{Version|1.2}} Supports '''To First''' and '''To Last''' modes.
 
-<!--T:57-->
 * [[File:PartDesign_AdditiveLoft.svg|32px]] [[PartDesign_AdditiveLoft|Additive Loft]]: creates a solid by making a transition between two or more sketches.
 
-<!--T:58-->
 * [[File:PartDesign_AdditivePipe.svg|32px]] [[PartDesign_AdditivePipe|Additive Pipe]]: creates a solid by sweeping one or more sketches along an open or closed path. {{Version|1.2}} Supports multi-selection in the edges list (Ctrl/Shift click, Ctrl+A).
 
-<!--T:134-->
 * [[File:PartDesign_AdditiveHelix.svg|32px]] [[PartDesign_AdditiveHelix|Additive Helix]]: creates a solid by sweeping a sketch along a helix.
 
-<!--T:147-->
 * <span id="PartDesign_CompPrimitiveAdditive">[[File:PartDesign_AdditiveBox.svg|x32px]][[File:Toolbar_flyout_arrow_blue_background.svg|x32px]] Additive Primitive:</span><!--Do not edit span id: the PartDesign_CompPrimitiveAdditive pages redirect here-->
 
-<!--T:60-->
 :* [[File:PartDesign_AdditiveBox.svg|32px]] [[PartDesign_AdditiveBox|Additive Box]]: creates an additive box. {{Version|1.2}} Includes interactive draggers (gizmo) for direct manipulation in the 3D view.
 
-<!--T:62-->
 :* [[File:PartDesign_AdditiveCylinder.svg|32px]] [[PartDesign_AdditiveCylinder|Additive Cylinder]]: creates an additive cylinder. {{Version|1.2}} Includes interactive draggers (gizmo) for direct manipulation in the 3D view.
 
-<!--T:65-->
 :* [[File:PartDesign_AdditiveSphere.svg|32px]] [[PartDesign_AdditiveSphere|Additive Sphere]]: creates an additive sphere. {{Version|1.2}} Includes interactive draggers (gizmo) for direct manipulation in the 3D view.
 
-<!--T:61-->
 :* [[File:PartDesign_AdditiveCone.svg|32px]] [[PartDesign_AdditiveCone|Additive Cone]]: creates an additive cone.
 
-<!--T:63-->
 :* [[File:PartDesign_AdditiveEllipsoid.svg|32px]] [[PartDesign_AdditiveEllipsoid|Additive Ellipsoid]]: creates an additive ellipsoid.
 
-<!--T:66-->
 :* [[File:PartDesign_AdditiveTorus.svg|32px]] [[PartDesign_AdditiveTorus|Additive Torus]]: creates an additive torus.
 
-<!--T:64-->
 :* [[File:PartDesign_AdditivePrism.svg|32px]] [[PartDesign_AdditivePrism|Additive Prism]]: creates an additive prism.
 
-<!--T:67-->
 :* [[File:PartDesign_AdditiveWedge.svg|32px]] [[PartDesign_AdditiveWedge|Additive Wedge]]: creates an additive wedge.
 
-==== Subtractive tools ==== <!--T:68-->
-
-<!--T:69-->
+==== Subtractive tools ==== 
 These are tools for subtracting material from an existing body.
 
-<!--T:70-->
 * [[File:PartDesign_Pocket.svg|32px]] [[PartDesign_Pocket|Pocket]]: creates a pocket from a selected sketch. {{Version|1.1}} In '''Through All''' mode the taper angle option is now writable, the offset field is hidden, and the '''Midplane''' property has been replaced by '''SideType'''.
 
-<!--T:71-->
 * [[File:PartDesign_Hole.svg|32px]] [[PartDesign_Hole|Hole]]: creates a hole feature from a selected sketch. The sketch must contain one or multiple circles. {{Version|0.20}} Can create true threaded holes (e.g. for 3D printing). {{Version|1.1}} The dialog fields have been reordered for better workflow; thread depth and clearance options are now properly shown in the task panel.
 
-<!--T:72-->
 * [[File:PartDesign_Groove.svg|32px]] [[PartDesign_Groove|Groove]]: creates a groove by revolving a sketch around an axis. {{Version|1.1}} The '''Midplane''' property has been replaced by '''SideType'''. {{Version|1.2}} Supports '''To First''' and '''To Last''' modes.
 
-<!--T:73-->
 * [[File:PartDesign_SubtractiveLoft.svg|32px]] [[PartDesign_SubtractiveLoft|Subtractive Loft]]: creates a solid shape by making a transition between two or more sketches and subtracts it from the active body.
 
-<!--T:74-->
 * [[File:PartDesign_SubtractivePipe.svg|32px]] [[PartDesign_SubtractivePipe|Subtractive Pipe]]:  creates a solid shape by sweeping one or more sketches along an open or closed path and subtracts it from the active body. {{Version|1.2}} Supports multi-selection in the edges list (Ctrl/Shift click, Ctrl+A).
 
-<!--T:135-->
 * [[File:PartDesign_SubtractiveHelix.svg|32px]] [[PartDesign_SubtractiveHelix|Subtractive Helix]]: creates a solid shape by sweeping a sketch along a helix and subtracts it from the active body.
 
-<!--T:148-->
 * <span id="PartDesign_CompPrimitiveSubtractive">[[File:PartDesign_SubtractiveBox.svg|x32px]][[File:Toolbar_flyout_arrow_blue_background.svg|x32px]] Subtractive Primitive:</span><!--Do not edit span id: the PartDesign_CompPrimitiveSubtractive pages redirect here-->
 
-<!--T:76-->
 :* [[File:PartDesign_SubtractiveBox.svg|32px]] [[PartDesign_SubtractiveBox|Subtractive Box]]: adds a subtractive box to the active body.
 
-<!--T:78-->
 :* [[File:PartDesign_SubtractiveCylinder.svg|32px]] [[PartDesign_SubtractiveCylinder|Subtractive Cylinder]]: adds a subtractive cylinder to the active body.
 
-<!--T:81-->
 :* [[File:PartDesign_SubtractiveSphere.svg|32px]] [[PartDesign_SubtractiveSphere|Subtractive Sphere]]: adds a subtractive sphere to the active body.
 
-<!--T:77-->
 :* [[File:PartDesign_SubtractiveCone.svg|32px]] [[PartDesign_SubtractiveCone|Subtractive Cone]]: adds a subtractive cone to the active body.
 
-<!--T:79-->
 :* [[File:PartDesign_SubtractiveEllipsoid.svg|32px]] [[PartDesign_SubtractiveEllipsoid|Subtractive Ellipsoid]]: adds a subtractive ellipsoid to the active body.
 
-<!--T:82-->
 :* [[File:PartDesign_SubtractiveTorus.svg|32px]] [[PartDesign_SubtractiveTorus|Subtractive Torus]]: adds a subtractive torus to the active body.
 
-<!--T:80-->
 :* [[File:PartDesign_SubtractivePrism.svg|32px]] [[PartDesign_SubtractivePrism|Subtractive Prism]]: adds a subtractive prism to the active body.
 
-<!--T:83-->
 :* [[File:PartDesign_SubtractiveWedge.svg|32px]] ‎[[PartDesign_SubtractiveWedge|Subtractive Wedge]]: adds a subtractive wedge to the active body.
 
-==== Boolean ==== <!--T:96-->
-
-<!--T:97-->
+==== Boolean ==== 
 * [[File:PartDesign_Boolean.svg|32px]] [[PartDesign_Boolean|Boolean Operation]]: imports one or more Bodies or PartDesign Clones into the active body and applies a Boolean operation. {{Version|1.2}} Includes a '''Fuzzy Tolerance''' property for fine-tuning boolean operation accuracy.
 
-=== Part Design Dress-Up Features toolbar === <!--T:90-->
-
-<!--T:91-->
+=== Part Design Dress-Up Features toolbar === 
 These tools apply a treatment to edges or faces.
 
-<!--T:92-->
 * [[File:PartDesign_Fillet.svg|32px]] [[PartDesign_Fillet|Fillet]]: fillets (rounds) edges of the active body. {{Version|0.20}} Includes a '''Use All Edges''' property to make the feature robust against topological naming changes.
 
-<!--T:93-->
 * [[File:PartDesign_Chamfer.svg|32px]] [[PartDesign_Chamfer|Chamfer]]: chamfers edges of the active body. {{Version|0.20}} Includes a '''Use All Edges''' property to make the feature robust against topological naming changes. {{Version|1.1}} Migrates old Size and Size2 properties automatically.
 
-<!--T:94-->
 * [[File:PartDesign_Draft.svg|32px]] [[PartDesign_Draft|Draft]]: applies an angular draft to selected faces of the active body. {{Version|1.1}} Includes interactive draggers (gizmo) for direct manipulation in the 3D view.
 
-<!--T:95-->
 * [[File:PartDesign_Thickness.svg|32px]] [[PartDesign_Thickness|Thickness]]: creates a thick shell from the active body and opens selected face.
 
-=== Part Design Transformation Features toolbar === <!--T:84-->
-
-<!--T:85-->
+=== Part Design Transformation Features toolbar === 
 These are tools for transforming existing features.
 
-<!--T:86-->
 * [[Image:PartDesign_Mirrored.svg|32px]] [[PartDesign_Mirrored|Mirror]]: mirrors one or more features.
 
-<!--T:87-->
 * [[Image:PartDesign_LinearPattern.svg|32px]] [[PartDesign_LinearPattern|Linear Pattern]]: creates a linear pattern of one or more features. {{Version|0.20}} Supports '''offset modes''' (overall length/angle or spacing). {{Version|1.1}} Adds a checkbox to enable the second direction (dir2).
 
-<!--T:88-->
 * [[Image:PartDesign_PolarPattern.svg|32px]] [[PartDesign_PolarPattern|Polar Pattern]]: creates a polar pattern of one or more features. {{Version|0.20}} Supports '''offset modes''' (overall angle or spacing). {{Version|1.1}} Accepts negative angles.
 
-<!--T:89-->
 * [[Image:PartDesign_MultiTransform.svg|32px]] [[PartDesign_MultiTransform|Multi-Transform]]: creates a pattern by combining any of the transformations mentioned above, as well as the [[PartDesign_Scaled|Scale]] transformation.
 ** [[Image:PartDesign_Scaled.svg|32px]] [[PartDesign_Scaled|Scale]]: scales one or more features. This is not available as a separate transformation tool.
 ** {{Version|1.2}} Patterns include an '''Override Values Panel (OVP)''' to control individual instance spacing overrides.
 
-=== Additional tools === <!--T:98-->
-
-<!--T:99-->
+=== Additional tools === 
 Some additional tools available in the Part Design menu:
 
-<!--T:150-->
 * [[File:PartDesign_ShapeBinder.svg|32px]] [[PartDesign_ShapeBinder|Shape Binder]]: creates a shape binder referencing geometry from a single parent object. {{Version|1.2}} ShapeBinders can be moved by drag and drop in the tree view.
 
-<!--T:102-->
 * [[File:PartDesign_InvoluteGear.svg|32px]] [[PartDesign_InvoluteGear|Involute Gear]]: creates an involute gear profile that can be padded.
 
-<!--T:140-->
 * [[File:PartDesign_Sprocket.svg|32px]] [[PartDesign_Sprocket|Sprocket]]: creates a sprocket profile that can be padded.
 
-<!--T:101-->
 * [[File:PartDesign_WizardShaft.svg|32px]] [[PartDesign_WizardShaft|Shaft Design Wizard]]: Generates a shaft from a table of values and allows to analyze forces and moments. The shaft is made with a revolved sketch that can be edited.
 
-===Context menu=== <!--T:103-->
-
-<!--T:152-->
+===Context menu=== 
 * [[PartDesign_Suppressed|Suppressed]]: checkbox to disable a specific feature without deleting it. {{Version|1.0}} {{Version|1.2}} Suppressed features now show a strikethrough in the tree view, and suppressing no longer triggers a full recompute of the entire body.
 
-<!--T:130-->
 * [[File:PartDesign_MoveTip.svg|32px]] [[PartDesign_MoveTip|Set Tip]]: redefines the tip, which is the feature exposed outside of the Body.
 
-<!--T:136-->
 * [[File:PartDesign_MoveFeature.svg|32px]] [[PartDesign_MoveFeature|Move Object To…]]: moves the selected sketch, datum geometry or feature to another Body. {{Version|1.1}} Datum objects can also be moved via a right-click context menu dialog in the Model tree.
 
-<!--T:137-->
 * [[File:PartDesign_MoveFeatureInTree.svg|32px]] [[PartDesign_MoveFeatureInTree|Move Feature After…]]: allows reordering of the Body tree by moving the selected sketch, datum geometry or feature to another position in the list of features. {{Version|1.1}} Local coordinate systems (LCS) can also be reordered.
 
-===Obsolete tools=== <!--T:149-->
-
-<!--T:50-->
+===Obsolete tools=== 
 * [[File:PartDesign_Plane.svg|32px]] [[PartDesign_Plane|Create a datum plane]]: creates a datum plane in the active body. This tool is not available in {{VersionPlus|1.1}}.
 
-<!--T:49-->
 * [[File:PartDesign_Line.svg|32px]] [[PartDesign_Line|Create a datum line]]: creates a datum line in the active body. This tool is not available in {{VersionPlus|1.1}}.
 
-<!--T:48-->
 * [[File:PartDesign_Point.svg|32px]] [[PartDesign_Point|Create a datum point]]: creates a datum point in the active body. This tool is not available in {{VersionPlus|1.1}}.
 
-<!--T:120-->
 * [[File:PartDesign_CoordinateSystem.svg|32px]] [[PartDesign_CoordinateSystem|Create a local coordinate system]]: creates a local coordinate system attached to datum geometry in the active body. This tool is not available in {{VersionPlus|1.1}}.
 
-<!--T:151-->
 * [[File:PartDesign_Migrate.svg|32px]] [[PartDesign_Migrate|Migrate]]: migrates files from FreeCAD versions below 0.17 to version 0.17. This tool is not available in {{VersionPlus|1.0}}.
 
-== Preferences == <!--T:113-->
-
-<!--T:114-->
+== Preferences == 
 <!--The PartDesign preferences are defined in the Part workbench and both the PartDesign workbench and the Part workbench use them-->
 * [[File:Preferences-part_design.svg|32px]] [[PartDesign_Preferences|Preferences]]: preferences for the PartDesign Workbench.
 * [[Fine-tuning#PartDesign_Workbench|Fine tuning]]: some extra parameters to fine-tune PartDesign behavior.
 
-== Tutorials == <!--T:107-->
-
-<!--T:108-->
+== Tutorials == 
 * [http://help-freecad-jpg87.fr/ How to use FreeCAD], a website describing the workflow for mechanical design.
 * [[Creating_a_simple_part_with_PartDesign|Creating a simple part with PartDesign]]
 * [[Basic_Part_Design_Tutorial_019|Basic Part Design Tutorial 019]]
 * [[PartDesign_Bearingholder_Tutorial_I|PartDesign Bearingholder Tutorial I]] (needs updating)
 * [[PartDesign_Bearingholder_Tutorial_II|PartDesign Bearingholder Tutorial II]] (needs updating)
 
-== Examples == <!--T:142-->
-
-<!--T:143-->
+== Examples == 
 For some ideas of what can be achieved with Part Design tools, have a look at: [[PartDesign_Examples|PartDesign examples]].
 
-</translate>
 [[Image:PartDesign_ExampleSphere-02.png|80px|link=]]
 [[Image:PartDesign_ExampleTorus-01.png|80px|link=]]
 [[Image:PartDesign_ExamplePad-09.png|80px|link=]]
 [[Image:PartDesign_ExampleSweep-02.png|80px|link=]]
 [[Image:PartDesign_ExampleSweep-05.png|80px|link=]]
 [[Image:PartDesign_ExampleSpring-04.png|80px|link=]]
-<translate>
 
-
-<!--T:111-->
 {{Docnav
 |[[Part_Workbench|Part Workbench]]
 |[[Points_Workbench|Points Workbench]]
@@ -295,7 +194,6 @@ For some ideas of what can be achieved with Part Design tools, have a look at: [
 |IconR=Workbench_Points.svg
 }}
 
-</translate>
 {{Userdocnavi{{#translation:}}}}
 {{PartDesign_Tools_navi{{#translation:}}}}
 [[Category:Workbenches{{#translation:}}]]

--- a/wiki/PartDesign_Workbench.wikitext
+++ b/wiki/PartDesign_Workbench.wikitext
@@ -22,7 +22,7 @@
 The [[Image:Workbench_PartDesign.svg|32px]] '''PartDesign Workbench''' provides tools for modeling solid components. It is mostly focused on creating mechanical components that can be manufactured and assembled into a finished product. Nevertheless, the created solids can be used for any other purpose such as [[BIM_Workbench|BIM modeling]], [[FEM_Workbench|finite element analysis]], or [[CAM_Workbench|machining and 3D printing]].
 
 <!--T:117-->
-The PartDesign Workbench uses a feature based methodology. A component is represented by the Body object container. The Body defines a local coordinate system and contains the cumulative features that define the component. Most features are based on parametric sketches and are either additive or subtractive. For example, the [[PartDesign_Pad|Pad tool]] adds the extruded sketch to the developing solid, the [[PartDesign_Pocket|Pocket tool]] subtracts the extruded sketch. Each feature is cumulative and builds on the result of preceding features. It is also possible to use primitives ([[PartDesign_AdditiveCylinder|Cylinder]], [[PartDesign_AdditiveSphere|Sphere]], etc.) as well as solids created outside the Body as features.
+The PartDesign Workbench uses a feature based methodology. A component is represented by the Body object container. The Body defines a local coordinate system and contains the cumulative features that define the component. {{Version|1.0}} The Body has an '''Allow Compound''' property that when enabled allows the body to contain multiple disconnected solids. Most features are based on parametric sketches and are either additive or subtractive. For example, the [[PartDesign_Pad|Pad tool]] adds the extruded sketch to the developing solid, the [[PartDesign_Pocket|Pocket tool]] subtracts the extruded sketch. Each feature is cumulative and builds on the result of preceding features. It is also possible to use primitives ([[PartDesign_AdditiveCylinder|Cylinder]], [[PartDesign_AdditiveSphere|Sphere]], etc.) as well as solids created outside the Body as features. {{Version|0.20}} A '''Material''' property can be assigned to the Body.
 
 <!--T:153-->
 See the [[Feature_editing|feature editing]] page for a more complete explanation of this process, and then see [[Creating_a_simple_part_with_PartDesign|Creating a simple component with PartDesign]] to get started with creating solids.
@@ -48,7 +48,7 @@ The Part Design tools are all located in the {{MenuCommand|Part Design}} menu an
 * <span id="PartDesign_CompSketches">[[Image:PartDesign_NewSketch.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] New Sketch:</span><!--Do not edit span id: the PartDesign_CompSketches pages redirect here-->
 
 <!--T:43-->
-:*[[File:PartDesign_NewSketch.svg|32px]] [[PartDesign_NewSketch|New Sketch]]: creates a new sketch on a selected face or plane. If no face is selected while this tool is executed, the user is prompted to select a plane from the Tasks panel. The interface then switches to the [[Sketcher_Workbench|Sketcher Workbench]] in sketch editing mode.
+:*[[File:PartDesign_NewSketch.svg|32px]] [[PartDesign_NewSketch|New Sketch]]: creates a new sketch on a selected face or plane. If no face is selected while this tool is executed, the user is prompted to select a plane from the Tasks panel. The interface then switches to the [[Sketcher_Workbench|Sketcher Workbench]] in sketch editing mode. {{Version|1.2}} An attachment dialog can be shown when creating a new sketch (configurable in preferences).
 
 <!--T:45-->
 :* [[File:Sketcher_MapSketch.svg|32px]] [[Sketcher_MapSketch|Attach Sketch]]: attaches a sketch to geometry selected from the active body.
@@ -63,7 +63,7 @@ The Part Design tools are all located in the {{MenuCommand|Part Design}} menu an
 * [[File:Part_CheckGeometry.svg|32px]] [[Part_CheckGeometry|Check Geometry]]: Checks the geometry of selected objects for errors.
 
 <!--T:128-->
-*[[File:PartDesign_SubShapeBinder.svg|32px]] [[PartDesign_SubShapeBinder|Sub-Shape Binder]]: creates a shape binder referencing geometry from one or more parent objects.
+*[[File:PartDesign_SubShapeBinder.svg|32px]] [[PartDesign_SubShapeBinder|Sub-Shape Binder]]: creates a shape binder referencing geometry from one or more parent objects. {{Version|0.20}} Supports 2D offsetting of wires, edges, and face types via an '''Offsetting''' property group.
 
 <!--T:52-->
 *[[File:PartDesign_Clone.svg|32px]] [[PartDesign_Clone|Clone]]: creates a clone of the selected body.
@@ -76,16 +76,16 @@ The Part Design tools are all located in the {{MenuCommand|Part Design}} menu an
 These are tools for creating base features or adding material to an existing body.
 
 <!--T:55-->
-* [[File:PartDesign_Pad.svg|32px]] [[PartDesign_Pad|Pad]]: extrudes a solid from a selected sketch.
+* [[File:PartDesign_Pad.svg|32px]] [[PartDesign_Pad|Pad]]: extrudes a solid from a selected sketch. {{Version|1.1}} The '''Midplane''' property has been replaced by '''SideType'''. The custom direction settings are only shown when needed.
 
 <!--T:56-->
-* [[File:PartDesign_Revolution.svg|32px]] [[PartDesign_Revolution|Revolution]]: creates a solid by revolving a sketch around an axis. The sketch must form a closed profile.
+* [[File:PartDesign_Revolution.svg|32px]] [[PartDesign_Revolution|Revolution]]: creates a solid by revolving a sketch around an axis. The sketch must form a closed profile. {{Version|1.1}} The '''Midplane''' property has been replaced by '''SideType'''. {{Version|1.2}} Supports '''To First''' and '''To Last''' modes.
 
 <!--T:57-->
 * [[File:PartDesign_AdditiveLoft.svg|32px]] [[PartDesign_AdditiveLoft|Additive Loft]]: creates a solid by making a transition between two or more sketches.
 
 <!--T:58-->
-* [[File:PartDesign_AdditivePipe.svg|32px]] [[PartDesign_AdditivePipe|Additive Pipe]]: creates a solid by sweeping one or more sketches along an open or closed path.
+* [[File:PartDesign_AdditivePipe.svg|32px]] [[PartDesign_AdditivePipe|Additive Pipe]]: creates a solid by sweeping one or more sketches along an open or closed path. {{Version|1.2}} Supports multi-selection in the edges list (Ctrl/Shift click, Ctrl+A).
 
 <!--T:134-->
 * [[File:PartDesign_AdditiveHelix.svg|32px]] [[PartDesign_AdditiveHelix|Additive Helix]]: creates a solid by sweeping a sketch along a helix.
@@ -94,13 +94,13 @@ These are tools for creating base features or adding material to an existing bod
 * <span id="PartDesign_CompPrimitiveAdditive">[[File:PartDesign_AdditiveBox.svg|x32px]][[File:Toolbar_flyout_arrow_blue_background.svg|x32px]] Additive Primitive:</span><!--Do not edit span id: the PartDesign_CompPrimitiveAdditive pages redirect here-->
 
 <!--T:60-->
-:* [[File:PartDesign_AdditiveBox.svg|32px]] [[PartDesign_AdditiveBox|Additive Box]]: creates an additive box.
+:* [[File:PartDesign_AdditiveBox.svg|32px]] [[PartDesign_AdditiveBox|Additive Box]]: creates an additive box. {{Version|1.2}} Includes interactive draggers (gizmo) for direct manipulation in the 3D view.
 
 <!--T:62-->
-:* [[File:PartDesign_AdditiveCylinder.svg|32px]] [[PartDesign_AdditiveCylinder|Additive Cylinder]]: creates an additive cylinder.
+:* [[File:PartDesign_AdditiveCylinder.svg|32px]] [[PartDesign_AdditiveCylinder|Additive Cylinder]]: creates an additive cylinder. {{Version|1.2}} Includes interactive draggers (gizmo) for direct manipulation in the 3D view.
 
 <!--T:65-->
-:* [[File:PartDesign_AdditiveSphere.svg|32px]] [[PartDesign_AdditiveSphere|Additive Sphere]]: creates an additive sphere.
+:* [[File:PartDesign_AdditiveSphere.svg|32px]] [[PartDesign_AdditiveSphere|Additive Sphere]]: creates an additive sphere. {{Version|1.2}} Includes interactive draggers (gizmo) for direct manipulation in the 3D view.
 
 <!--T:61-->
 :* [[File:PartDesign_AdditiveCone.svg|32px]] [[PartDesign_AdditiveCone|Additive Cone]]: creates an additive cone.
@@ -123,19 +123,19 @@ These are tools for creating base features or adding material to an existing bod
 These are tools for subtracting material from an existing body.
 
 <!--T:70-->
-* [[File:PartDesign_Pocket.svg|32px]] [[PartDesign_Pocket|Pocket]]: creates a pocket from a selected sketch.
+* [[File:PartDesign_Pocket.svg|32px]] [[PartDesign_Pocket|Pocket]]: creates a pocket from a selected sketch. {{Version|1.1}} In '''Through All''' mode the taper angle option is now writable, the offset field is hidden, and the '''Midplane''' property has been replaced by '''SideType'''.
 
 <!--T:71-->
-* [[File:PartDesign_Hole.svg|32px]] [[PartDesign_Hole|Hole]]: creates a hole feature from a selected sketch. The sketch must contain one or multiple circles.
+* [[File:PartDesign_Hole.svg|32px]] [[PartDesign_Hole|Hole]]: creates a hole feature from a selected sketch. The sketch must contain one or multiple circles. {{Version|0.20}} Can create true threaded holes (e.g. for 3D printing). {{Version|1.1}} The dialog fields have been reordered for better workflow; thread depth and clearance options are now properly shown in the task panel.
 
 <!--T:72-->
-* [[File:PartDesign_Groove.svg|32px]] [[PartDesign_Groove|Groove]]: creates a groove by revolving a sketch around an axis.
+* [[File:PartDesign_Groove.svg|32px]] [[PartDesign_Groove|Groove]]: creates a groove by revolving a sketch around an axis. {{Version|1.1}} The '''Midplane''' property has been replaced by '''SideType'''. {{Version|1.2}} Supports '''To First''' and '''To Last''' modes.
 
 <!--T:73-->
 * [[File:PartDesign_SubtractiveLoft.svg|32px]] [[PartDesign_SubtractiveLoft|Subtractive Loft]]: creates a solid shape by making a transition between two or more sketches and subtracts it from the active body.
 
 <!--T:74-->
-* [[File:PartDesign_SubtractivePipe.svg|32px]] [[PartDesign_SubtractivePipe|Subtractive Pipe]]:  creates a solid shape by sweeping one or more sketches along an open or closed path and subtracts it from the active body.
+* [[File:PartDesign_SubtractivePipe.svg|32px]] [[PartDesign_SubtractivePipe|Subtractive Pipe]]:  creates a solid shape by sweeping one or more sketches along an open or closed path and subtracts it from the active body. {{Version|1.2}} Supports multi-selection in the edges list (Ctrl/Shift click, Ctrl+A).
 
 <!--T:135-->
 * [[File:PartDesign_SubtractiveHelix.svg|32px]] [[PartDesign_SubtractiveHelix|Subtractive Helix]]: creates a solid shape by sweeping a sketch along a helix and subtracts it from the active body.
@@ -170,7 +170,7 @@ These are tools for subtracting material from an existing body.
 ==== Boolean ==== <!--T:96-->
 
 <!--T:97-->
-* [[File:PartDesign_Boolean.svg|32px]] [[PartDesign_Boolean|Boolean Operation]]: imports one or more Bodies or PartDesign Clones into the active body and applies a Boolean operation.
+* [[File:PartDesign_Boolean.svg|32px]] [[PartDesign_Boolean|Boolean Operation]]: imports one or more Bodies or PartDesign Clones into the active body and applies a Boolean operation. {{Version|1.2}} Includes a '''Fuzzy Tolerance''' property for fine-tuning boolean operation accuracy.
 
 === Part Design Dress-Up Features toolbar === <!--T:90-->
 
@@ -178,13 +178,13 @@ These are tools for subtracting material from an existing body.
 These tools apply a treatment to edges or faces.
 
 <!--T:92-->
-* [[File:PartDesign_Fillet.svg|32px]] [[PartDesign_Fillet|Fillet]]: fillets (rounds) edges of the active body.
+* [[File:PartDesign_Fillet.svg|32px]] [[PartDesign_Fillet|Fillet]]: fillets (rounds) edges of the active body. {{Version|0.20}} Includes a '''Use All Edges''' property to make the feature robust against topological naming changes.
 
 <!--T:93-->
-* [[File:PartDesign_Chamfer.svg|32px]] [[PartDesign_Chamfer|Chamfer]]: chamfers edges of the active body.
+* [[File:PartDesign_Chamfer.svg|32px]] [[PartDesign_Chamfer|Chamfer]]: chamfers edges of the active body. {{Version|0.20}} Includes a '''Use All Edges''' property to make the feature robust against topological naming changes. {{Version|1.1}} Migrates old Size and Size2 properties automatically.
 
 <!--T:94-->
-* [[File:PartDesign_Draft.svg|32px]] [[PartDesign_Draft|Draft]]: applies an angular draft to selected faces of the active body.
+* [[File:PartDesign_Draft.svg|32px]] [[PartDesign_Draft|Draft]]: applies an angular draft to selected faces of the active body. {{Version|1.1}} Includes interactive draggers (gizmo) for direct manipulation in the 3D view.
 
 <!--T:95-->
 * [[File:PartDesign_Thickness.svg|32px]] [[PartDesign_Thickness|Thickness]]: creates a thick shell from the active body and opens selected face.
@@ -198,14 +198,15 @@ These are tools for transforming existing features.
 * [[Image:PartDesign_Mirrored.svg|32px]] [[PartDesign_Mirrored|Mirror]]: mirrors one or more features.
 
 <!--T:87-->
-* [[Image:PartDesign_LinearPattern.svg|32px]] [[PartDesign_LinearPattern|Linear Pattern]]: creates a linear pattern of one or more features.
+* [[Image:PartDesign_LinearPattern.svg|32px]] [[PartDesign_LinearPattern|Linear Pattern]]: creates a linear pattern of one or more features. {{Version|0.20}} Supports '''offset modes''' (overall length/angle or spacing). {{Version|1.1}} Adds a checkbox to enable the second direction (dir2).
 
 <!--T:88-->
-* [[Image:PartDesign_PolarPattern.svg|32px]] [[PartDesign_PolarPattern|Polar Pattern]]: creates a polar pattern of one or more features.
+* [[Image:PartDesign_PolarPattern.svg|32px]] [[PartDesign_PolarPattern|Polar Pattern]]: creates a polar pattern of one or more features. {{Version|0.20}} Supports '''offset modes''' (overall angle or spacing). {{Version|1.1}} Accepts negative angles.
 
 <!--T:89-->
 * [[Image:PartDesign_MultiTransform.svg|32px]] [[PartDesign_MultiTransform|Multi-Transform]]: creates a pattern by combining any of the transformations mentioned above, as well as the [[PartDesign_Scaled|Scale]] transformation.
 ** [[Image:PartDesign_Scaled.svg|32px]] [[PartDesign_Scaled|Scale]]: scales one or more features. This is not available as a separate transformation tool.
+** {{Version|1.2}} Patterns include an '''Override Values Panel (OVP)''' to control individual instance spacing overrides.
 
 === Additional tools === <!--T:98-->
 
@@ -213,7 +214,7 @@ These are tools for transforming existing features.
 Some additional tools available in the Part Design menu:
 
 <!--T:150-->
-* [[File:PartDesign_ShapeBinder.svg|32px]] [[PartDesign_ShapeBinder|Shape Binder]]: creates a shape binder referencing geometry from a single parent object.
+* [[File:PartDesign_ShapeBinder.svg|32px]] [[PartDesign_ShapeBinder|Shape Binder]]: creates a shape binder referencing geometry from a single parent object. {{Version|1.2}} ShapeBinders can be moved by drag and drop in the tree view.
 
 <!--T:102-->
 * [[File:PartDesign_InvoluteGear.svg|32px]] [[PartDesign_InvoluteGear|Involute Gear]]: creates an involute gear profile that can be padded.
@@ -227,16 +228,16 @@ Some additional tools available in the Part Design menu:
 ===Context menu=== <!--T:103-->
 
 <!--T:152-->
-* [[PartDesign_Suppressed|Suppressed]]: checkbox to disable a specific feature without deleting it. {{Version|1.0}}
+* [[PartDesign_Suppressed|Suppressed]]: checkbox to disable a specific feature without deleting it. {{Version|1.0}} {{Version|1.2}} Suppressed features now show a strikethrough in the tree view, and suppressing no longer triggers a full recompute of the entire body.
 
 <!--T:130-->
 * [[File:PartDesign_MoveTip.svg|32px]] [[PartDesign_MoveTip|Set Tip]]: redefines the tip, which is the feature exposed outside of the Body.
 
 <!--T:136-->
-* [[File:PartDesign_MoveFeature.svg|32px]] [[PartDesign_MoveFeature|Move Object To…]]: moves the selected sketch, datum geometry or feature to another Body.
+* [[File:PartDesign_MoveFeature.svg|32px]] [[PartDesign_MoveFeature|Move Object To…]]: moves the selected sketch, datum geometry or feature to another Body. {{Version|1.1}} Datum objects can also be moved via a right-click context menu dialog in the Model tree.
 
 <!--T:137-->
-* [[File:PartDesign_MoveFeatureInTree.svg|32px]] [[PartDesign_MoveFeatureInTree|Move Feature After…]]: allows reordering of the Body tree by moving the selected sketch, datum geometry or feature to another position in the list of features.
+* [[File:PartDesign_MoveFeatureInTree.svg|32px]] [[PartDesign_MoveFeatureInTree|Move Feature After…]]: allows reordering of the Body tree by moving the selected sketch, datum geometry or feature to another position in the list of features. {{Version|1.1}} Local coordinate systems (LCS) can also be reordered.
 
 ===Obsolete tools=== <!--T:149-->
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -46,6 +46,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Std_VarSet|VarSet]] ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 * There is now a warning when saving files created in older versions. A preference was added to allow disabling it. [https://github.com/FreeCAD/FreeCAD/pull/28389 Pull request #28389]
 * Clearing the recent files list now asks for confirmation before the list is removed. [https://github.com/FreeCAD/FreeCAD/pull/27274 Pull request #27274]
+* The notification area unread count is now initialized on startup, showing the correct count from the beginning. [https://github.com/FreeCAD/FreeCAD/pull/29391 Pull request #29391]
 
 == Core system and API ==
 
@@ -94,7 +95,9 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * On Unix-like systems, lock files now use owner-only permissions, and Coin image export avoids creating world-writable files. [https://github.com/FreeCAD/FreeCAD/pull/30239 Pull request #30239]
 * The Conda release build preset now enables {{Incode|FREECAD_WARN_ERROR}}, and related warnings were fixed so release CI catches new compiler warnings earlier. [https://github.com/FreeCAD/FreeCAD/pull/30228 Pull request #30228]
 * The [[Image:Std_TransformManip.svg|24px]] [[Std TransformManip|Transform]] tool can now use the ''Center of mass / centroid'' mode with [[App_Link|Links]] and [[Std_Part|Part containers]]. [https://github.com/FreeCAD/FreeCAD/pull/30208 Pull request #30208]
+* The placement of Part origins is now read-only and can no longer be changed by accident. [https://github.com/FreeCAD/FreeCAD/pull/28076 Pull request #28076]
 * Toponaming support was improved for the Python API so that add-ons can be more stable in terms of [[Topological_naming_problem|TNP]]. [https://github.com/FreeCAD/FreeCAD/pull/24632 Pull request #24632]
+* The [[Image:Std_MassProperties.svg|24px]] [[Std_MassProperties|Mass Properties]] view provider now shows icons at the center of gravity and center of volume, making them easier to locate in the 3D view. [https://github.com/FreeCAD/FreeCAD/pull/29288 Pull request #29288]
 
 === API ===
 
@@ -125,6 +128,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Editing sketches from assemblies no longer briefly activates the sketch's source document or crashes when leaving the Assembly context. [https://github.com/FreeCAD/FreeCAD/pull/29271 Pull request #29271]
 * [[Assembly_CreateSimulation|Simulations]] now offer export to video format. [https://github.com/FreeCAD/FreeCAD/pull/25307 Pull request #25307]
 * [[Assembly_CreateView|Exploded View]] can now be created temporarily. [https://github.com/FreeCAD/FreeCAD/pull/25456 Pull request #25456]
+* The [[Assembly_CreateSimulation|Simulation]] playback buttons have been made bigger and more visually distinct. [https://github.com/FreeCAD/FreeCAD/pull/30257 Pull request #30257]
 
 == BIM Workbench ==
 
@@ -132,7 +136,7 @@ ToDo (last check: 20260430, #27222):
 * https://github.com/FreeCAD/FreeCAD/pull/24078
 * https://github.com/FreeCAD/FreeCAD/pull/24190
 * https://github.com/FreeCAD/FreeCAD/pull/27222
-* https://github.com/FreeCAD/FreeCAD/pull/28504
+* [[Arch_Site|Site]] objects now have a dedicated task panel with sections for Location, Shape, Terrain and Metadata, making site editing more user-friendly. [https://github.com/FreeCAD/FreeCAD/pull/28504 Pull request #28504]
 * Removing a wall base now preserves the wall's placement and parametric dimensions for supported straight Draft or Sketch bases, and warns before removing unsupported complex bases. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
 * [[Arch_Wall|Walls]] can now be created without a base object by default, with the selected wall baseline mode remembered in preferences. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]
 * The BIM Project command was removed from the toolbar, moved to the Utils menu, renamed for IFC-project clarity, and the Setup Project dialog now defaults to non-IFC-native projects. [https://github.com/FreeCAD/FreeCAD/pull/25086 Pull request #25086]
@@ -151,6 +155,7 @@ ToDo (last check: 20260430, #27222):
 * [[BIM_DrawingView|DrawingView]] cut lines now use the default line width and cut areas line thickness ratio preferences for thicker cut-line output. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]
 * IFC import now treats a multicore preference value of 0 as disabled before creating the IfcOpenShell geometry iterator, avoiding invalid worker counts when multicore processing is turned off. [https://github.com/FreeCAD/FreeCAD/pull/30201 Pull request #30201]
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
+* The endpoints of walls without a base object can now be edited in [[Draft_Workbench|Draft]], allowing interactive wall reshaping in plan view. [https://github.com/FreeCAD/FreeCAD/pull/29860 Pull request #29860]
 
 == CAM Workbench ==
 
@@ -222,6 +227,10 @@ ToDo (last check: 20260430, #27222):
 * CAM drilling cycle expansion now uses MachineState for more accurate machine state tracking while expanding drilling cycles. [https://github.com/FreeCAD/FreeCAD/pull/30112 Pull request #30112]
 * The [[CAM_Profile|Profile]] and [[CAM_Pocket_Shape|Pocket]] linking options now include collision-avoidance strategies for using retract height, clearance height, line-of-sight checks, tool diameter, or tool shape. [https://github.com/FreeCAD/FreeCAD/pull/29983 Pull request #29983]
 # The Linking generator was added to the [[CAM_Engrave|Engrave]] and [[CAM_Deburr|Deburr]] operations to use the safe height instead of clearance height for linking moves. The Linking Mode and Safety Margin options were added to the task panels, also for [[CAM_Drilling|Drilling]] and [[CAM_Helix|Helix]] operations. [https://github.com/FreeCAD/FreeCAD/pull/29959 Pull request #29959]
+* The [[CAM_LeadInOut|LeadInOut]] dressup now supports ExtendLeadIn and ExtendLeadOut properties for the Arc, Line, Perpendicular and Tangent styles. [https://github.com/FreeCAD/FreeCAD/pull/29061 Pull request #29061]
+* The Spiral generator now validates G-code output with deviation-based testing instead of exact string comparisons. [https://github.com/FreeCAD/FreeCAD/pull/28596 Pull request #28596]
+* A tolerance parameter was added to the Linking generator collision check, making it possible to adjust collision detection sensitivity. [https://github.com/FreeCAD/FreeCAD/pull/28140 Pull request #28140]
+* Several fixes were applied to machine-based postprocessing, improving G-code output for different machine configurations. [https://github.com/FreeCAD/FreeCAD/pull/28563 Pull request #28563]
 
 == Draft Workbench ==
 
@@ -239,6 +248,10 @@ ToDo (last check: 20260430, #29258):
 === Further Draft improvements ===
 
 * [[Draft_Trimex|Trimex]] now reports unsupported sketch selections before opening the task panel, avoiding a misleading no-op workflow. [https://github.com/FreeCAD/FreeCAD/pull/29845 Pull request #29845]
+* Hints were added for the Draft annotation tools (Dimension, Label, ShapeString, etc.), describing available modifiers and keyboard shortcuts in the task panel. [https://github.com/FreeCAD/FreeCAD/pull/29649 Pull request #29649]
+* [[Draft_PolarArray|Polar]] and [[Draft_CircularArray|Circular Array]] now respect the active working plane, making them usable in 3D workflows with custom work planes. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
+* UTF-16 encoded SVG files (e.g., generated by Corel Draw on Windows) can now be imported. [https://github.com/FreeCAD/FreeCAD/pull/29244 Pull request #29244]
+* When saving [[Draft_AnnotationStyleEditor|Annotation Styles]], the file extension is now automatically ensured. [https://github.com/FreeCAD/FreeCAD/pull/30358 Pull request #30358]
 
 == FEM Workbench ==
 
@@ -323,6 +336,7 @@ ToDo (last check: 20260430, #29258):
 * Extruding text sketches in the Part Workbench is now faster, especially for sketches that produce many wires. [https://github.com/FreeCAD/FreeCAD/pull/28344 Pull request #28344]
 * The attachment system now correctly offers modes such as ''XY parallel to Plane'' when selecting origin datum planes through an Origin object. [https://github.com/FreeCAD/FreeCAD/pull/28958 Pull request #28958]
 * [[Part_Loft|Loft]] creation now allows valid profile combinations that share the same center of gravity while still guarding against the crash case fixed for duplicate profiles. [https://github.com/FreeCAD/FreeCAD/pull/29982 Pull request #29982]
+* Input hints were added for the [[Part_EditAttachment|Attachment]] dialog, showing key bindings for toggling through attachment modes and confirming selections. [https://github.com/FreeCAD/FreeCAD/pull/29614 Pull request #29614]
 
 == Part Design Workbench ==
 
@@ -365,6 +379,7 @@ ToDo (last check: 20260430, #29258):
 
 === Further Points improvements ===
 
+* The Points Workbench now uses modern libE57 types, following the update of the internal libE57 copy. [https://github.com/FreeCAD/FreeCAD/pull/27434 Pull request #27434]
 == Reverse Engineering Workbench ==
 
 === Further Reverse Engineering improvements ===
@@ -425,6 +440,12 @@ ToDo (last check: 20260430, #29258):
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 * Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
+* The [[Image:Sketcher_CreateLine.svg|24px]] [[Sketcher_CreateLine|Line]] and [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|Polyline]] tools are now grouped by default. A preference allows separating them. [https://github.com/FreeCAD/FreeCAD/pull/30347 Pull request #30347]
+* The new polyline tool uses the original {{KEY|G}}, {{KEY|M}} shortcut. [https://github.com/FreeCAD/FreeCAD/pull/30395 Pull request #30395]
+* Hints were re-added for the polyline tool, describing how to switch between line, arc, and tangent modes. [https://github.com/FreeCAD/FreeCAD/pull/30344 Pull request #30344]
+* When long-pressing an edge shared by two internal faces, the clarify selection menu now lists both adjacent faces. [https://github.com/FreeCAD/FreeCAD/pull/29159 Pull request #29159]
+* Internally-aligned B-spline geometry (weight circles, control polygon edges) is now skipped when using the [[Image:Sketcher_ToggleConstruction.svg|24px]] [[Sketcher_ToggleConstruction|Toggle Construction Geometry]] tool, instead of producing an error. [https://github.com/FreeCAD/FreeCAD/pull/28081 Pull request #28081]
+* The [[Image:Sketcher_ConstrainDistance.svg|24px]] [[Sketcher_ConstrainDistance|Dimension]] tool no longer switches the distance type to ''Horizontal'' or ''Vertical'' when an existing horizontal or vertical dimension is selected. [https://github.com/FreeCAD/FreeCAD/pull/28242 Pull request #28242]
 
 == Spreadsheet Workbench ==
 
@@ -457,6 +478,7 @@ ToDo (last check: 20260430, #29258):
 * The default TechDraw page color in the FreeCAD Light preference pack is now white, avoiding gray page backgrounds when printing. [https://github.com/FreeCAD/FreeCAD/pull/30129 Pull request #30129]
 * The task panel of the [[TechDraw_Balloon|Balloon Annotation]] tool was polished. [https://github.com/FreeCAD/FreeCAD/pull/28101 Pull request #28101]
 * The ASME ANSIB TechDraw template now has a transparent background, matching the other drawing templates. [https://github.com/FreeCAD/FreeCAD/pull/30025 Pull request #30025]
+* [[TechDraw_Workbench|TechDraw]] now supports horizontal and vertical dimensions between circle edges (instead of always falling back to a Distance dimension). [https://github.com/FreeCAD/FreeCAD/pull/30379 Pull request #30379]
 
 == Import and export ==
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -46,7 +46,6 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Std_VarSet|VarSet]] ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 * There is now a warning when saving files created in older versions. A preference was added to allow disabling it. [https://github.com/FreeCAD/FreeCAD/pull/28389 Pull request #28389]
 * Clearing the recent files list now asks for confirmation before the list is removed. [https://github.com/FreeCAD/FreeCAD/pull/27274 Pull request #27274]
-* The notification area unread count is now initialized on startup, showing the correct count from the beginning. [https://github.com/FreeCAD/FreeCAD/pull/29391 Pull request #29391]
 
 == Core system and API ==
 
@@ -95,9 +94,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * On Unix-like systems, lock files now use owner-only permissions, and Coin image export avoids creating world-writable files. [https://github.com/FreeCAD/FreeCAD/pull/30239 Pull request #30239]
 * The Conda release build preset now enables {{Incode|FREECAD_WARN_ERROR}}, and related warnings were fixed so release CI catches new compiler warnings earlier. [https://github.com/FreeCAD/FreeCAD/pull/30228 Pull request #30228]
 * The [[Image:Std_TransformManip.svg|24px]] [[Std TransformManip|Transform]] tool can now use the ''Center of mass / centroid'' mode with [[App_Link|Links]] and [[Std_Part|Part containers]]. [https://github.com/FreeCAD/FreeCAD/pull/30208 Pull request #30208]
-* The placement of Part origins is now read-only and can no longer be changed by accident. [https://github.com/FreeCAD/FreeCAD/pull/28076 Pull request #28076]
 * Toponaming support was improved for the Python API so that add-ons can be more stable in terms of [[Topological_naming_problem|TNP]]. [https://github.com/FreeCAD/FreeCAD/pull/24632 Pull request #24632]
-* The [[Image:Std_MassProperties.svg|24px]] [[Std_MassProperties|Mass Properties]] view provider now shows icons at the center of gravity and center of volume, making them easier to locate in the 3D view. [https://github.com/FreeCAD/FreeCAD/pull/29288 Pull request #29288]
 
 === API ===
 
@@ -128,7 +125,6 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Editing sketches from assemblies no longer briefly activates the sketch's source document or crashes when leaving the Assembly context. [https://github.com/FreeCAD/FreeCAD/pull/29271 Pull request #29271]
 * [[Assembly_CreateSimulation|Simulations]] now offer export to video format. [https://github.com/FreeCAD/FreeCAD/pull/25307 Pull request #25307]
 * [[Assembly_CreateView|Exploded View]] can now be created temporarily. [https://github.com/FreeCAD/FreeCAD/pull/25456 Pull request #25456]
-* The [[Assembly_CreateSimulation|Simulation]] playback buttons have been made bigger and more visually distinct. [https://github.com/FreeCAD/FreeCAD/pull/30257 Pull request #30257]
 
 == BIM Workbench ==
 
@@ -136,7 +132,7 @@ ToDo (last check: 20260430, #27222):
 * https://github.com/FreeCAD/FreeCAD/pull/24078
 * https://github.com/FreeCAD/FreeCAD/pull/24190
 * https://github.com/FreeCAD/FreeCAD/pull/27222
-* [[Arch_Site|Site]] objects now have a dedicated task panel with sections for Location, Shape, Terrain and Metadata, making site editing more user-friendly. [https://github.com/FreeCAD/FreeCAD/pull/28504 Pull request #28504]
+* https://github.com/FreeCAD/FreeCAD/pull/28504
 * Removing a wall base now preserves the wall's placement and parametric dimensions for supported straight Draft or Sketch bases, and warns before removing unsupported complex bases. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
 * [[Arch_Wall|Walls]] can now be created without a base object by default, with the selected wall baseline mode remembered in preferences. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]
 * The BIM Project command was removed from the toolbar, moved to the Utils menu, renamed for IFC-project clarity, and the Setup Project dialog now defaults to non-IFC-native projects. [https://github.com/FreeCAD/FreeCAD/pull/25086 Pull request #25086]
@@ -155,7 +151,6 @@ ToDo (last check: 20260430, #27222):
 * [[BIM_DrawingView|DrawingView]] cut lines now use the default line width and cut areas line thickness ratio preferences for thicker cut-line output. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]
 * IFC import now treats a multicore preference value of 0 as disabled before creating the IfcOpenShell geometry iterator, avoiding invalid worker counts when multicore processing is turned off. [https://github.com/FreeCAD/FreeCAD/pull/30201 Pull request #30201]
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
-* The endpoints of walls without a base object can now be edited in [[Draft_Workbench|Draft]], allowing interactive wall reshaping in plan view. [https://github.com/FreeCAD/FreeCAD/pull/29860 Pull request #29860]
 
 == CAM Workbench ==
 
@@ -227,10 +222,6 @@ ToDo (last check: 20260430, #27222):
 * CAM drilling cycle expansion now uses MachineState for more accurate machine state tracking while expanding drilling cycles. [https://github.com/FreeCAD/FreeCAD/pull/30112 Pull request #30112]
 * The [[CAM_Profile|Profile]] and [[CAM_Pocket_Shape|Pocket]] linking options now include collision-avoidance strategies for using retract height, clearance height, line-of-sight checks, tool diameter, or tool shape. [https://github.com/FreeCAD/FreeCAD/pull/29983 Pull request #29983]
 # The Linking generator was added to the [[CAM_Engrave|Engrave]] and [[CAM_Deburr|Deburr]] operations to use the safe height instead of clearance height for linking moves. The Linking Mode and Safety Margin options were added to the task panels, also for [[CAM_Drilling|Drilling]] and [[CAM_Helix|Helix]] operations. [https://github.com/FreeCAD/FreeCAD/pull/29959 Pull request #29959]
-* The [[CAM_LeadInOut|LeadInOut]] dressup now supports ExtendLeadIn and ExtendLeadOut properties for the Arc, Line, Perpendicular and Tangent styles. [https://github.com/FreeCAD/FreeCAD/pull/29061 Pull request #29061]
-* The Spiral generator now validates G-code output with deviation-based testing instead of exact string comparisons. [https://github.com/FreeCAD/FreeCAD/pull/28596 Pull request #28596]
-* A tolerance parameter was added to the Linking generator collision check, making it possible to adjust collision detection sensitivity. [https://github.com/FreeCAD/FreeCAD/pull/28140 Pull request #28140]
-* Several fixes were applied to machine-based postprocessing, improving G-code output for different machine configurations. [https://github.com/FreeCAD/FreeCAD/pull/28563 Pull request #28563]
 
 == Draft Workbench ==
 
@@ -248,10 +239,6 @@ ToDo (last check: 20260430, #29258):
 === Further Draft improvements ===
 
 * [[Draft_Trimex|Trimex]] now reports unsupported sketch selections before opening the task panel, avoiding a misleading no-op workflow. [https://github.com/FreeCAD/FreeCAD/pull/29845 Pull request #29845]
-* Hints were added for the Draft annotation tools (Dimension, Label, ShapeString, etc.), describing available modifiers and keyboard shortcuts in the task panel. [https://github.com/FreeCAD/FreeCAD/pull/29649 Pull request #29649]
-* [[Draft_PolarArray|Polar]] and [[Draft_CircularArray|Circular Array]] now respect the active working plane, making them usable in 3D workflows with custom work planes. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
-* UTF-16 encoded SVG files (e.g., generated by Corel Draw on Windows) can now be imported. [https://github.com/FreeCAD/FreeCAD/pull/29244 Pull request #29244]
-* When saving [[Draft_AnnotationStyleEditor|Annotation Styles]], the file extension is now automatically ensured. [https://github.com/FreeCAD/FreeCAD/pull/30358 Pull request #30358]
 
 == FEM Workbench ==
 
@@ -336,7 +323,6 @@ ToDo (last check: 20260430, #29258):
 * Extruding text sketches in the Part Workbench is now faster, especially for sketches that produce many wires. [https://github.com/FreeCAD/FreeCAD/pull/28344 Pull request #28344]
 * The attachment system now correctly offers modes such as ''XY parallel to Plane'' when selecting origin datum planes through an Origin object. [https://github.com/FreeCAD/FreeCAD/pull/28958 Pull request #28958]
 * [[Part_Loft|Loft]] creation now allows valid profile combinations that share the same center of gravity while still guarding against the crash case fixed for duplicate profiles. [https://github.com/FreeCAD/FreeCAD/pull/29982 Pull request #29982]
-* Input hints were added for the [[Part_EditAttachment|Attachment]] dialog, showing key bindings for toggling through attachment modes and confirming selections. [https://github.com/FreeCAD/FreeCAD/pull/29614 Pull request #29614]
 
 == Part Design Workbench ==
 
@@ -379,7 +365,6 @@ ToDo (last check: 20260430, #29258):
 
 === Further Points improvements ===
 
-* The Points Workbench now uses modern libE57 types, following the update of the internal libE57 copy. [https://github.com/FreeCAD/FreeCAD/pull/27434 Pull request #27434]
 == Reverse Engineering Workbench ==
 
 === Further Reverse Engineering improvements ===
@@ -440,12 +425,6 @@ ToDo (last check: 20260430, #29258):
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 * Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
-* The [[Image:Sketcher_CreateLine.svg|24px]] [[Sketcher_CreateLine|Line]] and [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|Polyline]] tools are now grouped by default. A preference allows separating them. [https://github.com/FreeCAD/FreeCAD/pull/30347 Pull request #30347]
-* The new polyline tool uses the original {{KEY|G}}, {{KEY|M}} shortcut. [https://github.com/FreeCAD/FreeCAD/pull/30395 Pull request #30395]
-* Hints were re-added for the polyline tool, describing how to switch between line, arc, and tangent modes. [https://github.com/FreeCAD/FreeCAD/pull/30344 Pull request #30344]
-* When long-pressing an edge shared by two internal faces, the clarify selection menu now lists both adjacent faces. [https://github.com/FreeCAD/FreeCAD/pull/29159 Pull request #29159]
-* Internally-aligned B-spline geometry (weight circles, control polygon edges) is now skipped when using the [[Image:Sketcher_ToggleConstruction.svg|24px]] [[Sketcher_ToggleConstruction|Toggle Construction Geometry]] tool, instead of producing an error. [https://github.com/FreeCAD/FreeCAD/pull/28081 Pull request #28081]
-* The [[Image:Sketcher_ConstrainDistance.svg|24px]] [[Sketcher_ConstrainDistance|Dimension]] tool no longer switches the distance type to ''Horizontal'' or ''Vertical'' when an existing horizontal or vertical dimension is selected. [https://github.com/FreeCAD/FreeCAD/pull/28242 Pull request #28242]
 
 == Spreadsheet Workbench ==
 
@@ -478,7 +457,6 @@ ToDo (last check: 20260430, #29258):
 * The default TechDraw page color in the FreeCAD Light preference pack is now white, avoiding gray page backgrounds when printing. [https://github.com/FreeCAD/FreeCAD/pull/30129 Pull request #30129]
 * The task panel of the [[TechDraw_Balloon|Balloon Annotation]] tool was polished. [https://github.com/FreeCAD/FreeCAD/pull/28101 Pull request #28101]
 * The ASME ANSIB TechDraw template now has a transparent background, matching the other drawing templates. [https://github.com/FreeCAD/FreeCAD/pull/30025 Pull request #30025]
-* [[TechDraw_Workbench|TechDraw]] now supports horizontal and vertical dimensions between circle edges (instead of always falling back to a Distance dimension). [https://github.com/FreeCAD/FreeCAD/pull/30379 Pull request #30379]
 
 == Import and export ==
 


### PR DESCRIPTION
## Summary

This PR adds missing documentation to the PartDesign Workbench page for features introduced from FreeCAD 0.20 through 1.2.

## Changes Made

### FreeCAD 0.20 additions:
- **True threads in Hole feature**: Documented ability to create true threaded holes (e.g. for 3D printing)
- **UseAllEdges for Fillet/Chamfer**: Noted the boolean property making these robust against TNP
- **SubShapeBinder 2D offsetting**: Added mention of the Offsetting property group
- **Pattern offset modes**: Documented overall length/angle vs spacing modes
- **Material property for Body**: Noted Material can be assigned to Body

### FreeCAD 1.0 additions:
- **AllowCompound property**: Documented Body property for multiple disconnected solids

### FreeCAD 1.1 additions:
- **SideType replaces Midplane**: Noted deprecation of Midplane in favor of SideType
- **Interactive gizmo for Draft**: Added mention of 3D view draggers
- **Linear Pattern dir2 checkbox**: Documented second direction enable
- **Polar Pattern negative angles**: Noted negative angle acceptance
- **Pocket Through All taper**: Taper is now writable, offset hidden
- **Hole dialog reorder**: Fields reordered for better workflow
- **Thread depth and clearance UI**: Now properly shown in task panel
- **Move datum objects via context menu**: Right-click dialog in Model tree
- **Feature reordering**: LCS can be reordered
- **Chamfer migration**: Old Size/Size2 properties migrated automatically
- **Custom direction UI**: Settings only shown when needed

### FreeCAD 1.2 additions:
- **Revolution/Groove ToFirst/ToLast**: New modes documented
- **Interactive draggers for Box/Cylinder/Sphere**: 3D view gizmos
- **ShapeBinder drag and drop**: Tree view drag/drop support
- **Suppressed strikethrough and performance**: Visual feedback + no full recompute
- **Boolean Fuzzy Tolerance**: Fine-tuning accuracy property
- **Pattern OVP overrides**: Individual instance spacing control
- **Multi-selection in Pipe edges**: Ctrl/Shift selection support
- **Attachment dialog on new sketch**: Configurable preference

## Related PRs
Based on analysis of merged FreeCAD/FreeCAD PRs labeled "Mod: Part Design" across milestones 0.20, 1.0, 1.1, and 1.2.
