### PR TITLE
doc: Document missing Draft workbench features

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -267,6 +267,10 @@ ToDo (last check: 20260430, #29258):
 
 <!--T:87-->
 * [[Draft_Trimex|Trimex]] now reports unsupported sketch selections before opening the task panel, avoiding a misleading no-op workflow. [https://github.com/FreeCAD/FreeCAD/pull/29845 Pull request #29845]
+* Base-less walls created in the BIM workbench are now directly Draft-editable, allowing their endpoints to be modified dynamically using Draft edit handles. [https://github.com/FreeCAD/FreeCAD/pull/29860 Pull request #29860]
+* Saving annotation styles now guarantees that the file has a {{FileName|.json}} extension. [https://github.com/FreeCAD/FreeCAD/pull/30358 Pull request #30358]
+* In the Draft ShapeString tool, point coordinates entered manually in the task panel are no longer reset or overwritten by subsequent mouse movements in the 3D view. [https://github.com/FreeCAD/FreeCAD/pull/29762 Pull request #29762]
+* Added on-screen hints for Draft annotation tools to guide user input. [https://github.com/FreeCAD/FreeCAD/pull/29649 Pull request #29649]
 
 == FEM Workbench == <!--T:29-->
 


### PR DESCRIPTION
### Missing Draft Workbench Features for FreeCAD 1.2 Release Notes

This PR adds missing documentation for user-facing features and bug fixes merged during the FreeCAD 1.2/1.0 release cycle for the Draft workbench. All entries cite their source pull request in the upstream `FreeCAD/FreeCAD` repository.

#### Changes Documented:

1. **BIM Wall Draft Editing support** ([FreeCAD/FreeCAD#29860](https://github.com/FreeCAD/FreeCAD/pull/29860)):
   - *Description:* Base-less walls created in the BIM workbench are now directly Draft-editable. Users can dynamically modify endpoints using standard Draft edit handles.
   - *Impact:* Improves workbench interoperability and workflow fluidity.

2. **Annotation Style JSON extensions** ([FreeCAD/FreeCAD#30358](https://github.com/FreeCAD/FreeCAD/pull/30358)):
   - *Description:* Saving annotation styles now guarantees that the file has a `.json` extension.
   - *Impact:* Standardizes file export naming and avoids configuration loading issues.

3. **Draft ShapeString Task Panel coordinates preservation** ([FreeCAD/FreeCAD#29762](https://github.com/FreeCAD/FreeCAD/pull/29762)):
   - *Description:* In the ShapeString tool task panel, manually entered point coordinates are no longer reset or overwritten by subsequent mouse movements in the 3D view.
   - *Impact:* Resolves a key user interface friction point during coordinate input.

4. **Hints for Annotation Tools** ([FreeCAD/FreeCAD#29649](https://github.com/FreeCAD/FreeCAD/pull/29649)):
   - *Description:* Added on-screen hints for Draft annotation tools to guide user input.
   - *Impact:* Improves discoverability and ease of use for new users.