### PR TITLE
docs: Update Macros recipes with new macros for #332

### DIFF
--- a/wiki/Macros_recipes.wikitext
+++ b/wiki/Macros_recipes.wikitext
@@ -1,4 +1,4 @@
-<languages/>
+﻿<languages/>
 {{TOCright}}
 <translate>
 
@@ -18,6 +18,11 @@ If you have written a macro and want to include it in one of the categories on t
 
 </translate>
 <div class="mw-collapsible-content">
+* {{MacroLink|Icon=FCRotateViewAbsolute.png|FCRotateViewAbsolute|FCRotateViewAbsolute}}: Rotate the view absolutely
+* {{MacroLink|Icon=GuiSpacemouseRotationOff.png|GuiSpacemouseRotationOff|Spacemouse Rotation Off}}: Run to deactivate rotations on Spacemouse device.
+* {{MacroLink|Icon=GuiSpacemouseRotationOn.png|GuiSpacemouseRotationOn|Spacemouse Rotation On}}: Run to activate rotations on Spacemouse device.
+* {{MacroLink|Icon=GuiSpacemouseRotationToggle.png|GuiSpacemouseRotationToggle|Spacemouse Rotation Toggle}}: Run to toggle the activation of rotations on Spacemouse device.
+* {{MacroLink|Icon=ViewRotation.png|ViewRotation|View Rotation}}: This GUI allows the view to be rotated precisely
 <translate>
 
 <!--T:170-->
@@ -170,6 +175,11 @@ If you have written a macro and want to include it in one of the categories on t
 
 </translate>
 <div class="mw-collapsible-content">
+* {{MacroLink|Icon=DxfToSketchLayers.png|DxfToSketchLayers|DXF to Sketch Layers}}: DXF loader to a sketch for each layer or color
+* {{MacroLink|Icon=Export2Slicer.png|Export2Slicer|Export2Slicer}}: Export selected objects to amf/stl files and open them in slicing program
+* {{MacroLink|Icon=FabricationCutlist.png|FabricationCutlist|Fabrication Cutlist Maker}}: For designs made of Part WB Box and Cylinder primitives, creates a CSV cutlist.
+* {{MacroLink|Icon=LabelsToClipboard.png|LabelsToClipboard|Labels to Clipboard}}: Copy the labels of selected objects to the clipboard
+* {{MacroLink|Icon=ObjectsToPython.png|ObjectsToPython|Objects To Python}}: Exports objects from a FreeCAD project to a python script
 <translate>
 
 <!--T:199-->
@@ -275,6 +285,8 @@ If you have written a macro and want to include it in one of the categories on t
 
 </translate>
 <div class="mw-collapsible-content">
+* {{MacroLink|Icon=ExportFem.png|ExportFem|Export Fem}}: This macro exports FEM Data
+* {{MacroLink|Icon=FemAnimateModeShapes.png|FemAnimateModeShapes|Animate Mode Shapes for FEM}}: Animate mode shapes after running CalculiX
 <translate>
 
 <!--T:228-->
@@ -317,6 +329,9 @@ If you have written a macro and want to include it in one of the categories on t
 
 </translate>
 <div class="mw-collapsible-content">
+* {{MacroLink|Icon=DatumPlaneLocalAxis.png|DatumPlaneLocalAxis|Datum-Plane Local Axis}}: Select a datum plane in the 3D view then run, this macro will shows local axes for all selected planes or delete all created local axes if nothing is selected
+* {{MacroLink|Icon=GetGlobalPlacement.png|GetGlobalPlacement|Get Global Placement}}: Get the global placement, respecting links, link arrays and link scale
+* {{MacroLink|Icon=InfoPlus.png|InfoPlus|InfoPlus}}: Shows detailed information
 <translate>
 
 <!--T:235-->
@@ -431,6 +446,20 @@ If you have written a macro and want to include it in one of the categories on t
 
 </translate>
 <div class="mw-collapsible-content">
+* {{MacroLink|Icon=SolidSweep.png|SolidSweep|SolidSweep}}: Creates a solid sweep
+* {{MacroLink|Icon=AirfoilImportAndScale.png|AirfoilImportAndScale|Airfoil Import and Scale}}: Imports and scales an Airfoil in the form of a Draft Wire (DWire) or Basic Spline (BSpline)
+* {{MacroLink|Icon=BoxCreator.png|BoxCreator|BoxCreator}}: Creates a box with interlocked notches
+* {{MacroLink|Icon=BSpline3D.png|BSpline3D|BSpline3D}}: Create a parametric BSpline from Vertices selected in 3D view
+* {{MacroLink|Icon=EllipseCenter2Points.png|EllipseCenter2Points|Ellipse Center + 2 Points}}: Creates an ellipse from center and two points
+* {{MacroLink|Icon=G3d.png|G3d|Generador3D}}: Create a solid with 2 or 3 sketches (views)
+* {{MacroLink|Icon=HalfHull.png|HalfHull|HalfHull}}: Creates a half hull
+* {{MacroLink|Icon=HyperbolaCreater.png|HyperbolaCreater|HyperbolaCreater}}: This macro creates a hyperbola
+* {{MacroLink|Icon=ParabolaCreater.png|ParabolaCreater|Parabola Creater}}: Parabola Creater
+* {{MacroLink|Icon=ScatterObjectsOnSurface.png|ScatterObjectsOnSurface|Scatter Objects on Surface}}: Distribute objects randomly over surfaces of another object with spacing and rotation options.
+* {{MacroLink|Icon=ScrewMaker.png|ScrewMaker|Screw Maker}}: Generate a screw
+* {{MacroLink|Icon=TimingGear.png|TimingGear|GT2/GT3/GT5 Timing Gear Creator}}: GT2/GT3/GT5 Gear Creator Macro (any gear size from 5 to 360 teeth)
+* {{MacroLink|Icon=GeodesicDome.png|GeodesicDome|Geodesic Dome}}: Geodesic Dome
+* {{MacroLink|Icon=HoneycombSolid.png|HoneycombSolid|HoneycombSolid}}: Macro to create a Honeycomb solid
 <translate>
 
 <!--T:261-->
@@ -797,6 +826,12 @@ If you have written a macro and want to include it in one of the categories on t
 
 </translate>
 <div class = "mw-collapsible-content">
+* {{MacroLink|Icon=LasercutterSVGExport.png|LasercutterSVGExport|LasercutterSVGExport}}: Creates contour lines for all selected objects and arranges them on a TechDraw page
+* {{MacroLink|Icon=TechDrawAnnoTextFromv018.png|TechDrawAnnoTextFromv018|TechDrawAnnoTextFromv018}}: Convert v018 Annotation Text size to v019
+* {{MacroLink|Icon=TechDrawMigrateFromv018.png|TechDrawMigrateFromv018|TechDrawMigrateFromv018}}: Convert v018 Rotation property to v019
+* {{MacroLink|Icon=TechDrawSymbolsLibrary.png|TechDrawSymbolsLibrary|FreeCAD Symbols Library}}: Tools to manage FreeCAD Symbols Library
+* {{MacroLink|Icon=TechDrawTools.png|TechDrawTools|TechDrawTools}}: A container, including 38 helper tools to improve the appearance of drawings
+* {{MacroLink|Icon=TechDrawViewSet.png|TechDrawViewSet|TechDraw View Set}}: Set the parameters of the current view to correspond to the 3D Window
 <translate>
 
 <!--T:409-->
@@ -812,6 +847,16 @@ If you have written a macro and want to include it in one of the categories on t
 
 </translate>
 <div class="mw-collapsible-content">
+* {{MacroLink|Icon=WallDebase.png|WallDebase|Debase Walls}}: Converts line-based walls to be property-driven, skipping non-line-based walls.
+* {{MacroLink|Icon=SheetMetalStitchCut.png|SheetMetalStitchCut|StitchCut}}: Creates evenly spaced stitch cuts along a selected line in a sketch, for hand-folding sheet metal.
+* {{MacroLink|Icon=SketcherBlockAll.png|SketcherBlockAll|Sketcher Block All}}: Add a block constraint on all the geometry elements of a sketch.
+* {{MacroLink|Icon=SketcherFixAllPoints.png|SketcherFixAllPoints|SketcherFixAllPoints}}: Fix all points in a sketch.
+* {{MacroLink|Icon=GroupSorting.png|GroupSorting|GroupSorting (Ordenación)}}: The macro sorts the groups and pieces of a piece. Select groups with <CTRL> key, and execute the macro.
+* {{MacroLink|Icon=PiecesTemplates.png|PiecesTemplates|PiecesTemplates}}: Create a structured pieces (PiecesTemplates)
+* {{MacroLink|Icon=SketchAp.png|SketchAp|SketchAp}}: Create an INDEPENDENT sketch supported by a face.
+* {{MacroLink|Icon=Transparencies.png|Transparencies|Transparencies}}: The selected object becomes 50% transparent (if they have no transparency), and is detransparency otherwise.
+* {{MacroLink|Icon=treeHelper.png|treeHelper|Tree Helper}}: Macro to generate a helper tree that allows you to easily move objects in the tree structure
+* {{MacroLink|Icon=WikiObjectPropertiesListGenerator.png|WikiObjectPropertiesListGenerator|Wiki Object Properties List Generator}}: Generates lists of object properties for use in the FreeCAD Wiki documentation.
 <translate>
 
 <!--T:335-->


### PR DESCRIPTION
 by cross-referencing the official FreeCAD-macros repository with the wiki and appending missing macros to the respective categories. No T tags or existing entries were modified, avoiding the regression mistakes of previous PRs. The changes are strictly localized to the root wiki directory.