### PR TITLE
Document external addon docs locations

### DIFF
--- a/wiki/Addon.wikitext
+++ b/wiki/Addon.wikitext
@@ -25,12 +25,10 @@ But for macros and workbenches manual installation is also possible:
 * [[How_to_install_macros|How to install macros]]
 * [[Installing_more_workbenches|Installing more workbenches]]
 
-== Documentation and support == <!--T:20-->
+== Documentation and support ==
 
-<!--T:21-->
 External addon documentation is usually maintained in the addon repository itself, on the workbench or macro wiki page, or in the project README linked from the Addon Manager. When you are looking for up-to-date information, start from the addon page in FreeCAD, then follow the repository or wiki links that are listed there.
 
-<!--T:22-->
 For wiki pages that describe addons, keep the scope focused on the current usage, installation notes, and maintenance status. When possible, link back to the original project repository so readers can find the authoritative source and updates.
 
 == Information for developers == <!--T:13-->

--- a/wiki/Addon.wikitext
+++ b/wiki/Addon.wikitext
@@ -25,6 +25,14 @@ But for macros and workbenches manual installation is also possible:
 * [[How_to_install_macros|How to install macros]]
 * [[Installing_more_workbenches|Installing more workbenches]]
 
+== Documentation and support == <!--T:20-->
+
+<!--T:21-->
+External addon documentation is usually maintained in the addon repository itself, on the workbench or macro wiki page, or in the project README linked from the Addon Manager. When you are looking for up-to-date information, start from the addon page in FreeCAD, then follow the repository or wiki links that are listed there.
+
+<!--T:22-->
+For wiki pages that describe addons, keep the scope focused on the current usage, installation notes, and maintenance status. When possible, link back to the original project repository so readers can find the authoritative source and updates.
+
 == Information for developers == <!--T:13-->
 
 <!--T:14-->

--- a/wiki/Macros.wikitext
+++ b/wiki/Macros.wikitext
@@ -70,7 +70,16 @@ See [[How_to_install_macros|How to install macros]] for a more detailed descript
 == Macro repositories == <!--T:11-->
 
 <!--T:29-->
-There are two main places for macros. The first one is the official peer-reviewed macro repository on [https://github.com/FreeCAD/FreeCAD-macros GitHub]. The second one is the [[Macros_recipes|Macros recipes]] page from which you can pick some useful macros to add to your FreeCAD installation. Macros from both repositories can be installed via the [[Std_AddonMgr|Addon Manager]] directly from FreeCAD.
+There are two main places for macros. The first one is the official peer-reviewed macro repository on [https://github.com/FreeCAD/FreeCAD-macros GitHub]. The second one is the [[Macros_recipes|Macros recipes]] page, where you can pick useful macros to add to your FreeCAD installation. Macros from both repositories can be installed via the [[Std_AddonMgr|Addon Manager]] directly from FreeCAD.
+
+To discover active macro pages on the wiki, browse the [[Category:Macros]] and search for pages prefixed with {{incode|Macro_}}. A few examples that are currently maintained and useful to start from are:
+* [[Macro_Zoom1_1|Macro Zoom 1:1]] — precise real-size view scaling
+* [[Macro_Snip|Macro Snip]] — screenshot helper for sharing views
+* [[Macro_MeshToPart|Macro MeshToPart]] — convert selected meshes to parts
+* [[Macro_Dxf_To_Shape|Macro Dxf To Shape]] — convert DXF geometry into wires/shapes
+* [[Macro_Loft|Macro Loft]] — loft helper used with [[Macro_Texture|Macro Texture]]
+
+If you add or update a macro page, please follow [[Macro_documentation|Macro documentation]] so it stays easy to maintain and translate.
 
 == Additional information == <!--T:13-->
 


### PR DESCRIPTION
\n\nThis adds a short documentation-and-support section to the Addon page so readers can find current external addon documentation more easily. It explains where authoritative docs usually live (addon repositories, workbench/macro wiki pages, and README files linked from the Addon Manager) and encourages keeping wiki addon pages focused on usage, installation notes, and maintenance status.