### PR TITLE
docs: refresh developer hub links

### DIFF
--- a/wiki/Developer_hub.wikitext
+++ b/wiki/Developer_hub.wikitext
@@ -35,7 +35,7 @@ Start with these actively maintained resources:
 === Addon and extension development === <!--T:34-->
 
 <!--T:6-->
-* [https://freecad.github.io/Addon-Academy/ Addon Academy]: Step-by-step guides, topics, and demos for creating and maintaining FreeCAD addons.
+* [https://github.com/FreeCAD/Addon-Academy Addon Academy]: Guides, topics, and demos for creating and maintaining FreeCAD addons.
 * [[Workbench_creation|Workbench creation]]: Wiki background material on creating a workbench.
 * [[Power_users_hub|Power user's hub]]: Python scripting, GUI customization, and other extension points inside FreeCAD.
 * [[Translating_an_external_workbench|Translating an external workbench]]: Translation-specific guidance for addon maintainers.

--- a/wiki/Developer_hub.wikitext
+++ b/wiki/Developer_hub.wikitext
@@ -2,7 +2,7 @@
 <translate>
 
 <!--T:41-->
-{{VeryImportantMessage|The information on this page may be obsolete, see the [https://freecad.github.io/DevelopersHandbook/ Developers Handbook] for up-to-date information.}}
+{{VeryImportantMessage|Use this page as a curated index. The [https://freecad.github.io/DevelopersHandbook/ Developers Handbook] is the primary up-to-date reference for FreeCAD core development.}}
 
 </translate>
 [[Image:Crystal_Clear_app_tutorials.png|64px]]
@@ -11,141 +11,73 @@
 <translate>
 
 <!--T:2-->
-This is the place to come if you want to contribute to the development of the FreeCAD software. Many of the following pages might be outdated. Check the official FreeCAD Developers Handbook for more up to date information: https://freecad.github.io/DevelopersHandbook/
+This is the place to start if you want to contribute to the development of FreeCAD. The most current material now lives in the official Developers Handbook and a few actively maintained companion resources. Older wiki pages can still be useful as background material, but they should be checked against the handbook before you rely on them.
 
 <!--T:3-->
-These pages are in the early stage of development. If you can't find the information you are looking for, or have found useful information somewhere we have not linked to, then please leave a comment on the [https://forum.freecad.org/index.php?sid=5f84150e79db8842e277b042077097ff forum] and someone will look into it.
+If you can't find the information you are looking for, or have found useful information somewhere we have not linked to, please leave a comment on the [https://forum.freecad.org/ development forum] and someone will look into it.
 
 == Developer Documentation == <!--T:32-->
 
 <!--T:4-->
-The developer documentation comprises the following sections:
+Start with these actively maintained resources:
 
-=== Compiling FreeCAD === <!--T:33-->
+=== FreeCAD Developers Handbook === <!--T:33-->
 
 <!--T:5-->
-* [https://github.com/FreeCAD/FreeCAD GitHub repo]: If you are new to git, read [[Source_code_management|Source code management]]
+* [https://freecad.github.io/DevelopersHandbook/ Developers Handbook]: Overview of the current developer documentation set.
+* [https://freecad.github.io/DevelopersHandbook/roadmap/ Roadmap]: Broad objectives for the direction of FreeCAD development.
+* [https://freecad.github.io/DevelopersHandbook/gettingstarted/ Getting Started]: Build environments, dependencies, debugging, and the pull request workflow.
+* [https://freecad.github.io/DevelopersHandbook/designguide/ Design Guide]: User experience, interaction, naming, and interface guidance.
+* [https://freecad.github.io/DevelopersHandbook/codeformatting/ Code Formatting Guidelines]: Formatting expectations for C++ and Python contributions.
+* [https://freecad.github.io/DevelopersHandbook/bestpractices/ Best Practices]: Guidance for both developers and code reviewers.
+* [https://freecad.github.io/DevelopersHandbook/technical/ Technical Guide]: Codebase structure, translation, testing, release management, and reference links.
+
+=== Addon and extension development === <!--T:34-->
+
+<!--T:6-->
+* [https://freecad.github.io/Addon-Academy/ Addon Academy]: Step-by-step guides, topics, and demos for creating and maintaining FreeCAD addons.
+* [[Workbench_creation|Workbench creation]]: Wiki background material on creating a workbench.
+* [[Power_users_hub|Power user's hub]]: Python scripting, GUI customization, and other extension points inside FreeCAD.
+* [[Translating_an_external_workbench|Translating an external workbench]]: Translation-specific guidance for addon maintainers.
+
+=== API and source references === <!--T:35-->
+
+<!--T:7-->
+* [https://github.com/FreeCAD/SourceDoc SourceDoc]: Generated source documentation for the FreeCAD codebase.
+* [[:Category:API|API category]]: Wiki-organized API pages and reference material.
+* [[Std_DevHandbook|Std DevHandbook]]: The menu command that opens the Developers Handbook from inside FreeCAD.
+* [[File_Format_FCStd|File Format FCStd]]: Notes about the FreeCAD document format and stored data.
+
+=== Supplementary wiki pages === <!--T:36-->
+
+<!--T:13-->
+These pages can still be useful, but are secondary to the Developers Handbook:
+
+<!--T:14-->
 * [[Compile_on_Windows|Compiling on Windows]]
 * [[Compile_on_Linux|Compiling on Linux]]
 * [[Compile_on_MacOS|Compiling on MacOS]]
-* [[License|License details]]: About the FreeCAD licences and allowed uses of the source code and application.
-* [[Logo|Logo and other assets]]: How the FreeCAD logo and other assets of FreeCAD should be used.
-* [[Third_Party_Libraries|Third Party Libraries]]
-* [[Third_Party_Tools|Third Party Tools]]
-* [[Start up and Configuration|Start up and Configuration]]
-* [[Start_up_and_Configuration|Source documentation]]
-* Use [[https://github.com/FreeCAD/FreeCAD/issues|GitHub]] when you have a problem or think you may have found a bug
-
-=== Packaging === <!--T:19-->
-
-<!--T:26-->
-[[Packaging|Packaging]] consists in taking the compiled binaries and Python source files of FreeCAD, and distributing them for use in a particular system.
-
-<!--T:20-->
-* [[Linux_packaging|Linux packaging]]
-** [[Debian_development|Debian development]]
-** [[Debian_Unstable|Debian Unstable]]
-** [[Git_buildpackage|Git buildpackage]]
-* [[Windows_packaging|Windows packaging]]
-* [[MacOS_packaging|MacOS packaging]]
-
-=== Build Support Tools === <!--T:34-->
-
-<!--T:6-->
-* The [[FreeCAD_Build_Tool|FreeCAD Build Tool]]
-** [[Workbench_creation|Adding an application module]] to FreeCAD
-* [[Debugging|Debugging]] FreeCAD
-* [[Testing|Testing]] FreeCAD
-* [[Compiling_(Speeding_up)|Compiling (Speeding up)]] FreeCAD
+* [[Debugging|Debugging]]
+* [[Testing|Testing]]
 * [[Continuous_Integration|Continuous Integration]]
-
-=== Modifying FreeCAD === <!--T:35-->
-
-<!--T:7-->
-* Understanding [[The_FreeCAD_source_code|The FreeCAD source code]]
-* [[Tracker#Submitting_patches|Submitting patches]]
-* Add [[Gui_Command|Features]] or a [[Workbench_creation|Workbench]] to FreeCAD
-* [[Branding|Branding]] or ''how to give FreeCAD a unique look''
-* [[Artwork|Artwork]] we made for FreeCAD, that you can freely reuse.
-* [[Artwork_Guidelines|Artwork guidelines]] standards for icons
+* [[Packaging|Packaging]]
 * [[Localisation|Translating FreeCAD]]
-* [[Extra_python_modules|Extra Python modules]], or ''how to extend python functionality within FreeCAD''
-* [[Google_Summer_of_Code|Google Summer of Code]] get involved via Google's student support program.
-* [[Fine-tuning|Fine-tuning]] shows different options and parameter switches that can overcome problems.
-* [[Wrapping_a_Cplusplus_class_in_Python|Wrapping a C++ class in Python]] shows how to create the Python wrapper for a C++ class.
-* [[NewFeatureCheckList_C++|Checklist for adding a Feature to a C++ workbench]] provides an aid for contributors.
+* [[License|License details]]
+* [[Logo|Logo and other assets]]
+* [[Third_Party_Libraries|Third-party libraries]]
+* [[Third_Party_Tools|Third-party tools]]
 
-<!--T:16-->
-* [[Translating_an_external_workbench|Translating an external workbench]]
-
-=== Module developer's guide === <!--T:36-->
-
-<!--T:13-->
-[https://github.com/qingfengxia/FreeCAD_Mod_Dev_Guide FreeCAD Mod Dev Guide]: This is an ebook under writing on GitHub, please fork and send pull request to contribute.
-
-<!--T:14-->
-Chapters:
-* Overview and Software Architecture
-* Source code structure
-* Base and App module
-* Gui module
-* Python wrapping
-* Modular design
-* FEM module source analysis (mixed C++ and Python)
-* Development of CFD Module (pure Python)
-* Module testing and debugging
-* Contribute code with git
+=== Related documentation projects === <!--T:37-->
 
 <!--T:15-->
-Latest PDF preview can be downloaded from [https://github.com/qingfengxia/FreeCAD_Mod_Dev_Guide/tree/master/pdf PDFfolder] of this GitHub repository.
-
-=== Internals === <!--T:21-->
-
-==== OpenCascade Documentation ==== <!--T:8-->
-
-<!--T:17-->
-OpenCascade is a software development platform for 3D surface and solid modeling, CAD data exchange, and visualization, mostly in the form of C++ libraries.
-
-<!--T:18-->
-* [http://opencascade.wikidot.com/romansarticles Roman Lygin's tutorials]
-* [https://dev.opencascade.org/cdoc/overview/html/index.html Full Online Documentation]
-* [https://dev.opencascade.org/doc/refman/html/index.html Reference Manual]
-* [http://opencascade.wikidot.com The openCascade wiki] (currently containing ?? Chinese spam)
-
-==== File format ==== <!--T:27-->
-
-<!--T:28-->
-[[File_Format_FCStd|File Format FCStd]]. The files created with FreeCAD are {{incode|.zip}} files that include the [https://en.wikipedia.org/wiki/Boundary_representation BREP] geometry, as well as XML data that describes the document.
-
-==== Sketcher solver ==== <!--T:22-->
-
-<!--T:23-->
-* [https://forum.freecad.org/viewtopic.php?f=10&t=36355 Sketcher Solver Architecture Booklet] (forum thread), [https://github.com/abdullahtahiriyo/FreeCADBooks/tree/master/FreeCAD_Solver_Architecture source] in GitHub.
-* [https://github.com/FreeCAD/FreeCAD/blob/master/src/Mod/Sketcher/App/planegcs/ PlaneGCS solver] in the FreeCAD source code; important files are [https://github.com/FreeCAD/FreeCAD/blob/master/src/Mod/Sketcher/App/planegcs/GCS.cpp GCS.cpp] and [https://github.com/FreeCAD/FreeCAD/blob/master/src/Mod/Sketcher/App/planegcs/SubSystem.cpp SubSystem.cpp].
-* [https://forum.freecad.org/viewtopic.php?f=9&t=29192 Recent Several Sketcher improvements].
-
-<!--T:24-->
-The Sketcher solver isn't perfect, as there are some issues with numerical precision when using large values, see [https://forum.freecad.org/viewtopic.php?f=10&t=40502 Adventure of fixing sketcher solver for large sketches].
-
-<!--T:25-->
-The development of a new solver architecture could improve the way the solver is used both in the [[Sketcher_Workbench|Sketcher Workbench]], and for assembly of 3D bodies. See [https://forum.freecad.org/viewtopic.php?f=20&t=40525 Reimplementing constraint solver].
-
-== Roadmap == <!--T:37-->
-
-<!--T:9-->
-FreeCAD, though usable in certain areas, is at the beginning of a long way into the CAD mainstream. There is still a lot to do to reach a state where we can compete with commercial software.
-
-<!--T:39-->
-[[FreeCAD_1.0_Development_Cycle|FreeCAD 1.0 Development Cycle]]
+* [https://github.com/FreeCAD/lens-docs lens-docs]: Documentation for the Lens project in the wider FreeCAD ecosystem.
 
 == Community == <!--T:30-->
 
 <!--T:31-->
-* [ircs://irc.libera.chat:6697/freecad IRC channel] ,synchronized with [https://gitter.im/FreeCAD/FreeCAD gitter channel]
+* [https://github.com/FreeCAD/FreeCAD FreeCAD GitHub repository]
+* [https://github.com/FreeCAD/FreeCAD/issues FreeCAD issue tracker]
 * [https://forum.freecad.org/viewforum.php?f=6 Development forum]
-
-<!--T:10-->
-* [[Development_roadmap|Development roadmap]]
 
 == Credits == <!--T:40-->
 


### PR DESCRIPTION
<!-- 🚨 𝗡𝗼𝘁𝗶𝗰𝗲 Please be aware that translations cannot be changed via pull requests. Head over to the wiki at: https://wiki.freecad.org -->



## Summary
- refresh `wiki/Developer_hub.wikitext` around the current Developers Handbook, Addon Academy, SourceDoc, and lens-docs resources
- remove outdated sections and stale references that no longer reflect the current developer documentation surface
- keep the page focused on current entry points for handbook guidance, API references, addon development, build and debug pages, and related docs projects

## Notes
- documentation-only update to the Developer hub page
- no translation pages or unrelated wiki content were changed