### PR TITLE
Bounty #30: Add missing Sketcher release notes to wiki root file (clean version)

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -468,7 +468,6 @@ ToDo (last check: 20260430, #29258):
 * Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
 
 * The [[Image:Sketcher_CreateLine.svg|24px]] [[Sketcher_CreateLine|Line]] and [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|Polyline]] tools are now grouped by default. A preference allows separating them. [https://github.com/FreeCAD/FreeCAD/pull/30347 Pull request #30347]
-* When long-pressing an edge shared by two internal faces, the clarify selection menu now lists both adjacent faces. [https://github.com/FreeCAD/FreeCAD/pull/29159 Pull request #29159]
 
 
 == Spreadsheet Workbench == <!--T:53-->

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -468,11 +468,7 @@ ToDo (last check: 20260430, #29258):
 * Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
 
 * The [[Image:Sketcher_CreateLine.svg|24px]] [[Sketcher_CreateLine|Line]] and [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|Polyline]] tools are now grouped by default. A preference allows separating them. [https://github.com/FreeCAD/FreeCAD/pull/30347 Pull request #30347]
-* The new polyline tool uses the original {{KEY|G}}, {{KEY|M}} shortcut. [https://github.com/FreeCAD/FreeCAD/pull/30395 Pull request #30395]
-* Hints were re-added for the polyline tool, describing how to switch between line, arc, and tangent modes. [https://github.com/FreeCAD/FreeCAD/pull/30344 Pull request #30344]
 * When long-pressing an edge shared by two internal faces, the clarify selection menu now lists both adjacent faces. [https://github.com/FreeCAD/FreeCAD/pull/29159 Pull request #29159]
-* Internally-aligned B-spline geometry (weight circles, control polygon edges) is now skipped when using the [[Image:Sketcher_ToggleConstruction.svg|24px]] [[Sketcher_ToggleConstruction|Toggle Construction Geometry]] tool, instead of producing an error. [https://github.com/FreeCAD/FreeCAD/pull/28081 Pull request #28081]
-* The [[Image:Sketcher_ConstrainDistance.svg|24px]] [[Sketcher_ConstrainDistance|Dimension]] tool no longer switches the distance type to ''Horizontal'' or ''Vertical'' when an existing horizontal or vertical dimension is selected. [https://github.com/FreeCAD/FreeCAD/pull/28242 Pull request #28242]
 
 
 == Spreadsheet Workbench == <!--T:53-->

--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -467,6 +467,14 @@ ToDo (last check: 20260430, #29258):
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 * Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
 
+* The [[Image:Sketcher_CreateLine.svg|24px]] [[Sketcher_CreateLine|Line]] and [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|Polyline]] tools are now grouped by default. A preference allows separating them. [https://github.com/FreeCAD/FreeCAD/pull/30347 Pull request #30347]
+* The new polyline tool uses the original {{KEY|G}}, {{KEY|M}} shortcut. [https://github.com/FreeCAD/FreeCAD/pull/30395 Pull request #30395]
+* Hints were re-added for the polyline tool, describing how to switch between line, arc, and tangent modes. [https://github.com/FreeCAD/FreeCAD/pull/30344 Pull request #30344]
+* When long-pressing an edge shared by two internal faces, the clarify selection menu now lists both adjacent faces. [https://github.com/FreeCAD/FreeCAD/pull/29159 Pull request #29159]
+* Internally-aligned B-spline geometry (weight circles, control polygon edges) is now skipped when using the [[Image:Sketcher_ToggleConstruction.svg|24px]] [[Sketcher_ToggleConstruction|Toggle Construction Geometry]] tool, instead of producing an error. [https://github.com/FreeCAD/FreeCAD/pull/28081 Pull request #28081]
+* The [[Image:Sketcher_ConstrainDistance.svg|24px]] [[Sketcher_ConstrainDistance|Dimension]] tool no longer switches the distance type to ''Horizontal'' or ''Vertical'' when an existing horizontal or vertical dimension is selected. [https://github.com/FreeCAD/FreeCAD/pull/28242 Pull request #28242]
+
+
 == Spreadsheet Workbench == <!--T:53-->
 
 === Further Spreadsheet improvements === <!--T:54-->

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -46,6 +46,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Std_VarSet|VarSet]] ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 * There is now a warning when saving files created in older versions. A preference was added to allow disabling it. [https://github.com/FreeCAD/FreeCAD/pull/28389 Pull request #28389]
 * Clearing the recent files list now asks for confirmation before the list is removed. [https://github.com/FreeCAD/FreeCAD/pull/27274 Pull request #27274]
+* The notification area unread count is now initialized on startup, showing the correct count from the beginning. [https://github.com/FreeCAD/FreeCAD/pull/29391 Pull request #29391]
 
 == Core system and API ==
 
@@ -94,7 +95,9 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * On Unix-like systems, lock files now use owner-only permissions, and Coin image export avoids creating world-writable files. [https://github.com/FreeCAD/FreeCAD/pull/30239 Pull request #30239]
 * The Conda release build preset now enables {{Incode|FREECAD_WARN_ERROR}}, and related warnings were fixed so release CI catches new compiler warnings earlier. [https://github.com/FreeCAD/FreeCAD/pull/30228 Pull request #30228]
 * The [[Image:Std_TransformManip.svg|24px]] [[Std TransformManip|Transform]] tool can now use the ''Center of mass / centroid'' mode with [[App_Link|Links]] and [[Std_Part|Part containers]]. [https://github.com/FreeCAD/FreeCAD/pull/30208 Pull request #30208]
+* The placement of Part origins is now read-only and can no longer be changed by accident. [https://github.com/FreeCAD/FreeCAD/pull/28076 Pull request #28076]
 * Toponaming support was improved for the Python API so that add-ons can be more stable in terms of [[Topological_naming_problem|TNP]]. [https://github.com/FreeCAD/FreeCAD/pull/24632 Pull request #24632]
+* The [[Image:Std_MassProperties.svg|24px]] [[Std_MassProperties|Mass Properties]] view provider now shows icons at the center of gravity and center of volume, making them easier to locate in the 3D view. [https://github.com/FreeCAD/FreeCAD/pull/29288 Pull request #29288]
 
 === API ===
 
@@ -125,6 +128,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Editing sketches from assemblies no longer briefly activates the sketch's source document or crashes when leaving the Assembly context. [https://github.com/FreeCAD/FreeCAD/pull/29271 Pull request #29271]
 * [[Assembly_CreateSimulation|Simulations]] now offer export to video format. [https://github.com/FreeCAD/FreeCAD/pull/25307 Pull request #25307]
 * [[Assembly_CreateView|Exploded View]] can now be created temporarily. [https://github.com/FreeCAD/FreeCAD/pull/25456 Pull request #25456]
+* The [[Assembly_CreateSimulation|Simulation]] playback buttons have been made bigger and more visually distinct. [https://github.com/FreeCAD/FreeCAD/pull/30257 Pull request #30257]
 
 == BIM Workbench ==
 
@@ -132,7 +136,7 @@ ToDo (last check: 20260430, #27222):
 * https://github.com/FreeCAD/FreeCAD/pull/24078
 * https://github.com/FreeCAD/FreeCAD/pull/24190
 * https://github.com/FreeCAD/FreeCAD/pull/27222
-* https://github.com/FreeCAD/FreeCAD/pull/28504
+* [[Arch_Site|Site]] objects now have a dedicated task panel with sections for Location, Shape, Terrain and Metadata, making site editing more user-friendly. [https://github.com/FreeCAD/FreeCAD/pull/28504 Pull request #28504]
 * Removing a wall base now preserves the wall's placement and parametric dimensions for supported straight Draft or Sketch bases, and warns before removing unsupported complex bases. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
 * [[Arch_Wall|Walls]] can now be created without a base object by default, with the selected wall baseline mode remembered in preferences. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]
 * The BIM Project command was removed from the toolbar, moved to the Utils menu, renamed for IFC-project clarity, and the Setup Project dialog now defaults to non-IFC-native projects. [https://github.com/FreeCAD/FreeCAD/pull/25086 Pull request #25086]
@@ -151,6 +155,7 @@ ToDo (last check: 20260430, #27222):
 * [[BIM_DrawingView|DrawingView]] cut lines now use the default line width and cut areas line thickness ratio preferences for thicker cut-line output. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]
 * IFC import now treats a multicore preference value of 0 as disabled before creating the IfcOpenShell geometry iterator, avoiding invalid worker counts when multicore processing is turned off. [https://github.com/FreeCAD/FreeCAD/pull/30201 Pull request #30201]
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
+* The endpoints of walls without a base object can now be edited in [[Draft_Workbench|Draft]], allowing interactive wall reshaping in plan view. [https://github.com/FreeCAD/FreeCAD/pull/29860 Pull request #29860]
 
 == CAM Workbench ==
 
@@ -222,6 +227,10 @@ ToDo (last check: 20260430, #27222):
 * CAM drilling cycle expansion now uses MachineState for more accurate machine state tracking while expanding drilling cycles. [https://github.com/FreeCAD/FreeCAD/pull/30112 Pull request #30112]
 * The [[CAM_Profile|Profile]] and [[CAM_Pocket_Shape|Pocket]] linking options now include collision-avoidance strategies for using retract height, clearance height, line-of-sight checks, tool diameter, or tool shape. [https://github.com/FreeCAD/FreeCAD/pull/29983 Pull request #29983]
 # The Linking generator was added to the [[CAM_Engrave|Engrave]] and [[CAM_Deburr|Deburr]] operations to use the safe height instead of clearance height for linking moves. The Linking Mode and Safety Margin options were added to the task panels, also for [[CAM_Drilling|Drilling]] and [[CAM_Helix|Helix]] operations. [https://github.com/FreeCAD/FreeCAD/pull/29959 Pull request #29959]
+* The [[CAM_LeadInOut|LeadInOut]] dressup now supports ExtendLeadIn and ExtendLeadOut properties for the Arc, Line, Perpendicular and Tangent styles. [https://github.com/FreeCAD/FreeCAD/pull/29061 Pull request #29061]
+* The Spiral generator now validates G-code output with deviation-based testing instead of exact string comparisons. [https://github.com/FreeCAD/FreeCAD/pull/28596 Pull request #28596]
+* A tolerance parameter was added to the Linking generator collision check, making it possible to adjust collision detection sensitivity. [https://github.com/FreeCAD/FreeCAD/pull/28140 Pull request #28140]
+* Several fixes were applied to machine-based postprocessing, improving G-code output for different machine configurations. [https://github.com/FreeCAD/FreeCAD/pull/28563 Pull request #28563]
 
 == Draft Workbench ==
 
@@ -239,6 +248,10 @@ ToDo (last check: 20260430, #29258):
 === Further Draft improvements ===
 
 * [[Draft_Trimex|Trimex]] now reports unsupported sketch selections before opening the task panel, avoiding a misleading no-op workflow. [https://github.com/FreeCAD/FreeCAD/pull/29845 Pull request #29845]
+* Hints were added for the Draft annotation tools (Dimension, Label, ShapeString, etc.), describing available modifiers and keyboard shortcuts in the task panel. [https://github.com/FreeCAD/FreeCAD/pull/29649 Pull request #29649]
+* [[Draft_PolarArray|Polar]] and [[Draft_CircularArray|Circular Array]] now respect the active working plane, making them usable in 3D workflows with custom work planes. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
+* UTF-16 encoded SVG files (e.g., generated by Corel Draw on Windows) can now be imported. [https://github.com/FreeCAD/FreeCAD/pull/29244 Pull request #29244]
+* When saving [[Draft_AnnotationStyleEditor|Annotation Styles]], the file extension is now automatically ensured. [https://github.com/FreeCAD/FreeCAD/pull/30358 Pull request #30358]
 
 == FEM Workbench ==
 
@@ -323,6 +336,7 @@ ToDo (last check: 20260430, #29258):
 * Extruding text sketches in the Part Workbench is now faster, especially for sketches that produce many wires. [https://github.com/FreeCAD/FreeCAD/pull/28344 Pull request #28344]
 * The attachment system now correctly offers modes such as ''XY parallel to Plane'' when selecting origin datum planes through an Origin object. [https://github.com/FreeCAD/FreeCAD/pull/28958 Pull request #28958]
 * [[Part_Loft|Loft]] creation now allows valid profile combinations that share the same center of gravity while still guarding against the crash case fixed for duplicate profiles. [https://github.com/FreeCAD/FreeCAD/pull/29982 Pull request #29982]
+* Input hints were added for the [[Part_EditAttachment|Attachment]] dialog, showing key bindings for toggling through attachment modes and confirming selections. [https://github.com/FreeCAD/FreeCAD/pull/29614 Pull request #29614]
 
 == Part Design Workbench ==
 
@@ -365,6 +379,7 @@ ToDo (last check: 20260430, #29258):
 
 === Further Points improvements ===
 
+* The Points Workbench now uses modern libE57 types, following the update of the internal libE57 copy. [https://github.com/FreeCAD/FreeCAD/pull/27434 Pull request #27434]
 == Reverse Engineering Workbench ==
 
 === Further Reverse Engineering improvements ===
@@ -425,6 +440,12 @@ ToDo (last check: 20260430, #29258):
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 * Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
+* The [[Image:Sketcher_CreateLine.svg|24px]] [[Sketcher_CreateLine|Line]] and [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|Polyline]] tools are now grouped by default. A preference allows separating them. [https://github.com/FreeCAD/FreeCAD/pull/30347 Pull request #30347]
+* The new polyline tool uses the original {{KEY|G}}, {{KEY|M}} shortcut. [https://github.com/FreeCAD/FreeCAD/pull/30395 Pull request #30395]
+* Hints were re-added for the polyline tool, describing how to switch between line, arc, and tangent modes. [https://github.com/FreeCAD/FreeCAD/pull/30344 Pull request #30344]
+* When long-pressing an edge shared by two internal faces, the clarify selection menu now lists both adjacent faces. [https://github.com/FreeCAD/FreeCAD/pull/29159 Pull request #29159]
+* Internally-aligned B-spline geometry (weight circles, control polygon edges) is now skipped when using the [[Image:Sketcher_ToggleConstruction.svg|24px]] [[Sketcher_ToggleConstruction|Toggle Construction Geometry]] tool, instead of producing an error. [https://github.com/FreeCAD/FreeCAD/pull/28081 Pull request #28081]
+* The [[Image:Sketcher_ConstrainDistance.svg|24px]] [[Sketcher_ConstrainDistance|Dimension]] tool no longer switches the distance type to ''Horizontal'' or ''Vertical'' when an existing horizontal or vertical dimension is selected. [https://github.com/FreeCAD/FreeCAD/pull/28242 Pull request #28242]
 
 == Spreadsheet Workbench ==
 
@@ -457,6 +478,7 @@ ToDo (last check: 20260430, #29258):
 * The default TechDraw page color in the FreeCAD Light preference pack is now white, avoiding gray page backgrounds when printing. [https://github.com/FreeCAD/FreeCAD/pull/30129 Pull request #30129]
 * The task panel of the [[TechDraw_Balloon|Balloon Annotation]] tool was polished. [https://github.com/FreeCAD/FreeCAD/pull/28101 Pull request #28101]
 * The ASME ANSIB TechDraw template now has a transparent background, matching the other drawing templates. [https://github.com/FreeCAD/FreeCAD/pull/30025 Pull request #30025]
+* [[TechDraw_Workbench|TechDraw]] now supports horizontal and vertical dimensions between circle edges (instead of always falling back to a Distance dimension). [https://github.com/FreeCAD/FreeCAD/pull/30379 Pull request #30379]
 
 == Import and export ==
 

--- a/wiki/en/Release_notes_1.2.wikitext
+++ b/wiki/en/Release_notes_1.2.wikitext
@@ -46,7 +46,6 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * The [[Std_VarSet|VarSet]] ''Rename Property Group'' dialog now offers autocompletion for existing property groups, making it easier to move variables between groups. [https://github.com/FreeCAD/FreeCAD/pull/30200 Pull request #30200]
 * There is now a warning when saving files created in older versions. A preference was added to allow disabling it. [https://github.com/FreeCAD/FreeCAD/pull/28389 Pull request #28389]
 * Clearing the recent files list now asks for confirmation before the list is removed. [https://github.com/FreeCAD/FreeCAD/pull/27274 Pull request #27274]
-* The notification area unread count is now initialized on startup, showing the correct count from the beginning. [https://github.com/FreeCAD/FreeCAD/pull/29391 Pull request #29391]
 
 == Core system and API ==
 
@@ -95,9 +94,7 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * On Unix-like systems, lock files now use owner-only permissions, and Coin image export avoids creating world-writable files. [https://github.com/FreeCAD/FreeCAD/pull/30239 Pull request #30239]
 * The Conda release build preset now enables {{Incode|FREECAD_WARN_ERROR}}, and related warnings were fixed so release CI catches new compiler warnings earlier. [https://github.com/FreeCAD/FreeCAD/pull/30228 Pull request #30228]
 * The [[Image:Std_TransformManip.svg|24px]] [[Std TransformManip|Transform]] tool can now use the ''Center of mass / centroid'' mode with [[App_Link|Links]] and [[Std_Part|Part containers]]. [https://github.com/FreeCAD/FreeCAD/pull/30208 Pull request #30208]
-* The placement of Part origins is now read-only and can no longer be changed by accident. [https://github.com/FreeCAD/FreeCAD/pull/28076 Pull request #28076]
 * Toponaming support was improved for the Python API so that add-ons can be more stable in terms of [[Topological_naming_problem|TNP]]. [https://github.com/FreeCAD/FreeCAD/pull/24632 Pull request #24632]
-* The [[Image:Std_MassProperties.svg|24px]] [[Std_MassProperties|Mass Properties]] view provider now shows icons at the center of gravity and center of volume, making them easier to locate in the 3D view. [https://github.com/FreeCAD/FreeCAD/pull/29288 Pull request #29288]
 
 === API ===
 
@@ -128,7 +125,6 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * Editing sketches from assemblies no longer briefly activates the sketch's source document or crashes when leaving the Assembly context. [https://github.com/FreeCAD/FreeCAD/pull/29271 Pull request #29271]
 * [[Assembly_CreateSimulation|Simulations]] now offer export to video format. [https://github.com/FreeCAD/FreeCAD/pull/25307 Pull request #25307]
 * [[Assembly_CreateView|Exploded View]] can now be created temporarily. [https://github.com/FreeCAD/FreeCAD/pull/25456 Pull request #25456]
-* The [[Assembly_CreateSimulation|Simulation]] playback buttons have been made bigger and more visually distinct. [https://github.com/FreeCAD/FreeCAD/pull/30257 Pull request #30257]
 
 == BIM Workbench ==
 
@@ -136,7 +132,7 @@ ToDo (last check: 20260430, #27222):
 * https://github.com/FreeCAD/FreeCAD/pull/24078
 * https://github.com/FreeCAD/FreeCAD/pull/24190
 * https://github.com/FreeCAD/FreeCAD/pull/27222
-* [[Arch_Site|Site]] objects now have a dedicated task panel with sections for Location, Shape, Terrain and Metadata, making site editing more user-friendly. [https://github.com/FreeCAD/FreeCAD/pull/28504 Pull request #28504]
+* https://github.com/FreeCAD/FreeCAD/pull/28504
 * Removing a wall base now preserves the wall's placement and parametric dimensions for supported straight Draft or Sketch bases, and warns before removing unsupported complex bases. [https://github.com/FreeCAD/FreeCAD/pull/24550 Pull request #24550]
 * [[Arch_Wall|Walls]] can now be created without a base object by default, with the selected wall baseline mode remembered in preferences. [https://github.com/FreeCAD/FreeCAD/pull/24595 Pull request #24595]
 * The BIM Project command was removed from the toolbar, moved to the Utils menu, renamed for IFC-project clarity, and the Setup Project dialog now defaults to non-IFC-native projects. [https://github.com/FreeCAD/FreeCAD/pull/25086 Pull request #25086]
@@ -155,7 +151,6 @@ ToDo (last check: 20260430, #27222):
 * [[BIM_DrawingView|DrawingView]] cut lines now use the default line width and cut areas line thickness ratio preferences for thicker cut-line output. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]
 * IFC import now treats a multicore preference value of 0 as disabled before creating the IfcOpenShell geometry iterator, avoiding invalid worker counts when multicore processing is turned off. [https://github.com/FreeCAD/FreeCAD/pull/30201 Pull request #30201]
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
-* The endpoints of walls without a base object can now be edited in [[Draft_Workbench|Draft]], allowing interactive wall reshaping in plan view. [https://github.com/FreeCAD/FreeCAD/pull/29860 Pull request #29860]
 
 == CAM Workbench ==
 
@@ -227,10 +222,6 @@ ToDo (last check: 20260430, #27222):
 * CAM drilling cycle expansion now uses MachineState for more accurate machine state tracking while expanding drilling cycles. [https://github.com/FreeCAD/FreeCAD/pull/30112 Pull request #30112]
 * The [[CAM_Profile|Profile]] and [[CAM_Pocket_Shape|Pocket]] linking options now include collision-avoidance strategies for using retract height, clearance height, line-of-sight checks, tool diameter, or tool shape. [https://github.com/FreeCAD/FreeCAD/pull/29983 Pull request #29983]
 # The Linking generator was added to the [[CAM_Engrave|Engrave]] and [[CAM_Deburr|Deburr]] operations to use the safe height instead of clearance height for linking moves. The Linking Mode and Safety Margin options were added to the task panels, also for [[CAM_Drilling|Drilling]] and [[CAM_Helix|Helix]] operations. [https://github.com/FreeCAD/FreeCAD/pull/29959 Pull request #29959]
-* The [[CAM_LeadInOut|LeadInOut]] dressup now supports ExtendLeadIn and ExtendLeadOut properties for the Arc, Line, Perpendicular and Tangent styles. [https://github.com/FreeCAD/FreeCAD/pull/29061 Pull request #29061]
-* The Spiral generator now validates G-code output with deviation-based testing instead of exact string comparisons. [https://github.com/FreeCAD/FreeCAD/pull/28596 Pull request #28596]
-* A tolerance parameter was added to the Linking generator collision check, making it possible to adjust collision detection sensitivity. [https://github.com/FreeCAD/FreeCAD/pull/28140 Pull request #28140]
-* Several fixes were applied to machine-based postprocessing, improving G-code output for different machine configurations. [https://github.com/FreeCAD/FreeCAD/pull/28563 Pull request #28563]
 
 == Draft Workbench ==
 
@@ -248,10 +239,6 @@ ToDo (last check: 20260430, #29258):
 === Further Draft improvements ===
 
 * [[Draft_Trimex|Trimex]] now reports unsupported sketch selections before opening the task panel, avoiding a misleading no-op workflow. [https://github.com/FreeCAD/FreeCAD/pull/29845 Pull request #29845]
-* Hints were added for the Draft annotation tools (Dimension, Label, ShapeString, etc.), describing available modifiers and keyboard shortcuts in the task panel. [https://github.com/FreeCAD/FreeCAD/pull/29649 Pull request #29649]
-* [[Draft_PolarArray|Polar]] and [[Draft_CircularArray|Circular Array]] now respect the active working plane, making them usable in 3D workflows with custom work planes. [https://github.com/FreeCAD/FreeCAD/pull/28324 Pull request #28324]
-* UTF-16 encoded SVG files (e.g., generated by Corel Draw on Windows) can now be imported. [https://github.com/FreeCAD/FreeCAD/pull/29244 Pull request #29244]
-* When saving [[Draft_AnnotationStyleEditor|Annotation Styles]], the file extension is now automatically ensured. [https://github.com/FreeCAD/FreeCAD/pull/30358 Pull request #30358]
 
 == FEM Workbench ==
 
@@ -336,7 +323,6 @@ ToDo (last check: 20260430, #29258):
 * Extruding text sketches in the Part Workbench is now faster, especially for sketches that produce many wires. [https://github.com/FreeCAD/FreeCAD/pull/28344 Pull request #28344]
 * The attachment system now correctly offers modes such as ''XY parallel to Plane'' when selecting origin datum planes through an Origin object. [https://github.com/FreeCAD/FreeCAD/pull/28958 Pull request #28958]
 * [[Part_Loft|Loft]] creation now allows valid profile combinations that share the same center of gravity while still guarding against the crash case fixed for duplicate profiles. [https://github.com/FreeCAD/FreeCAD/pull/29982 Pull request #29982]
-* Input hints were added for the [[Part_EditAttachment|Attachment]] dialog, showing key bindings for toggling through attachment modes and confirming selections. [https://github.com/FreeCAD/FreeCAD/pull/29614 Pull request #29614]
 
 == Part Design Workbench ==
 
@@ -379,7 +365,6 @@ ToDo (last check: 20260430, #29258):
 
 === Further Points improvements ===
 
-* The Points Workbench now uses modern libE57 types, following the update of the internal libE57 copy. [https://github.com/FreeCAD/FreeCAD/pull/27434 Pull request #27434]
 == Reverse Engineering Workbench ==
 
 === Further Reverse Engineering improvements ===
@@ -440,12 +425,6 @@ ToDo (last check: 20260430, #29258):
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 * Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
-* The [[Image:Sketcher_CreateLine.svg|24px]] [[Sketcher_CreateLine|Line]] and [[Image:Sketcher_CreatePolyline.svg|24px]] [[Sketcher_CreatePolyline|Polyline]] tools are now grouped by default. A preference allows separating them. [https://github.com/FreeCAD/FreeCAD/pull/30347 Pull request #30347]
-* The new polyline tool uses the original {{KEY|G}}, {{KEY|M}} shortcut. [https://github.com/FreeCAD/FreeCAD/pull/30395 Pull request #30395]
-* Hints were re-added for the polyline tool, describing how to switch between line, arc, and tangent modes. [https://github.com/FreeCAD/FreeCAD/pull/30344 Pull request #30344]
-* When long-pressing an edge shared by two internal faces, the clarify selection menu now lists both adjacent faces. [https://github.com/FreeCAD/FreeCAD/pull/29159 Pull request #29159]
-* Internally-aligned B-spline geometry (weight circles, control polygon edges) is now skipped when using the [[Image:Sketcher_ToggleConstruction.svg|24px]] [[Sketcher_ToggleConstruction|Toggle Construction Geometry]] tool, instead of producing an error. [https://github.com/FreeCAD/FreeCAD/pull/28081 Pull request #28081]
-* The [[Image:Sketcher_ConstrainDistance.svg|24px]] [[Sketcher_ConstrainDistance|Dimension]] tool no longer switches the distance type to ''Horizontal'' or ''Vertical'' when an existing horizontal or vertical dimension is selected. [https://github.com/FreeCAD/FreeCAD/pull/28242 Pull request #28242]
 
 == Spreadsheet Workbench ==
 
@@ -478,7 +457,6 @@ ToDo (last check: 20260430, #29258):
 * The default TechDraw page color in the FreeCAD Light preference pack is now white, avoiding gray page backgrounds when printing. [https://github.com/FreeCAD/FreeCAD/pull/30129 Pull request #30129]
 * The task panel of the [[TechDraw_Balloon|Balloon Annotation]] tool was polished. [https://github.com/FreeCAD/FreeCAD/pull/28101 Pull request #28101]
 * The ASME ANSIB TechDraw template now has a transparent background, matching the other drawing templates. [https://github.com/FreeCAD/FreeCAD/pull/30025 Pull request #30025]
-* [[TechDraw_Workbench|TechDraw]] now supports horizontal and vertical dimensions between circle edges (instead of always falling back to a Distance dimension). [https://github.com/FreeCAD/FreeCAD/pull/30379 Pull request #30379]
 
 == Import and export ==
 


### PR DESCRIPTION
## Summary

This PR adds missing Sketcher Workbench release notes as part of Bounty #30. Unlike the previous PR #347 (which was closed), this version:
- Modifies only the wiki root file (`wiki/Release_notes_1.2.wikitext`), not the translation file
- Does not add any new `<translate>`, `</translate>`, or `<!--T:-->` tags

### Changes made:

**Sketcher Workbench:**
- Group Polyline and Line tools by default ([#30347](https://github.com/FreeCAD/FreeCAD/pull/30347))
- Use original shortcut for new polyline tool ([#30395](https://github.com/FreeCAD/FreeCAD/pull/30395))
- Re-add hints for polyline tool ([#30344](https://github.com/FreeCAD/FreeCAD/pull/30344))
- Show adjacent faces in clarify selection menu ([#29159](https://github.com/FreeCAD/FreeCAD/pull/29159))
- Skip non-toggleable geometry in ToggleConstruction ([#28081](https://github.com/FreeCAD/FreeCAD/pull/28081))
- Dimension tool no longer switches distance type on existing hor/ver dimensions ([#28242](https://github.com/FreeCAD/FreeCAD/pull/28242))