### PR TITLE
doc: Document missing CAM workbench features

### DIFF
--- a/wiki/Release_notes_1.2.wikitext
+++ b/wiki/Release_notes_1.2.wikitext
@@ -246,6 +246,8 @@ ToDo (last check: 20260430, #27222):
 * CAM drilling cycle expansion now uses MachineState for more accurate machine state tracking while expanding drilling cycles. [https://github.com/FreeCAD/FreeCAD/pull/30112 Pull request #30112]
 * The [[CAM_Profile|Profile]] and [[CAM_Pocket_Shape|Pocket]] linking options now include collision-avoidance strategies for using retract height, clearance height, line-of-sight checks, tool diameter, or tool shape. [https://github.com/FreeCAD/FreeCAD/pull/29983 Pull request #29983]
 * The Linking generator was added to the [[CAM_Engrave|Engrave]] and [[CAM_Deburr|Deburr]] operations to use the safe height instead of clearance height for linking moves. The Linking Mode and Safety Margin options were added to the task panels, also for [[CAM_Drilling|Drilling]] and [[CAM_Helix|Helix]] operations. [https://github.com/FreeCAD/FreeCAD/pull/29959 Pull request #29959]
+* Fixed job toggle freezing in CAM workbench. [https://github.com/FreeCAD/FreeCAD/pull/30240 Pull request #30240]
+* Fixed comment round-trip save/load issues in CAM G-code. [https://github.com/FreeCAD/FreeCAD/pull/30317 Pull request #30317]
 
 == Draft Workbench == <!--T:27-->
 


### PR DESCRIPTION
### Missing CAM Workbench Features for FreeCAD 1.2 Release Notes

This PR documents missing user-facing features and bug fixes in the CAM workbench for the FreeCAD 1.2/1.0 release cycle. All entries cite their source pull request in the upstream `FreeCAD/FreeCAD` repository.

#### Changes Documented:

1. **Job Toggle Freezing fix** ([FreeCAD/FreeCAD#30240](https://github.com/FreeCAD/FreeCAD/pull/30240)):
   - *Description:* Fixed Job toggle freezing in the CAM workbench by skipping redundant recomputes for all sub-operations when the Job is in a frozen state.
   - *Impact:* Eliminates heavy UI lags when switching/freezing CAM jobs.

2. **G-code Comment Round-trip save/load** ([FreeCAD/FreeCAD#30317](https://github.com/FreeCAD/FreeCAD/pull/30317)):
   - *Description:* Fixed G-code save/load comment round-trip formatting issues where space suffixes were incorrectly added to annotations.
   - *Impact:* Ensures comment annotations preserve formatting on round-trip saves.