### PR TITLE
docs: update PartDesign Body visibility behavior

### DIFF
--- a/wiki/PartDesign_Body.wikitext
+++ b/wiki/PartDesign_Body.wikitext
@@ -209,6 +209,15 @@ The Body's visibility supersedes the visibility of any object it contains. If th
 <!--T:86-->
 Multiple [[Sketch|Sketches]] may be visible at one time, but only one [[PartDesign_Feature|PartDesign Feature]] (solid result) can be visible at a time. Selecting a hidden feature and pressing the {{KEY|Space}} bar in the keyboard will make it visible, and automatically hide the previously visible feature.
 
+<!--T:102-->
+{{Version|1.2}} The behavior of the {{KEY|Space}} bar depends on where the selection was made:
+
+* '''From the [[3D_View|3D View]]''': Pressing {{KEY|Space}} toggles the visibility of the entire [[PartDesign_Body|Body]]. This applies regardless of whether a feature or the Body itself is selected.
+* '''From the [[Tree_View|Tree View]]''': Pressing {{KEY|Space}} toggles the visibility of the selected object (feature, sketch, datum, etc.) without affecting the Body's overall visibility.
+
+<!--T:103-->
+{{Emphasis|Note:}} Features that do not create geometry (Sketches, Datums, Binders, etc.) always toggle individually, regardless of the selection source.
+
 <!--T:87-->
 [[File:PartDesign_Body_Visibility.png]]
 {{Caption|PartDesign Body: multiple [[Sketch|Sketches]] may be visible simultaneously, but only one solid [[PartDesign_Feature|PartDesign Feature]] may be visible at one time, whether it is the Tip or not.}}


### PR DESCRIPTION
## Summary

Update the PartDesign Body documentation to reflect the new spacebar visibility behavior introduced in FreeCAD 1.2.

### Changes

Updated the **Visibility management** section of `PartDesign_Body.wikitext` to document:

- **From 3D View**: Pressing Space toggles the visibility of the entire Body (not individual features)
- **From Tree View**: Pressing Space toggles the visibility of the selected object (feature, sketch, datum, etc.)
- **Non-geometry features**: Sketches, Datums, Binders, etc. always toggle individually regardless of selection source

### Context

This change reflects the behavior introduced in:
- [FreeCAD PR #29110](https://github.com/FreeCAD/FreeCAD/pull/29110): Initial change to toggle Body instead of feature from 3D view
- [FreeCAD PR #30231](https://github.com/FreeCAD/FreeCAD/pull/30231): Refined behavior to distinguish between 3D view and tree view selections

### Version Note

Added `{{Version|1.2}}` template to indicate this behavior was introduced in FreeCAD 1.2.
