### PR TITLE
doc: Document missing 1.2 release notes information

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -267,6 +267,10 @@ ToDo (last check: 20260430, #29258):
 
 <!--T:87-->
 * [[Draft_Trimex|Trimex]] now reports unsupported sketch selections before opening the task panel, avoiding a misleading no-op workflow. [https://github.com/FreeCAD/FreeCAD/pull/29845 Pull request #29845]
+* Base-less walls created in the BIM workbench are now directly Draft-editable, allowing their endpoints to be modified dynamically using Draft edit handles. [https://github.com/FreeCAD/FreeCAD/pull/29860 Pull request #29860]
+* Saving annotation styles now guarantees that the file has a {{FileName|.json}} extension. [https://github.com/FreeCAD/FreeCAD/pull/30358 Pull request #30358]
+* In the Draft ShapeString tool, point coordinates entered manually in the task panel are no longer reset or overwritten by subsequent mouse movements in the 3D view. [https://github.com/FreeCAD/FreeCAD/pull/29762 Pull request #29762]
+* Added on-screen hints for Draft annotation tools to guide user input. [https://github.com/FreeCAD/FreeCAD/pull/29649 Pull request #29649]
 
 == FEM Workbench == <!--T:29-->
 
@@ -389,6 +393,9 @@ ToDo (last check: 20260430, #29258):
 * Errors from Part Design dress-up features such as chamfers and fillets are now shown in the notification area and Report view instead of a popup dialog, allowing users to stay in the task panel. [https://github.com/FreeCAD/FreeCAD/pull/28131 Pull request #28131]
 * Now unhiding a Body with no visible features also unhides its tip. [https://github.com/FreeCAD/FreeCAD/pull/24887 Pull request #24887]
 * Changing a [[PartDesign_Pad|Pad]] to the ''Up To Face'' type no longer crashes if the feature is not inside a [[PartDesign_Body|Body]]; an error is reported instead. [https://github.com/FreeCAD/FreeCAD/pull/30022 Pull request #30022]
+* Fixed the UpToShape extrusion pocket/pad logic when computing against complex geometric target bodies. [https://github.com/FreeCAD/FreeCAD/pull/29686 Pull request #29686]
+* Starting the Chamfer tool now correctly activates selection mode immediately upon GUI initialization. [https://github.com/FreeCAD/FreeCAD/pull/29313 Pull request #29313]
+* Fixed Length and Length2 expression migration handling for TwoLengths pad parameters. [https://github.com/FreeCAD/FreeCAD/pull/29247 Pull request #29247]
 * Pressing {{KEY|Space}} on an element selected from the 3D view (e.g. from selecting a face) now toggles the visibility of the entire [[PartDesign_Body|PartDesign Body]] instead of the last feature, making it easier to show or hide bodies in assemblies or files with multiple bodies. Selection in the Tree view still toggles the selected object. [https://github.com/FreeCAD/FreeCAD/pull/29110 Pull request #29110] and [https://github.com/FreeCAD/FreeCAD/pull/30231 Pull request #30231]
 * Input hints were implemented for the interactive control draggers. [https://github.com/FreeCAD/FreeCAD/pull/29631 Pull request #29631]
 * [[PartDesign_SubShapeBinder|SubShapeBinder]] now uses the ''BuildFace'' face maker to handle overlapping geometry. [https://github.com/FreeCAD/FreeCAD/pull/29249 Pull request #29249]
@@ -466,6 +473,8 @@ ToDo (last check: 20260430, #29258):
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 * Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
+* Fixed the line style dropdowns in the task panel showing empty selections upon starting the workbench. [https://github.com/FreeCAD/FreeCAD/pull/30151 Pull request #30151]
+* Improved text labeling consistency in the task panel by changing "Change Value" to "Edit Value". [https://github.com/FreeCAD/FreeCAD/pull/29556 Pull request #29556]
 * The [[Sketcher_Dialog#Constraints|Sketcher Dialog]] has two new commands - to delete all constraints and to delete filtered constraints. [https://github.com/FreeCAD/FreeCAD/pull/29993 Pull request #29993]
 
 == Spreadsheet Workbench == <!--T:53-->


### PR DESCRIPTION
### Missing Release Notes Information for FreeCAD 1.2 Release Notes

This PR documents missing user-facing features and bug fixes across the Draft, PartDesign, and Sketcher workbenches for the FreeCAD 1.2/1.0 release cycle. All entries cite their source pull requests in the upstream `FreeCAD/FreeCAD` repository.

#### Draft Workbench Changes Documented:
* **BIM Wall Draft Editing support** ([FreeCAD/FreeCAD#29860](https://github.com/FreeCAD/FreeCAD/pull/29860)): Base-less walls created in the BIM workbench are now directly Draft-editable.
* **Annotation Style JSON extensions** ([FreeCAD/FreeCAD#30358](https://github.com/FreeCAD/FreeCAD/pull/30358)): Saving annotation styles now guarantees that the file has a `.json` extension.
* **Draft ShapeString Task Panel coordinates preservation** ([FreeCAD/FreeCAD#29762](https://github.com/FreeCAD/FreeCAD/pull/29762)): Point coordinates manually entered are no longer overwritten by mouse movements.
* **Hints for Annotation Tools** ([FreeCAD/FreeCAD#29649](https://github.com/FreeCAD/FreeCAD/pull/29649)): Added on-screen hints for Draft annotation tools to guide user input.

#### PartDesign Workbench Changes Documented:
* **UpToShape Extrusion complex target body logic** ([FreeCAD/FreeCAD#29686](https://github.com/FreeCAD/FreeCAD/pull/29686)): Fixed the UpToShape pocket and pad extrusion logic when computing against complex geometric target bodies.
* **Chamfer Tool Selection Mode initialization** ([FreeCAD/FreeCAD#29313](https://github.com/FreeCAD/FreeCAD/pull/29313)): Starting the Chamfer tool now correctly activates selection mode immediately upon GUI initialization.
* **TwoLengths Pad expression migration** ([FreeCAD/FreeCAD#29247](https://github.com/FreeCAD/FreeCAD/pull/29247)): Fixed Length and Length2 expression migration handling for TwoLengths pad parameters.

#### Sketcher Workbench Changes Documented:
* **Line Style Dropdown rendering** ([FreeCAD/FreeCAD#30151](https://github.com/FreeCAD/FreeCAD/pull/30151)): Fixed the line style dropdowns in the task panel showing empty selections upon starting.
* **Task Panel label consistency** ([FreeCAD/FreeCAD#29556](https://github.com/FreeCAD/FreeCAD/pull/29556)): Improved text labeling consistency in the task panel by renaming "Change Value" to "Edit Value".