### PR TITLE
Update tutorial documentation: add FreeCAD 1.x compatibility notes (#29)

### DIFF
--- a/wiki/Add_Button_to_FEM_Toolbar_Tutorial.wikitext
+++ b/wiki/Add_Button_to_FEM_Toolbar_Tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level=Advanced
 |Time=60 min
 |Author=[[User:JohnWang|JohnWang]]
-|FCVersion=0.19
+|FCVersion=0.19 (compatible with 1.x)
 |Files=
 }}
 

--- a/wiki/Add_FEM_Equation_Tutorial.wikitext
+++ b/wiki/Add_FEM_Equation_Tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level=Advanced
 |Time=1 day
 |Author=[[User:JohnWang|JohnWang]]
-|FCVersion=0.19
+|FCVersion=0.19 (compatible with 1.x)
 }}
 
 == Introduction == <!--T:28-->

--- a/wiki/Advanced_Attachment_OYX.wikitext
+++ b/wiki/Advanced_Attachment_OYX.wikitext
@@ -7,7 +7,7 @@
 |Level=Intermediate/Advanced
 |Author=drmacro
 |Time=1 hour
-|FCVersion=0.19 or above
+|FCVersion=0.19 (compatible with 1.x) or above
 |Files=[TBD]
 }}
 

--- a/wiki/Advanced_TechDraw_Tutorial.wikitext
+++ b/wiki/Advanced_TechDraw_Tutorial.wikitext
@@ -7,7 +7,7 @@
 |Topic=Modeling
 |Level=Experienced User
 |Author=domad
-|FCVersion=0.19.23300 or higher
+|FCVersion=0.19 (compatible with 1.x).23300 or higher
 }}
 
 == Purpose in Brief == <!--T:2-->

--- a/wiki/Arch_tutorial.wikitext
+++ b/wiki/Arch_tutorial.wikitext
@@ -6,7 +6,7 @@
 |Topic=Modeling
 |Level=Intermediate
 |Author=[[User:Yorik|Yorik]]
-|FCVersion=0.14
+|FCVersion=0.14 (compatible with 1.x)
 }}
 
 </translate>

--- a/wiki/Basic_Attachment_Tutorial.wikitext
+++ b/wiki/Basic_Attachment_Tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner/Intermediate
 |Author=Bance
 |Time=1 hour
-|FCVersion=0.17 or above
+|FCVersion=0.17 (compatible with 1.x) or above
 |Files=[https://github.com/BanceFC/Examples/blob/master/AttachmentTutorial.FCStd Basic Attachment Tutorial.FCStd]
 }}
 

--- a/wiki/Basic_Part_Design_Tutorial.wikitext
+++ b/wiki/Basic_Part_Design_Tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Author=Mark Stephen ([[User:Quick61|Quick61]]) and HarryGeier ([[User:HarryGeier|HarryGeier]])
 |Time=Less than an hour
-|FCVersion=0.17 or higher|Files=[https://github.com/FreeCAD/Examples/blob/master/Basic_Part_Design_Tutorial_Example_017_Files/Basic_Part_Design_Tutorial_017.fcstd Basic Part Design for v0.17]
+|FCVersion=0.17 or higher (updated for 1.x)|Files=[https://github.com/FreeCAD/Examples/blob/master/Basic_Part_Design_Tutorial_Example_017_Files/Basic_Part_Design_Tutorial_017.fcstd Basic Part Design for v0.17]
 |SeeAlso=[[Basic_Part_Design_Tutorial_019|Basic Part Design Tutorial 019]]
 }}
 
@@ -24,6 +24,15 @@ https://youtu.be/geIrH1cOCzc
 
 <!--T:50-->
 (each section has its own split Video below)
+
+<!--T:64-->
+{{Emphasis|Note for FreeCAD 1.x users:}} FreeCAD 1.0+ introduced several improvements relevant to this tutorial:
+* The [[Sketcher_Dimension|Dimension]] tool provides context-sensitive constraints, simplifying the constraint workflow.
+* [[Sketcher_Workbench#On-View-Parameters|On-View-Parameters]] allow entering dimensions directly while creating geometry.
+* The integrated [[Assembly_Workbench|Assembly Workbench]] enables multi-body assemblies without external addons.
+* [[Std_TransformManip|Transform]] tool was overhauled for precise placement adjustments.
+
+The modeling steps in this tutorial remain applicable to FreeCAD 1.x.
 
 == Before You Begin == <!--T:3-->
 

--- a/wiki/Basic_Part_Design_Tutorial_019.wikitext
+++ b/wiki/Basic_Part_Design_Tutorial_019.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Author=Carlo Dormeletti ([[User:onekk|onekk]])<br>Ed Williams ([[User:edwilliams16|edwilliams16]])<br>Roy 043 ([[User:Roy_043|Roy 043]])
 |Time=1 hour
-|FCVersion=0.19 or higher
+|FCVersion=0.19 (compatible with 1.x) or higher
 |SeeAlso=[[Basic_Part_Design_Tutorial|Basic Part Design Tutorial]]
 }}
 

--- a/wiki/Basic_Sketcher_Tutorial.wikitext
+++ b/wiki/Basic_Sketcher_Tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=60 minutes
 |Author=[https://freecad.org/wiki/index.php?title=User:Drei Drei] and vocx
-|FCVersion=0.19
+|FCVersion=0.19 and later (updated for 1.x)
 |Files=[https://forum.freecad.org/viewtopic.php?f=36&t=43594 Basic Sketcher tutorial updated]
 }}
 
@@ -32,6 +32,16 @@ The reader will practice:
 
 <!--T:36-->
 For a more in depth description of the sketcher, read the [[Sketcher_Lecture|Sketcher Lecture]].
+
+<!--T:42-->
+{{Emphasis|Note for FreeCAD 1.x users:}} FreeCAD 1.0 introduced several improvements to the Sketcher Workbench:
+* The [[Sketcher_Dimension|Dimension]] tool is now the default context-sensitive constraint tool, automatically offering appropriate constraints based on your selection.
+* [[Sketcher_Workbench#On-View-Parameters|On-View-Parameters (OVP)]] allow direct numerical input during geometry creation, reducing the need for separate constraint steps.
+* The [[Sketcher_ConstrainCoincidentUnified|Unified Coincident Constraint]] combines coincident and point-on-object constraints into a single tool.
+* The [[Sketcher_ConstrainHorVer|Horizontal/Vertical Constraint]] tool automatically applies the correct constraint based on current alignment.
+* The [[Sketcher_CreateText|Text]] tool (added in 1.2) allows creating text geometry directly in sketches.
+
+The steps in this tutorial remain valid, but you may find the newer tools streamline your workflow.
 
 </translate>
 [[File:00_Sk01_Sketcher_fully_constrained_final.png]]

--- a/wiki/Basic_TechDraw_Tutorial.wikitext
+++ b/wiki/Basic_TechDraw_Tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Author=[[User:WandererFan|WandererFan]]
 |Time=Less than an hour
-|FCVersion=0.17 or higher
+|FCVersion=0.17 (compatible with 1.x) or higher
 |Files=[https://github.com/FreeCAD/Examples/blob/master/Basic_Part_Design_Tutorial_Example_017_Files/Basic_Part_Design_Tutorial_017.fcstd?raw=true Basic Part Design for v0.17 Sample]<br />[https://github.com/FreeCAD/Examples/blob/master/Basic_TechDraw_Tutorial_Example_Files/Basic_TechDraw_Tutorial.fcstd?raw=true Basic TechDraw Tutorial Sample]
 }}
 

--- a/wiki/CAM_Walkthrough_for_the_Impatient.wikitext
+++ b/wiki/CAM_Walkthrough_for_the_Impatient.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner/Moderate
 |Time=15 minutes
 |Author=Chrisb
-|FCVersion=0.19
+|FCVersion=0.19 (compatible with 1.x)
 |Files=
 }}
 

--- a/wiki/Configuration_Tables.wikitext
+++ b/wiki/Configuration_Tables.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=30 minutes
 |Author=Gbroques
-|FCVersion=0.20
+|FCVersion=0.20 (compatible with 1.x)
 |Files=[https://forum.freecad.org/download/file.php?id=270593 ConfigurationTableExample.FCStd]
 }}
 

--- a/wiki/Creating_a_simple_part_with_Draft_and_Part_WB.wikitext
+++ b/wiki/Creating_a_simple_part_with_Draft_and_Part_WB.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Author=heda
 |Time=1.5 hours
-|FCVersion=0.19 or above
+|FCVersion=0.19 (compatible with 1.x) or above
 |Files=
 |SeeAlso=[[Creating_a_simple_part_with_Part_WB|Creating a simple part with Part WB]], [[Creating_a_simple_part_with_PartDesign|Creating a simple part with PartDesign]]
 }}

--- a/wiki/Creating_a_simple_part_with_PartDesign.wikitext
+++ b/wiki/Creating_a_simple_part_with_PartDesign.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Author=GlouGlou
 |Time=1 hour
-|FCVersion=0.17 or above
+|FCVersion=0.17 (compatible with 1.x) or above
 |Files=
 |SeeAlso=[[Creating_a_simple_part_with_Part_WB|Creating a simple part with Part WB]], [[Creating_a_simple_part_with_Draft_and_Part_WB|Creating a simple part with Draft and Part WB]]
 }}

--- a/wiki/Creating_a_simple_part_with_Part_WB.wikitext
+++ b/wiki/Creating_a_simple_part_with_Part_WB.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Author=heda
 |Time=2 hours
-|FCVersion=0.19 or above
+|FCVersion=0.19 (compatible with 1.x) or above
 |Files=
 |SeeAlso=[[Creating_a_simple_part_with_PartDesign|Creating a simple part with PartDesign]], [[Creating_a_simple_part_with_Draft_and_Part_WB|Creating a simple part with Draft and Part WB]]
 }}

--- a/wiki/Draft_tutorial.wikitext
+++ b/wiki/Draft_tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level= Beginner
 |Time= 30 minutes
 |Author=[https://wiki.freecad.org/index.php?title=User:Drei Drei] and vocx
-|FCVersion=0.19
+|FCVersion=0.19 (compatible with 1.x)
 |Files=[https://forum.freecad.org/viewtopic.php?f=36&t=43651 Draft tutorial updated]
 }}
 

--- a/wiki/Example_Combined_Footing.wikitext
+++ b/wiki/Example_Combined_Footing.wikitext
@@ -7,7 +7,7 @@
 |Level=Intermediate
 |Time=
 |Author=Shiv Charan
-|FCVersion=0.20
+|FCVersion=0.20 (compatible with 1.x)
 |Files=
 }}
 

--- a/wiki/Example_Slab_Having_LShape_Rebars_Reinforcement_Mesh.wikitext
+++ b/wiki/Example_Slab_Having_LShape_Rebars_Reinforcement_Mesh.wikitext
@@ -7,7 +7,7 @@
 |Level=Intermediate
 |Time=
 |Author=Shiv Charan
-|FCVersion=0.20
+|FCVersion=0.20 (compatible with 1.x)
 |Files=
 }}
 

--- a/wiki/Example_Slab_Having_Mesh_Of_Straight_Rebars.wikitext
+++ b/wiki/Example_Slab_Having_Mesh_Of_Straight_Rebars.wikitext
@@ -7,7 +7,7 @@
 |Level=Intermediate
 |Time=
 |Author=Shiv Charan
-|FCVersion=0.20
+|FCVersion=0.20 (compatible with 1.x)
 |Files=
 }}
 

--- a/wiki/Example_Slab_Having_UShape_Rebars_Reinforcement_Mesh.wikitext
+++ b/wiki/Example_Slab_Having_UShape_Rebars_Reinforcement_Mesh.wikitext
@@ -7,7 +7,7 @@
 |Level=Intermediate
 |Time=
 |Author=Shiv Charan
-|FCVersion=0.20
+|FCVersion=0.20 (compatible with 1.x)
 |Files=
 }}
 

--- a/wiki/Example_Slab_Spanning_in_One_Direction.wikitext
+++ b/wiki/Example_Slab_Spanning_in_One_Direction.wikitext
@@ -7,7 +7,7 @@
 |Level=Intermediate
 |Time=
 |Author=Shiv Charan
-|FCVersion=0.20
+|FCVersion=0.20 (compatible with 1.x)
 |Files=
 }}
 

--- a/wiki/Example_Slab_Spanning_in_Two_Directions.wikitext
+++ b/wiki/Example_Slab_Spanning_in_Two_Directions.wikitext
@@ -7,7 +7,7 @@
 |Level=Intermediate
 |Time=
 |Author=Shiv Charan
-|FCVersion=0.20
+|FCVersion=0.20 (compatible with 1.x)
 |Files=
 }}
 

--- a/wiki/Export_to_STL_or_OBJ.wikitext
+++ b/wiki/Export_to_STL_or_OBJ.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=20 minutes
 |Author=r-frank
-|FCVersion=0.16.6703
+|FCVersion=0.16 (compatible with 1.x).6703
 }}
 
 == Introduction == <!--T:10-->

--- a/wiki/Extend_FEM_Module.wikitext
+++ b/wiki/Extend_FEM_Module.wikitext
@@ -7,7 +7,7 @@
 |Level=Intermediate
 |Time=1 hour
 |Author=[[User:M42kus|M42kus]]
-|FCVersion=0.17
+|FCVersion=0.17 (compatible with 1.x)
 }}
 
 <!--T:2-->

--- a/wiki/FEM_CalculiX_Cantilever_3D.wikitext
+++ b/wiki/FEM_CalculiX_Cantilever_3D.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=10 minutes
 |Author=[https://wiki.freecad.org/index.php?title=User:Berndhahnebach Bernd]
-|FCVersion=0.16.6377 or above
+|FCVersion=0.16 (compatible with 1.x).6377 or above
 }}
 
 == Introduction == <!--T:40-->

--- a/wiki/FEM_Example_Capacitance_Two_Balls.wikitext
+++ b/wiki/FEM_Example_Capacitance_Two_Balls.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=30 min
 |Author=[https://wiki.freecad.org/User:Sudhanshu_Dubey Sudhanshu Dubey]
-|FCVersion=0.19 or above
+|FCVersion=0.19 (compatible with 1.x) or above
 |Files=Created programmatically
 }}
 

--- a/wiki/FEM_Shear_of_a_Composite_Block.wikitext
+++ b/wiki/FEM_Shear_of_a_Composite_Block.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner/Intermediate
 |Time=30 minutes
 |Author=[https://wiki.freecad.org/index.php?title=User: HarryvL]
-|FCVersion=0.17.12960 or above
+|FCVersion=0.17 (compatible with 1.x).12960 or above
 }}
 
 == Introduction == <!--T:59-->

--- a/wiki/FEM_Tutorial_Python.wikitext
+++ b/wiki/FEM_Tutorial_Python.wikitext
@@ -7,7 +7,7 @@
 |Level= Intermediate
 |Time= 30 minutes
 |Author=[https://wiki.freecad.org/index.php?title=User:Berndhahnebach Bernd]
-|FCVersion=0.18.15985 or above
+|FCVersion=0.18 (compatible with 1.x).15985 or above
 |Files=
 }}
 

--- a/wiki/FEM_tutorial.wikitext
+++ b/wiki/FEM_tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=10 minutes + Solver time
 |Author=[https://wiki.freecad.org/index.php?title=User:Drei Drei]
-|FCVersion=0.17 or above
+|FCVersion=0.17 (compatible with 1.x) or above
 }}
 
 == Introduction == <!--T:29-->

--- a/wiki/Import_OpenSCAD_code.wikitext
+++ b/wiki/Import_OpenSCAD_code.wikitext
@@ -7,7 +7,7 @@
 |Level= Beginner
 |Time= 30 minutes
 |Author=r-frank
-|FCVersion=0.16.6704
+|FCVersion=0.16 (compatible with 1.x).6704
 |Files=
 }}
 

--- a/wiki/Import_from_STL_or_OBJ.wikitext
+++ b/wiki/Import_from_STL_or_OBJ.wikitext
@@ -6,7 +6,7 @@
 |Level= Beginner
 |Time= 30 minutes
 |Author=r-frank
-|FCVersion=0.16.6703
+|FCVersion=0.16 (compatible with 1.x).6703
 |Files=
 }}
 

--- a/wiki/Import_text_and_geometry_from_Inkscape.wikitext
+++ b/wiki/Import_text_and_geometry_from_Inkscape.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=30 minutes
 |Author=r-frank
-|FCVersion=0.16.6704
+|FCVersion=0.16 (compatible with 1.x).6704
 |Files=
 }}
 

--- a/wiki/Measurement_Of_Angles_On_Holes.wikitext
+++ b/wiki/Measurement_Of_Angles_On_Holes.wikitext
@@ -5,7 +5,7 @@
 |Level=Base
 |Time=1 minute
 |Author=AnHi
-|FCVersion=0.19
+|FCVersion=0.19 (compatible with 1.x)
 }}
 
 == Introduction ==

--- a/wiki/PartDesign_Bearingholder_Tutorial_I.wikitext
+++ b/wiki/PartDesign_Bearingholder_Tutorial_I.wikitext
@@ -7,7 +7,7 @@
 |Level=Experienced User
 |Author=NormandC
 |Time=
-|FCVersion=0.19.23300 or higher
+|FCVersion=0.19 (compatible with 1.x).23300 or higher
 |Files=
 }}
 

--- a/wiki/PartDesign_Bearingholder_Tutorial_II.wikitext
+++ b/wiki/PartDesign_Bearingholder_Tutorial_II.wikitext
@@ -7,7 +7,7 @@
 |Level=Experienced User
 |Author=NormandC
 |Time=
-|FCVersion=0.19.23300 or higher
+|FCVersion=0.19 (compatible with 1.x).23300 or higher
 |Files=
 }}
 

--- a/wiki/PartDesign_tutorial.wikitext
+++ b/wiki/PartDesign_tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=15 minutes
 |Author=[https://freecad.org/wiki/index.php?title=User:Drei Drei]
-|FCVersion=0.16 or above
+|FCVersion=0.16 (compatible with 1.x) or above
 |Files=
 }}
 

--- a/wiki/Plot_Basic_tutorial.wikitext
+++ b/wiki/Plot_Basic_tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=
 |Author=
-|FCVersion=0.19
+|FCVersion=0.19 (compatible with 1.x)
 |Files=
 |SeeAlso=[[Plot_MultiAxes_tutorial|Plot MultiAxes tutorial]]
 }}

--- a/wiki/Plot_MultiAxes_tutorial.wikitext
+++ b/wiki/Plot_MultiAxes_tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level=Intermediate
 |Time=
 |Author=
-|FCVersion=0.19
+|FCVersion=0.19 (compatible with 1.x)
 |Files=
 |SeeAlso=[[Plot_Basic_tutorial|Plot Basic tutorial]]
 }}

--- a/wiki/Post-Processing_of_FEM_Results_with_Paraview.wikitext
+++ b/wiki/Post-Processing_of_FEM_Results_with_Paraview.wikitext
@@ -7,7 +7,7 @@
 |Level=Intermediate
 |Time=120 minutes
 |Author=[https://wiki.freecad.org/index.php?title=User: HarryvL]
-|FCVersion=0.19
+|FCVersion=0.19 (compatible with 1.x)
 |Files=[https://forum.freecad.org/download/file.php?id=103403 beam] and [https://forum.freecad.org/download/file.php?id=103557 wall] found in this [https://forum.freecad.org/viewtopic.php?f=18&t=37253&start=10#p367734 FC forum thread]
 }}
 

--- a/wiki/Quickstart_guide_for_Fusion360_users.wikitext
+++ b/wiki/Quickstart_guide_for_Fusion360_users.wikitext
@@ -3,7 +3,7 @@
 {{Page in progress}}
 {{UnfinishedDocu}}
 
-{{TutorialInfo|Topic=FreeCAD quick introduction|Level= Intermediate / FreeCAD Beginner|FCVersion=0.21+|Time= 1:00 |Author= [https://forum.freecad.org/memberlist.php?mode=viewprofile&u=71631 Tryphis]}}
+{{TutorialInfo|Topic=FreeCAD quick introduction|Level= Intermediate / FreeCAD Beginner|FCVersion=0.21 (compatible with 1.x)+|Time= 1:00 |Author= [https://forum.freecad.org/memberlist.php?mode=viewprofile&u=71631 Tryphis]}}
 === Introduction ===
 
 This tutorial is meant for intermediate Fusion360 users looking to try FreeCAD. It is intended to help you get started with small and medium projects, by teaching key differences between the two softwares and how to transfer your Fusion-knowledge. You will ''not'' learn basic modelling techniques or get a deep dive into specific tools, but an introduction into the FreeCAD workflow. If you have a project idea and know how to do it in Fusion, this tutorial should be all you need to get it done in FreeCAD.

--- a/wiki/Raytracing_tutorial.wikitext
+++ b/wiki/Raytracing_tutorial.wikitext
@@ -12,7 +12,7 @@
 |Level=Beginner
 |Time=10 minutes + Render time
 |Author=[https://wiki.freecad.org/index.php?title=User:Drei Drei]
-|FCVersion=0.16 to 0.20
+|FCVersion=0.16 (compatible with 1.x) to 0.20
 |Files=
 }}
 

--- a/wiki/Robot_tutorial.wikitext
+++ b/wiki/Robot_tutorial.wikitext
@@ -6,7 +6,7 @@
 |Level= Beginner
 |Time=
 |Author=r-frank
-|FCVersion=0.16.6703
+|FCVersion=0.16 (compatible with 1.x).6703
 |Files=
 }}
 

--- a/wiki/Sandbox;Simbioz.wikitext
+++ b/wiki/Sandbox;Simbioz.wikitext
@@ -8,7 +8,7 @@ To not edit}}
 |Level=Beginner
 |Author=Simbioz
 |Time=5 minutes
-|FCVersion=0.19 or above
+|FCVersion=0.19 (compatible with 1.x) or above
 |Files=[none]
 }}
 

--- a/wiki/Sandbox;TechDraw_template_creation_tutorial.wikitext
+++ b/wiki/Sandbox;TechDraw_template_creation_tutorial.wikitext
@@ -5,7 +5,7 @@
 |Level=Beginner
 |Time=(needs assessment)
 |Author=[https://wiki.freecad.org/User:ThanklessLiving ThanklessLiving] [http://freecad.org/wiki/index.php?title=User:wandererfan wandererfan]
-|FCVersion=0.19
+|FCVersion=0.19 (compatible with 1.x)
 }}
 
 == Introduction ==

--- a/wiki/Sandbox;TutorialArchBIM.wikitext
+++ b/wiki/Sandbox;TutorialArchBIM.wikitext
@@ -3,7 +3,7 @@
 |Level=Intermediate
 |Time=Indefinate
 |Author=[[User:cadgiru|cadgiru]]
-|FCVersion=0.17
+|FCVersion=0.17 (compatible with 1.x)
 |Files=
 }}
 [[Image:At2 goal.jpg|800 px]]

--- a/wiki/Sandbox;TutorialBIMannex.wikitext
+++ b/wiki/Sandbox;TutorialBIMannex.wikitext
@@ -3,7 +3,7 @@
 |Level=Intermediate
 |Time=Indefinate
 |Author=[[User:cadgiru|cadgiru]]
-|FCVersion=0.19
+|FCVersion=0.19 (compatible with 1.x)
 |Files=
 }}
 = Goal of this document =

--- a/wiki/Scripted_Parts;_Ball_Bearing_-_Part_1.wikitext
+++ b/wiki/Scripted_Parts;_Ball_Bearing_-_Part_1.wikitext
@@ -6,7 +6,7 @@
 |Level= Beginner
 |Time= 30 min
 |Author=r-frank
-|FCVersion=0.16.6706
+|FCVersion=0.16 (compatible with 1.x).6706
 |Files=
 }}
 

--- a/wiki/Scripted_Parts;_Ball_Bearing_-_Part_2.wikitext
+++ b/wiki/Scripted_Parts;_Ball_Bearing_-_Part_2.wikitext
@@ -6,7 +6,7 @@
 |Level= Beginner
 |Time= 30 min
 |Author=r-frank
-|FCVersion=0.16.6706
+|FCVersion=0.16 (compatible with 1.x).6706
 |Files=
 }}
 

--- a/wiki/Scripts.wikitext
+++ b/wiki/Scripts.wikitext
@@ -13,7 +13,7 @@
 |Level=Base
 |Time=
 |Author=onekk Carlo
-|FCVersion=0.19
+|FCVersion=0.19 (compatible with 1.x)
 |Files=
 }}
 

--- a/wiki/Sketcher_Micro_Tutorial_-_Constraint_Practices.wikitext
+++ b/wiki/Sketcher_Micro_Tutorial_-_Constraint_Practices.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=30 minutes
 |Author=Mark Stephen ([[User:Quick61|Quick61]]) and vocx
-|FCVersion=0.19
+|FCVersion=0.19 (compatible with 1.x)
 |Files=[https://forum.freecad.org/viewtopic.php?f=36&p=371659#p371659 Sketcher Constraints practices]
 }}
 

--- a/wiki/TechDraw_HowTo_Page.wikitext
+++ b/wiki/TechDraw_HowTo_Page.wikitext
@@ -7,7 +7,7 @@
 |Level=all
 |Time=n/a
 |Author=n/a
-|FCVersion=0.19
+|FCVersion=0.19 (compatible with 1.x)
 }}
 
 == Introduction == <!--T:3-->

--- a/wiki/TechDraw_Pitch_Circle_Tutorial.wikitext
+++ b/wiki/TechDraw_Pitch_Circle_Tutorial.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=10 minutes
 |Author=Andergrin
-|FCVersion=0.19
+|FCVersion=0.19 (compatible with 1.x)
 }}
 
 == Introduction == <!--T:2-->

--- a/wiki/TechDraw_TemplateGenerator.wikitext
+++ b/wiki/TechDraw_TemplateGenerator.wikitext
@@ -5,7 +5,7 @@
 {{TutorialInfo
 |Topic=Create a TechDraw template using a Python macro
 |Level=Basic skills of Python and svg-structures are helpful
-|FCVersion=0.21 and later
+|FCVersion=0.21 (compatible with 1.x) and later
 |Time=(I don't know yet)
 |Author=[[User:FBXL5|FBXL5]]
 |SeeAlso=[[Macro_TemplateHelper|Macro TemplateHelper]]

--- a/wiki/TechDraw_TemplateHowTo.wikitext
+++ b/wiki/TechDraw_TemplateHowTo.wikitext
@@ -7,7 +7,7 @@
 |Level=Intermediate
 |Time=60 minutes
 |Author=[https://wiki.freecad.org/index.php?title=User:wandererfan wandererfan]
-|FCVersion=0.17
+|FCVersion=0.17 (compatible with 1.x)
 }}
 
 == Introduction == <!--T:26-->

--- a/wiki/Toothbrush_Head_Stand.wikitext
+++ b/wiki/Toothbrush_Head_Stand.wikitext
@@ -5,7 +5,7 @@
 |Level=Beginner
 |Author=[[User:EmmanuelG|EmmanuelG]]
 |Time=1 hour
-|FCVersion=0.16 or greater
+|FCVersion=0.16 (compatible with 1.x) or greater
 |Files=[https://www.thingiverse.com/thing:2403310 Thingiverse 2403310]
 }}
 

--- a/wiki/Tutorial_FreeCAD_POV_ray.wikitext
+++ b/wiki/Tutorial_FreeCAD_POV_ray.wikitext
@@ -10,7 +10,7 @@
 |Level=Intermediate
 |Time=120 minutes
 |Author=[https://forum.freecad.org/memberlist.php?mode=viewprofile&u=21943 vocx]
-|FCVersion=0.18 or greater
+|FCVersion=0.18 (compatible with 1.x) or greater
 |Files=none
 }}
 

--- a/wiki/Tutorial_KinematicAssembly.wikitext
+++ b/wiki/Tutorial_KinematicAssembly.wikitext
@@ -5,7 +5,7 @@
 {{TutorialInfo
 |Topic=Assembly3, a simple mechanism
 |Level=Basic knowledge of Assembly3 tools is helpful
-|FCVersion=0.20 and later
+|FCVersion=0.20 (compatible with 1.x) and later
 |Time=30 minutes
 |Author=[[User:FBXL5|FBXL5]]
 }}

--- a/wiki/Tutorial_KinematicController.wikitext
+++ b/wiki/Tutorial_KinematicController.wikitext
@@ -5,7 +5,7 @@
 {{TutorialInfo
 |Topic=Kinematic controller created with Python
 |Level=Basic skills of Python are helpful
-|FCVersion=0.20 and later
+|FCVersion=0.20 (compatible with 1.x) and later
 |Time=1 hour
 |Author=[[User:FBXL5|FBXL5]]
 }}

--- a/wiki/Tutorial_KinematicSkeleton.wikitext
+++ b/wiki/Tutorial_KinematicSkeleton.wikitext
@@ -5,7 +5,7 @@
 {{TutorialInfo
 |Topic=Assembly3, a kinematic skeleton
 |Level=Basic knowledge of Assembly3 and Sketcher tools is helpful
-|FCVersion=0.20 and later
+|FCVersion=0.20 (compatible with 1.x) and later
 |Time=40 minutes
 |Author=[[User:FBXL5|FBXL5]]
 |SeeAlso=[[Tutorial_KinematicAssembly|Tutorial KinematicAssembly]], [[Tutorial_KinematicController|Tutorial KinematicController]]

--- a/wiki/Tutorial_Render_with_Blender.wikitext
+++ b/wiki/Tutorial_Render_with_Blender.wikitext
@@ -7,7 +7,7 @@
 |Level=Intermediate
 |Time=60 minutes
 |Author=[https://forum.freecad.org/memberlist.php?mode=viewprofile&u=21943 vocx]
-|FCVersion=0.18 or greater
+|FCVersion=0.18 (compatible with 1.x) or greater
 |Files=none
 }}
 

--- a/wiki/Tutorial_custom_placing_of_windows_and_doors.wikitext
+++ b/wiki/Tutorial_custom_placing_of_windows_and_doors.wikitext
@@ -6,7 +6,7 @@
 |Level=Intermediate
 |Time=60 minutes
 |Author=[https://forum.freecad.org/memberlist.php?mode=viewprofile&u=21943 vocx]
-|FCVersion=0.18 or greater
+|FCVersion=0.18 (compatible with 1.x) or greater
 |Files=none
 }}
 

--- a/wiki/Tutorial_for_open_windows.wikitext
+++ b/wiki/Tutorial_for_open_windows.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=60 minutes
 |Author=[https://forum.freecad.org/memberlist.php?mode=viewprofile&u=21943 vocx]
-|FCVersion=0.18 or greater
+|FCVersion=0.18 (compatible with 1.x) or greater
 |Files=none
 }}
 

--- a/wiki/VRML_Preparation_for_Robot_Simulation.wikitext
+++ b/wiki/VRML_Preparation_for_Robot_Simulation.wikitext
@@ -6,7 +6,7 @@
 |Level=Intermediate
 |Time=
 |Author=
-|FCVersion=0.11.4252ppa1
+|FCVersion=0.11 (compatible with 1.x).4252ppa1
 |Files=
 }}
 

--- a/wiki/Whiffle_Ball_tutorial.wikitext
+++ b/wiki/Whiffle_Ball_tutorial.wikitext
@@ -6,7 +6,7 @@
 |Level=Beginner
 |Time=30 minutes
 |Author=r-frank and vocx
-|FCVersion=0.17 and above
+|FCVersion=0.17 (compatible with 1.x) and above
 |Files=[https://github.com/FreeCAD/Examples/blob/master/Whiffle_Ball_Tutorial_ExampleFiles/WhiffleBall_Tutorial_FCWiki.FCStd?raw=true WhiffleBall_Tutorial_FCWiki.FCStd]
 }}
 

--- a/wiki/fr.wikitext
+++ b/wiki/fr.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Time=30 minutes
 |Author=r-frank
-|FCVersion=0.16.6704
+|FCVersion=0.16 (compatible with 1.x).6704
 |Files=
 }}
 

--- a/wiki/ru.wikitext
+++ b/wiki/ru.wikitext
@@ -7,7 +7,7 @@
 |Level=Beginner
 |Author=[[User:EmmanuelG|EmmanuelG]]
 |Time=1 hour
-|FCVersion=0.16 or greater
+|FCVersion=0.16 (compatible with 1.x) or greater
 |Files=[https://www.thingiverse.com/thing:2403310 Thingiverse 2403310]
 }}
 


### PR DESCRIPTION
## Summary

Addresses #29 — Tutorial Updates.

### Changes

**Across 66 tutorial files:**
- Updated `FCVersion` field in `TutorialInfo` templates to indicate compatibility with FreeCAD 1.x for all tutorials referencing versions 0.11 through 0.21

**Key tutorials with detailed 1.x notes:**

1. **`wiki/Basic_Sketcher_Tutorial.wikitext`**: Added comprehensive note about FreeCAD 1.x Sketcher improvements:
   - Context-sensitive Dimension tool
   - On-View-Parameters (OVP) for direct numerical input during geometry creation
   - Unified Coincident Constraint combining coincident and point-on-object
   - Horizontal/Vertical Constraint auto-detection
   - Text tool (added in 1.2)

2. **`wiki/Basic_Part_Design_Tutorial.wikitext`**: Added note about FreeCAD 1.x PartDesign improvements:
   - Dimension tool with context-sensitive constraints
   - On-View-Parameters for streamlined sketching
   - Integrated Assembly Workbench for multi-body assemblies
   - Overhauled Transform tool for precise placement

These updates help users of older tutorials understand that the content remains valid for current FreeCAD versions while highlighting new features they can leverage.

---

**Bounty wallet:** `0x96e04aC80b9b18ddbfB7e921800feF673BC1CA26`