### PR TITLE
Fix outdated documentation: About_FreeCAD and Basic_modeling_tutorial (#28)

### DIFF
--- a/wiki/About_FreeCAD.wikitext
+++ b/wiki/About_FreeCAD.wikitext
@@ -1,65 +1,67 @@
-// ==========================================================
-// 水烟碗 3D 实体模型数模工程代码 (Kaloud尺寸 + 粗砂陶工艺补偿版)
-// 修正说明：优化了内部气道贯通性、螺旋线截断、标识贴合度
-// ==========================================================
+<languages/>
+<translate>
 
-$fn = 100; // 提高3D曲面渲染精细度
-shrinkage_compensation = 1.11; // 11% 粗砂陶高温烧结收缩补偿系数
+<!--T:1-->
+{{TOCright}}
 
-scale([shrinkage_compensation, shrinkage_compensation, shrinkage_compensation]) {
-    difference() {
-        // 【1. 外轮廓实体构建】
-        union() {
-            // 下半部分：光面微锥形把柄 (高度59mm，底44mm，顶45mm)
-            cylinder(h=59, r1=22, r2=22.5); 
-            
-            // 把柄与碗体衔接的顺滑圆角过渡区
-            translate([0, 0, 54]) 
-                cylinder(h=10, r1=22.5, r2=32);
-                
-            // 上半部分：碗体基础外轮廓 (高度37mm，总高101mm)
-            translate([0, 0, 64])
-                cylinder(h=37, r1=32, r2=45.5);
-                
-            // 外部螺旋线条（增加外轮廓交集保护，防止螺旋线刺破烟仓内壁）
-            intersection() {
-                translate([0, 0, 64]) cylinder(h=37, r1=32, r2=45.5);
-                translate([0, 0, 64])
-                    for (a = [0 : 30 : 360]) {
-                        rotate([0, 0, a])
-                        translate([29, 0, 0]) // 微调外移，保证凸起质感
-                        linear_extrude(height = 36, twist = -60, scale = 1.3)
-                        circle(r = 3.5, $fn = 6);
-                    }
-            }
-        }
+== Introduction == <!--T:2-->
 
-        // 【2. 内部烟仓与气流通道掏空 (保证壁厚不低于 5mm)】
-        // 顶部烟草仓：深21mm，完美适配 Kaloud 碳盒路径
-        translate([0, 0, 80])
-            cylinder(h=22, r1=28, r2=38); 
-            
-        // 中央漏斗孔 (Funnel Spire)：上下完全贯通主气道
-        // 原高度50~85mm有断层，现修正为45~82mm，与底部孔和烟仓完美交汇
-        translate([0, 0, 45])
-            cylinder(h=37, r1=5, r2=6); 
-            
-        // 底部连接孔：带 1.5° 拔模斜度，深度扩展到 55mm 确保与中心气道重叠贯通
-        translate([0, 0, -1])
-            cylinder(h=56, r1=12.5, r2=11); 
+<!--T:3-->
+[[Image:Workbench_Start.svg|24px]] [[Start_Workbench|FreeCAD]] is a general-purpose parametric 3D CAD modeler and BIM (Building Information Modeling) application. It is primarily designed for mechanical engineering product design but also extends to a wider range of engineering uses such as architecture, electrical engineering, and more.
 
-        // 【3. 品牌标识圆圈 U 凹刻加工 (深度 0.5mm)】
-        // 原 Y=-45 悬空无法切削，现修正为 Y=-40 并增加 14° 倾角贴合碗体斜面
-        translate([0, -40, 82]) 
-            rotate([104, 0, 0]) { // 90度 + 14度外壁倾斜角
-                // 外圈圆形边框
-                difference() {
-                    cylinder(h=2, r=9, center=true);
-                    cylinder(h=3, r=7.5, center=true);
-                }
-                // 内圈大写字母 "U"
-                linear_extrude(height=2, center=true)
-                    text("U", size=9, font="Liberation Serif:style=Bold", halign="center", valign="center");
-            }
-    }
-}
+<!--T:4-->
+FreeCAD is free and open-source software (FOSS) licensed under the [[License|LGPL-2.1-or-later license]]. The source code is hosted on [https://github.com/FreeCAD/FreeCAD GitHub] and development is community-driven.
+
+<!--T:5-->
+FreeCAD is available on all major operating systems including Windows, macOS, and Linux. See the [[Download|Download]] page for installation instructions.
+
+== Key Features == <!--T:6-->
+
+<!--T:7-->
+* '''Parametric modeling''': All objects are natively parametric, meaning their shape can be driven by properties, expressions, or constraints at any time.
+* '''Workbench architecture''': Tools are organized into workbenches. You can switch workbenches depending on the task at hand (Part, PartDesign, Sketcher, Arch, Draft, TechDraw, FEM, and more).
+* '''Standard data formats''': FreeCAD supports STEP, IGES, OBJ, STL, SVG, DXF, IFC, and many more formats for import and export.
+* '''Python scripting''': Every aspect of FreeCAD can be driven from Python. Macros and external scripts can automate repetitive tasks or extend functionality.
+* '''Assembly support''': The integrated [[Assembly_Workbench|Assembly Workbench]] (introduced in FreeCAD 1.0) enables creating multi-body assemblies with joints and constraints.
+* '''BIM tools''': The [[BIM_Workbench|BIM Workbench]] provides tools for architectural design and building information modeling.
+* '''FEM (Finite Element Analysis)''': Built-in FEM tools allow structural, thermal, and fluid analysis using solvers such as CalculiX and Elmer.
+* '''Technical drawings''': The [[TechDraw_Workbench|TechDraw Workbench]] generates 2D technical drawings from 3D models.
+
+== Current Version == <!--T:8-->
+
+<!--T:9-->
+The current stable version of FreeCAD is '''1.1.1''', released on 2026-04-15. For details on what's new, see the [[Release_notes_1.1|release notes for FreeCAD 1.1]].
+
+<!--T:10-->
+For older release notes, consult the [[Feature_list#Release_notes|Feature list]].
+
+== Community == <!--T:11-->
+
+<!--T:12-->
+FreeCAD has an active community of users and developers. You can participate through:
+
+* The [https://forum.freecad.org FreeCAD Forum] for discussions, questions, and sharing projects.
+* The [https://wiki.freecad.org FreeCAD Wiki] (this documentation) for learning and reference.
+* The [https://github.com/FreeCAD/FreeCAD GitHub repository] for bug reports, feature requests, and code contributions.
+* The [https://discord.gg/2vztQgWvTQ FreeCAD Discord] for real-time chat.
+
+== Getting Started == <!--T:13-->
+
+<!--T:14-->
+If you are new to FreeCAD, consider starting with these resources:
+
+* [[Getting_started|Getting started]] — a walkthrough of the basic concepts and interface.
+* [[Tutorials_for_beginners|Tutorials for beginners]] — hands-on tutorials to learn core workflows.
+* [[Sketcher_Workbench|Sketcher Workbench]] — learn about 2D sketching, which is the foundation of most 3D modeling in FreeCAD.
+* [[PartDesign_Workbench|PartDesign Workbench]] — build solid bodies from sketches using feature-based modeling.
+
+== See Also == <!--T:15-->
+
+* [[Feature_list|Feature list]]
+* [[Release_notes_1.1|Release notes 1.1]]
+* [[Workbenches|Workbenches]]
+* [[Installing_on_Windows|Installing on Windows]]
+* [[Installing_on_Linux|Installing on Linux]]
+* [[Installing_on_Mac|Installing on Mac]]
+
+</translate>

--- a/wiki/Basic_modeling_tutorial.wikitext
+++ b/wiki/Basic_modeling_tutorial.wikitext
@@ -16,11 +16,11 @@
 This Basic Modeling Tutorial will show you how to model an iron angle. One thing to know is that FreeCAD is modular by design, and like for many other CAD software, there are always more than one way to do things. We will explore two methods here.
 
 <!--T:37-->
-This tutorial was written with version 0.15 of FreeCAD.
+{{Emphasis|Note:}} This tutorial was originally written for FreeCAD 0.15. The core concepts described remain valid for current versions of FreeCAD (1.x). Some interface details and property names may differ slightly.
 
 <!--T:2-->
 == Before we begin ==
-Keep in mind that FreeCAD is still in an early stage of development, so you might not be as productive as with another CAD application, and you will certainly encounter bugs, or experience crashes. FreeCAD now has the ability to save backup files. The number of those backup files can be specified in the preferences dialog. Don't hesitate to allow 2 or 3 backup files until you know well how to deal with FreeCAD.
+FreeCAD has matured significantly since this tutorial was first written. It is now a capable and stable CAD application. Auto-save and backup files are enabled by default; the number of backup files can be configured in {{MenuCommand|Edit → Preferences → General → Document}}.
 
 <!--T:3-->
 Save your work often, from time to time save your work under a different name, so you have a "safe" copy to fall back to, and be prepared to the possibility that some commands might not give you the expected results. 
@@ -104,7 +104,7 @@ First we need to define on which [[Draft_SelectPlane|working plane]] to draft ou
 ##* 1st point: 0, 0, 0
 ##* 2nd point: 50, 0, 0
 ##* 3rd point: 0,10, 0
-##* 4th point: -40, 0, 0 '''Note:''' ''in FreeCAD 0.16, there is a bug that removes the previous point when entering the minus sign in the input field. A workaround is to enter a positive value, then place the cursor before the number and add the minus sign. (This bug is resolved in v0.17)''
+##* 4th point: -40, 0, 0
 ##* 5th point: 0, 40, 0
 ##* 6th point: -10, 0, 0
 # Press the {{KEY|Close}} button to close the profile. You should now have this profile, titled '''DWire''' in the Model tab:


### PR DESCRIPTION
## Summary

Addresses #28 — Updating outdated information.

### Changes

1. **`wiki/About_FreeCAD.wikitext`**: The About FreeCAD page contained vandalized/unrelated content (OpenSCAD code for a 3D model). Replaced with proper FreeCAD documentation including:
   - Introduction to FreeCAD
   - Key features overview (parametric modeling, workbenches, formats, scripting, Assembly, BIM, FEM, TechDraw)
   - Current version information (1.1.1)
   - Community resources (forum, wiki, GitHub, Discord)
   - Getting started links

2. **`wiki/Basic_modeling_tutorial.wikitext`**: Updated outdated references:
   - Clarified tutorial was originally written for FreeCAD 0.15 but concepts remain valid for FreeCAD 1.x
   - Removed "early stage of development" language; noted FreeCAD is now mature and stable
   - Updated backup file instructions to reference current preferences path
   - Removed resolved FreeCAD 0.16 input field bug workaround note

---

**Bounty wallet:** `0x96e04aC80b9b18ddbfB7e921800feF673BC1CA26`