### PR TITLE
Improve macro discoverability in docs

### DIFF
--- a/wiki/Macros.wikitext
+++ b/wiki/Macros.wikitext
@@ -70,7 +70,16 @@ See [[How_to_install_macros|How to install macros]] for a more detailed descript
 == Macro repositories == <!--T:11-->
 
 <!--T:29-->
-There are two main places for macros. The first one is the official peer-reviewed macro repository on [https://github.com/FreeCAD/FreeCAD-macros GitHub]. The second one is the [[Macros_recipes|Macros recipes]] page from which you can pick some useful macros to add to your FreeCAD installation. Macros from both repositories can be installed via the [[Std_AddonMgr|Addon Manager]] directly from FreeCAD.
+There are two main places for macros. The first one is the official peer-reviewed macro repository on [https://github.com/FreeCAD/FreeCAD-macros GitHub]. The second one is the [[Macros_recipes|Macros recipes]] page, where you can pick useful macros to add to your FreeCAD installation. Macros from both repositories can be installed via the [[Std_AddonMgr|Addon Manager]] directly from FreeCAD.
+
+To discover active macro pages on the wiki, browse the [[Category:Macros]] and search for pages prefixed with {{incode|Macro_}}. A few examples that are currently maintained and useful to start from are:
+* [[Macro_Zoom1_1|Macro Zoom 1:1]] — precise real-size view scaling
+* [[Macro_Snip|Macro Snip]] — screenshot helper for sharing views
+* [[Macro_MeshToPart|Macro MeshToPart]] — convert selected meshes to parts
+* [[Macro_Dxf_To_Shape|Macro Dxf To Shape]] — convert DXF geometry into wires/shapes
+* [[Macro_Loft|Macro Loft]] — loft helper used with [[Macro_Texture|Macro Texture]]
+
+If you add or update a macro page, please follow [[Macro_documentation|Macro documentation]] so it stays easy to maintain and translate.
 
 == Additional information == <!--T:13-->
 


### PR DESCRIPTION
This updates the main Macros page to help readers find current macro documentation more easily. It adds a short discovery section that points to the wiki macro category, a few maintained macro examples, and the macro documentation guidelines so new/updated macro pages stay easy to maintain and translate.