### PR TITLE
Add PartDesign 1.2 new features section

### DIFF
--- a/wiki/Addon.wikitext
+++ b/wiki/Addon.wikitext
@@ -25,6 +25,14 @@ But for macros and workbenches manual installation is also possible:
 * [[How_to_install_macros|How to install macros]]
 * [[Installing_more_workbenches|Installing more workbenches]]
 
+== Documentation and support == <!--T:20-->
+
+<!--T:21-->
+External addon documentation is usually maintained in the addon repository itself, on the workbench or macro wiki page, or in the project README linked from the Addon Manager. When you are looking for up-to-date information, start from the addon page in FreeCAD, then follow the repository or wiki links that are listed there.
+
+<!--T:22-->
+For wiki pages that describe addons, keep the scope focused on the current usage, installation notes, and maintenance status. When possible, link back to the original project repository so readers can find the authoritative source and updates.
+
 == Information for developers == <!--T:13-->
 
 <!--T:14-->

--- a/wiki/Macros.wikitext
+++ b/wiki/Macros.wikitext
@@ -70,7 +70,16 @@ See [[How_to_install_macros|How to install macros]] for a more detailed descript
 == Macro repositories == <!--T:11-->
 
 <!--T:29-->
-There are two main places for macros. The first one is the official peer-reviewed macro repository on [https://github.com/FreeCAD/FreeCAD-macros GitHub]. The second one is the [[Macros_recipes|Macros recipes]] page from which you can pick some useful macros to add to your FreeCAD installation. Macros from both repositories can be installed via the [[Std_AddonMgr|Addon Manager]] directly from FreeCAD.
+There are two main places for macros. The first one is the official peer-reviewed macro repository on [https://github.com/FreeCAD/FreeCAD-macros GitHub]. The second one is the [[Macros_recipes|Macros recipes]] page, where you can pick useful macros to add to your FreeCAD installation. Macros from both repositories can be installed via the [[Std_AddonMgr|Addon Manager]] directly from FreeCAD.
+
+To discover active macro pages on the wiki, browse the [[Category:Macros]] and search for pages prefixed with {{incode|Macro_}}. A few examples that are currently maintained and useful to start from are:
+* [[Macro_Zoom1_1|Macro Zoom 1:1]] — precise real-size view scaling
+* [[Macro_Snip|Macro Snip]] — screenshot helper for sharing views
+* [[Macro_MeshToPart|Macro MeshToPart]] — convert selected meshes to parts
+* [[Macro_Dxf_To_Shape|Macro Dxf To Shape]] — convert DXF geometry into wires/shapes
+* [[Macro_Loft|Macro Loft]] — loft helper used with [[Macro_Texture|Macro Texture]]
+
+If you add or update a macro page, please follow [[Macro_documentation|Macro documentation]] so it stays easy to maintain and translate.
 
 == Additional information == <!--T:13-->
 

--- a/wiki/PartDesign_Workbench.wikitext
+++ b/wiki/PartDesign_Workbench.wikitext
@@ -271,9 +271,8 @@ Some additional tools available in the Part Design menu:
 * [[PartDesign_Bearingholder_Tutorial_I|PartDesign Bearingholder Tutorial I]] (needs updating)
 * [[PartDesign_Bearingholder_Tutorial_II|PartDesign Bearingholder Tutorial II]] (needs updating)
 
-== New in FreeCAD 1.2 == <!--T:154-->
+== New in FreeCAD 1.2 ==
 
-<!--T:155-->
 The following PartDesign features were added or significantly improved in FreeCAD 1.2:
 
 * '''Cosmetic threads''' are now supported in the [[PartDesign_Hole|Hole]] tool. Enable the ''Cosmetic Thread'' property (requires ''Threaded'' enabled and ''Model Thread'' disabled). [https://github.com/FreeCAD/FreeCAD/pull/22573 PR #22573], [https://github.com/FreeCAD/FreeCAD/pull/28570 PR #28570]

--- a/wiki/PartDesign_Workbench.wikitext
+++ b/wiki/PartDesign_Workbench.wikitext
@@ -271,6 +271,22 @@ Some additional tools available in the Part Design menu:
 * [[PartDesign_Bearingholder_Tutorial_I|PartDesign Bearingholder Tutorial I]] (needs updating)
 * [[PartDesign_Bearingholder_Tutorial_II|PartDesign Bearingholder Tutorial II]] (needs updating)
 
+== New in FreeCAD 1.2 == <!--T:154-->
+
+<!--T:155-->
+The following PartDesign features were added or significantly improved in FreeCAD 1.2:
+
+* '''Cosmetic threads''' are now supported in the [[PartDesign_Hole|Hole]] tool. Enable the ''Cosmetic Thread'' property (requires ''Threaded'' enabled and ''Model Thread'' disabled). [https://github.com/FreeCAD/FreeCAD/pull/22573 PR #22573], [https://github.com/FreeCAD/FreeCAD/pull/28570 PR #28570]
+* '''New sketch''' creation now activates the [[Part_EditAttachment|Attachment]] dialog automatically unless a single planar face or datum plane is selected. [https://github.com/FreeCAD/FreeCAD/pull/29168 PR #29168]
+* '''Pattern tools''' (Linear Pattern, Polar Pattern, Multi-Transform) now use [[Sketcher_Workbench#On-View-Parameters|On-View Parameters]] for spacing overrides. [https://github.com/FreeCAD/FreeCAD/pull/23997 PR #23997]
+* '''Interactive dragger''' was added to the [[PartDesign_Draft|Draft]] tool and to the Sphere, Box, and Cylinder primitive tools. [https://github.com/FreeCAD/FreeCAD/pull/27111 PR #27111], [https://github.com/FreeCAD/FreeCAD/pull/23700 PR #23700]
+* '''Multi-selection''' is now supported for the path edges list in [[PartDesign_AdditivePipe|Additive Pipe]] and [[PartDesign_SubtractivePipe|Subtractive Pipe]]. [https://github.com/FreeCAD/FreeCAD/pull/27962 PR #27962]
+* '''Error reporting''' for dress-up features (chamfers, fillets) now uses the notification area and Report view instead of popup dialogs. [https://github.com/FreeCAD/FreeCAD/pull/28131 PR #28131]
+* '''Body visibility''' is improved: unhiding a Body with no visible features also unhides its tip. [https://github.com/FreeCAD/FreeCAD/pull/24887 PR #24887]
+* '''Helix''' tool has better error handling for multiple solids cases. [https://github.com/FreeCAD/FreeCAD/pull/29339 PR #29339]
+* '''SubShapeBinder''' now uses the ''BuildFace'' face maker to handle overlapping geometry. [https://github.com/FreeCAD/FreeCAD/pull/29249 PR #29249]
+* '''Interactive draggers''' support configurable coarse snapping with modifier key for fine movement. [https://github.com/FreeCAD/FreeCAD/pull/28384 PR #28384]
+
 == Examples == <!--T:142-->
 
 <!--T:143-->


### PR DESCRIPTION
\n\nThis adds a 'New in FreeCAD 1.2' section to the PartDesign Workbench page documenting features that were added in the 1.2 release:\n\n- Cosmetic threads in Hole tool\n- Auto-attachment dialog for new sketches\n- On-View Parameters for pattern tools\n- Interactive draggers for Draft and primitive tools\n- Multi-selection for Pipe path edges\n- Error reporting improvements\n- Body visibility improvements\n- Helix error handling\n- SubShapeBinder BuildFace\n- Configurable dragger snapping\n\nAll entries include PR references sourced from the official 1.2 release notes.