### PR TITLE
doc: Document missing BIM workbench features

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -173,6 +173,9 @@ ToDo (last check: 20260430, #27222):
 * [[BIM_DrawingView|DrawingView]] cut lines now use the default line width and cut areas line thickness ratio preferences for thicker cut-line output. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]
 * IFC import now treats a multicore preference value of 0 as disabled before creating the IfcOpenShell geometry iterator, avoiding invalid worker counts when multicore processing is turned off. [https://github.com/FreeCAD/FreeCAD/pull/30201 Pull request #30201]
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
+* The BIM Project Manager removed reference to the obsolete NorthDeviation property. [https://github.com/FreeCAD/FreeCAD/pull/28913 Pull request #28913]
+* Fixed Arch CutPlane deselection issue in BIM workbench. [https://github.com/FreeCAD/FreeCAD/pull/29699 Pull request #29699]
+* Fixed an issue where unsupported base objects for ArchWalls were not managed properly. [https://github.com/FreeCAD/FreeCAD/pull/29810 Pull request #29810]
 
 == CAM Workbench == <!--T:25-->
 


### PR DESCRIPTION
### Missing BIM Workbench Features for FreeCAD 1.2 Release Notes

This PR adds missing documentation for user-facing features and bug fixes in the BIM workbench for the FreeCAD 1.2/1.0 release cycle. All entries cite their source pull request in the upstream `FreeCAD/FreeCAD` repository.

#### Changes Documented:

1. **Project Manager obsolete NorthDeviation removal** ([FreeCAD/FreeCAD#28913](https://github.com/FreeCAD/FreeCAD/pull/28913)):
   - *Description:* Removed reference to the obsolete `NorthDeviation` property in the BIM Project Manager.
   - *Impact:* Simplifies project metadata management.

2. **CutPlane Deselection handling** ([FreeCAD/FreeCAD#29699](https://github.com/FreeCAD/FreeCAD/pull/29699)):
   - *Description:* Fixed Arch CutPlane deselection issue in BIM workbench.
   - *Impact:* Ensures correct selection state management.

3. **ArchWall Unsupported Base safety check** ([FreeCAD/FreeCAD#29810](https://github.com/FreeCAD/FreeCAD/pull/29810)):
   - *Description:* Fixed an issue where unsupported base objects for ArchWalls were not managed properly, leading to silent failures or incorrect wall generations.
   - *Impact:* Improves geometry validation when creating walls from profiles.