### PR TITLE
doc: Update external addon documentation and add External Add-ons page

### DIFF
--- a/wiki/Addon.wikitext
+++ b/wiki/Addon.wikitext
@@ -24,11 +24,12 @@ The recommended way to install addons is with the [[File:Std_AddonMgr.svg|24px]]
 But for macros and workbenches manual installation is also possible:
 * [[How_to_install_macros|How to install macros]]
 * [[Installing_more_workbenches|Installing more workbenches]]
+* [[External_Add-ons|External Add-ons]]
 
 == Information for developers == <!--T:13-->
 
 <!--T:14-->
-If you have developed a macro or workbench, and want to see it included in the Addon manager, read how to do so on the repository pages: ([https://github.com/FreeCAD/FreeCAD-addons/ FreeCAD-addons] and [https://github.com/FreeCAD/FreeCAD-macros/ FreeCAD-macros]). If you add your macro to the [[Macros_recipes|Macros recipes]] page, there is nothing else to do, it will automatically be picked up by the Addon manager.
+If you have developed a macro or workbench, and want to see it included in the Addon manager, read how to do so on the repository pages: ([https://github.com/FreeCAD/Addons FreeCAD Addons Repository]). If you add your macro to the [[Macros_recipes|Macros recipes]] page, there is nothing else to do, it will automatically be picked up by the Addon manager.
 
 <!--T:19-->
 See also:

--- a/wiki/External_Add-ons.wikitext
+++ b/wiki/External_Add-ons.wikitext
@@ -1,0 +1,62 @@
+This page provides an overview of external add-ons (workbenches and macros) available for FreeCAD. For the complete and always up-to-date list, visit the [https://github.com/FreeCAD/Addons Addons Repository].
+
+{{TOCright}}
+
+== Official Add-on Repository ==
+
+The [https://github.com/FreeCAD/Addons FreeCAD Addons Repository] is the central index for all FreeCAD add-ons:
+
+* [https://github.com/FreeCAD/Addons/tree/master/Mod Workbenches] — Full workbenches
+* [https://github.com/FreeCAD/Addons/tree/master/Macro Macros] — Python scripts
+
+To install add-ons, use the [[Std_AddonMgr|Addon Manager]] at {{MenuCommand|Tools → Addon Manager}}.
+
+== Popular Workbenches ==
+
+{| class="wikitable"
+! Workbench !! Description !! Repository
+|-
+| SheetMetal || Sheet metal design tools || [https://github.com/shaise/FreeCAD_SheetMetal GitHub]
+|-
+| A2plus || Assembly workbench || [https://github.com/kbwbe/A2plus GitHub]
+|-
+| Fasteners || Standard fastener library || [https://github.com/shaise/FreeCAD_FastenersWB GitHub]
+|-
+| Curves || NURBS curve tools || [https://github.com/tomate44/CurvesWB GitHub]
+|-
+| Assembly3 || Assembly solver || [https://github.com/realthunder/FreeCAD_assembly3 GitHub]
+|}
+
+== Installing Add-ons ==
+
+=== Using the Addon Manager ===
+
+# Go to {{MenuCommand|Tools → Addon Manager}}
+# Browse or search for the desired add-on
+# Click "Install" and restart FreeCAD
+
+=== Manual Installation ===
+
+# Download the add-on repository
+# Place it in your FreeCAD Mod directory:
+** Linux: {{FileName|~/.local/share/FreeCAD/Mod/}}
+** Windows: {{FileName|%APPDATA%\FreeCAD\Mod\}}
+** Mac: {{FileName|~/Library/Application Support/FreeCAD/Mod/}}
+# Restart FreeCAD
+
+== Creating Add-ons ==
+
+* [https://github.com/FreeCAD/Addon-Academy Addon Academy] — Tutorial repository
+* [[Workbench_creation|Workbench Creation Guide]] — Official documentation
+* [https://freecad.github.io/DevelopersHandbook/ Developers Handbook] — Developer guide
+
+== Contributing Add-ons ==
+
+To submit your add-on to the official repository:
+
+# Fork the [https://github.com/FreeCAD/Addons Addons Repository]
+# Add your add-on metadata to the appropriate directory
+# Submit a Pull Request
+# See [https://github.com/FreeCAD/Addons/blob/master/CONTRIBUTING.md CONTRIBUTING.md] for details
+
+[[Category:Addons]]

--- a/wiki/Std_AddonMgr.wikitext
+++ b/wiki/Std_AddonMgr.wikitext
@@ -23,7 +23,7 @@
 ==Description== <!--T:25-->
 
 <!--T:2-->
-The '''Std AddonMgr''' command opens the Addon Manager. With the Addon Manager you can install and manage [https://www.freecad.org/addons.php external workbenches], [[macros|macros]], and [[Preference_Packs|preference packs]] provided by the FreeCAD community. By default the available addons are taken from two repositories, [https://github.com/FreeCAD/FreeCAD-addons/ FreeCAD-addons] and from the [[Macros_recipes|Macros recipes]] page of this wiki. If git is installed on your system, additional macros will be loaded from [https://github.com/FreeCAD/FreeCAD-macros/ FreeCAD-macros]. Custom repositories can be added in the [[Preferences_Editor#Addon_Manager|Addon Manager preferences]].
+The '''Std AddonMgr''' command opens the Addon Manager. With the Addon Manager you can install and manage [https://www.freecad.org/addons.php external workbenches], [[macros|macros]], and [[Preference_Packs|preference packs]] provided by the FreeCAD community. By default the available addons are taken from the official [https://github.com/FreeCAD/Addons FreeCAD Addons Repository] (unified index) and the [[Macros_recipes|Macros recipes]] page of this wiki. Custom repositories can be added in the [[Preferences_Editor#Addon_Manager|Addon Manager preferences]].
 
 <!--T:80-->
 As of May 2025, the Addon Manager can now be used to install and update a self-updating version of itself by installing the "Addon Manager" addon. It is compatible with FreeCAD 0.21 and later.


### PR DESCRIPTION
### Update External Addon Documentation and Add External Add-ons page

This PR provides comprehensive documentation updates for external add-ons, workbenches, and macros. It redirects references to the unified central official FreeCAD Addons Repository (github.com/FreeCAD/Addons) instead of old separate repositories.

#### Changes:

1. **External Add-ons page** (New File `wiki/External_Add-ons.wikitext`):
   - Adds a clean wikitext landing page summarizing official repository details, popular workbenches (SheetMetal, A2plus, Fasteners, Curves, Assembly3), manual and Addon Manager installation steps, and contribution standards.
   - Note: Created as a clean wiki root file without manual `<translate>` or T-tags to allow the translation subsystem to automatically manage multi-language generation.

2. **Addon main wiki page** (`wiki/Addon.wikitext`):
   - Links to the new `External Add-ons` page and redirects instructions to use `github.com/FreeCAD/Addons`.

3. **Std_AddonMgr documentation** (`wiki/Std_AddonMgr.wikitext`):
   - Updates command documentation to reference the unified `FreeCAD/Addons` index.