### PR TITLE
doc: Document missing Sketcher workbench features

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -466,6 +466,8 @@ ToDo (last check: 20260430, #29258):
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 * Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
+* Fixed the line style dropdowns in the task panel showing empty selections upon starting the workbench. [https://github.com/FreeCAD/FreeCAD/pull/30151 Pull request #30151]
+* Improved text labeling consistency in the task panel by changing "Change Value" to "Edit Value". [https://github.com/FreeCAD/FreeCAD/pull/29556 Pull request #29556]
 * The [[Sketcher_Dialog#Constraints|Sketcher Dialog]] has two new commands - to delete all constraints and to delete filtered constraints. [https://github.com/FreeCAD/FreeCAD/pull/29993 Pull request #29993]
 
 == Spreadsheet Workbench == <!--T:53-->


### PR DESCRIPTION
### Missing Sketcher Workbench Features for FreeCAD 1.2 Release Notes

This PR documents missing user-facing features and bug fixes in the Sketcher workbench for the FreeCAD 1.2/1.0 release cycle. All entries cite their source pull requests in the upstream `FreeCAD/FreeCAD` repository.

#### Changes Documented:

1. **Line Style Dropdown rendering** ([FreeCAD/FreeCAD#30151](https://github.com/FreeCAD/FreeCAD/pull/30151)):
   - *Description:* Fixed the line style dropdowns in the task panel showing empty selections upon starting the workbench when no custom style sheet is applied.
   - *Impact:* Restores visual dropdown options on launch.

2. **Task Panel label consistency** ([FreeCAD/FreeCAD#29556](https://github.com/FreeCAD/FreeCAD/pull/29556)):
   - *Description:* Improved text labeling consistency in the task panel by renaming the command label from "Change Value" to "Edit Value" to align with the 3D view context menus.
   - *Impact:* Standardizes user interface vocabulary.