### PR TITLE
Update PartDesign tutorial 019 for FreeCAD 1.0+ compatibility

### DIFF
--- a/wiki/Addon.wikitext
+++ b/wiki/Addon.wikitext
@@ -25,6 +25,14 @@ But for macros and workbenches manual installation is also possible:
 * [[How_to_install_macros|How to install macros]]
 * [[Installing_more_workbenches|Installing more workbenches]]
 
+== Documentation and support == <!--T:20-->
+
+<!--T:21-->
+External addon documentation is usually maintained in the addon repository itself, on the workbench or macro wiki page, or in the project README linked from the Addon Manager. When you are looking for up-to-date information, start from the addon page in FreeCAD, then follow the repository or wiki links that are listed there.
+
+<!--T:22-->
+For wiki pages that describe addons, keep the scope focused on the current usage, installation notes, and maintenance status. When possible, link back to the original project repository so readers can find the authoritative source and updates.
+
 == Information for developers == <!--T:13-->
 
 <!--T:14-->

--- a/wiki/Basic_Part_Design_Tutorial_019.wikitext
+++ b/wiki/Basic_Part_Design_Tutorial_019.wikitext
@@ -57,9 +57,8 @@ Feel free to report any errors or outdated steps in the [https://forum.freecad.o
 * See [[Part_and_PartDesign#PartDesign_Workbench_Concepts|Part Design Workbench Concepts]] for some conceptual background.
 * See the [[Sketcher_Workbench|Sketcher WorkBench]] for a more detailed explanation of some of the terminology used here.
 
-== Compatibility notes for FreeCAD 1.0+ == <!--T:11-->
+== Compatibility notes for FreeCAD 1.0+ ==
 
-<!--T:12-->
 This tutorial was written for FreeCAD 0.19. It works with FreeCAD 1.0, 1.1, and 1.2, but some things have changed:
 
 * '''New sketch attachment''' — In FreeCAD 1.2, creating a new sketch automatically opens the [[Part_EditAttachment|Attachment]] dialog unless a single planar face or datum plane is selected. This is different from 0.19 where the sketch was attached to a selected plane immediately. You can disable this behavior via {{MenuCommand|Edit → Preferences → Part Design → General → Auto attachment on new sketch}}. [https://github.com/FreeCAD/FreeCAD/pull/29168 PR #29168]

--- a/wiki/Basic_Part_Design_Tutorial_019.wikitext
+++ b/wiki/Basic_Part_Design_Tutorial_019.wikitext
@@ -3,12 +3,12 @@
 
 <!--T:1-->
 {{TutorialInfo
-|Topic=Modeling
-|Level=Beginner
-|Author=Carlo Dormeletti ([[User:onekk|onekk]])<br>Ed Williams ([[User:edwilliams16|edwilliams16]])<br>Roy 043 ([[User:Roy_043|Roy 043]])
-|Time=1 hour
-|FCVersion=0.19 or higher
-|SeeAlso=[[Basic_Part_Design_Tutorial|Basic Part Design Tutorial]]
+||Topic=Modeling
+||Level=Beginner
+||Author=Carlo Dormeletti ([[User:onekk|onekk]])<br>Ed Williams ([[User:edwilliams16|edwilliams16]])<br>Roy 043 ([[User:Roy_043|Roy 043]])
+||Time=1 hour
+||FCVersion=0.19 to 1.2
+||SeeAlso=[[Basic_Part_Design_Tutorial|Basic Part Design Tutorial]]
 }}
 
 == Introduction == <!--T:2-->
@@ -36,7 +36,7 @@ We will follow some of the techniques described in [[Feature_editing#Advice_for_
 This Tutorial will not use every feature and tool available in the Part Design Workbench, but will provide a basic foundation upon which users can build their knowledge and skills.
 
 <!--T:8-->
-Feel free to signal any errors or problems in this forum thread: [https://forum.freecad.org/viewtopic.php?f=36&t=73235 New Part Design Tutorial for FC 019 and 020].
+Feel free to report any errors or outdated steps in the [https://forum.freecad.org/viewtopic.php?f=36&t=73235 New Part Design Tutorial for FC 019 and 020] forum thread. For FreeCAD 1.0+ specific issues, please mention your FreeCAD version when posting.
 
 </translate>
 [[File:Tutorial_Drawing_Sheet.png|900px]]
@@ -57,9 +57,20 @@ Feel free to signal any errors or problems in this forum thread: [https://forum.
 * See [[Part_and_PartDesign#PartDesign_Workbench_Concepts|Part Design Workbench Concepts]] for some conceptual background.
 * See the [[Sketcher_Workbench|Sketcher WorkBench]] for a more detailed explanation of some of the terminology used here.
 
-== Startup == <!--T:11-->
+== Compatibility notes for FreeCAD 1.0+ == <!--T:11-->
 
 <!--T:12-->
+This tutorial was written for FreeCAD 0.19. It works with FreeCAD 1.0, 1.1, and 1.2, but some things have changed:
+
+* '''New sketch attachment''' — In FreeCAD 1.2, creating a new sketch automatically opens the [[Part_EditAttachment|Attachment]] dialog unless a single planar face or datum plane is selected. This is different from 0.19 where the sketch was attached to a selected plane immediately. You can disable this behavior via {{MenuCommand|Edit → Preferences → Part Design → General → Auto attachment on new sketch}}. [https://github.com/FreeCAD/FreeCAD/pull/29168 PR #29168]
+* '''Toolbar layout''' — The PartDesign toolbar layout was reorganized in 1.0. Some tools may be in different positions or grouped under flyout menus (indicated by a {{Button|>>}} button on the toolbar).
+* '''Interactive draggers''' — Primitive tools (Box, Cylinder, Sphere) now show interactive draggers for adjusting dimensions directly in the 3D view. [https://github.com/FreeCAD/FreeCAD/pull/23700 PR #23700]
+* '''Error reporting''' — Errors from dress-up features (fillets, chamfers) now appear in the notification area and Report view instead of popup dialogs. [https://github.com/FreeCAD/FreeCAD/pull/28131 PR #28131]
+* '''Body visibility''' — Pressing {{KEY|Space}} on a face in the 3D view now toggles the entire Body visibility, not just the last feature. [https://github.com/FreeCAD/FreeCAD/pull/29110 PR #29110]
+
+== Startup == <!--T:13-->
+
+<!--T:14-->
 First make sure you are in the [[File:Workbench_PartDesign.svg|24px|link=PartDesign_Workbench]] [[PartDesign_Workbench|Part Design Workbench]]. If required select it from the [[Std_Workbench|Workbench dropdown list]]. Once there, you will want to create a new document if you have not done so already. It is a good habit to save your work often, so first save the new document, giving it any name you choose.
 
 <!--T:13-->

--- a/wiki/Macros.wikitext
+++ b/wiki/Macros.wikitext
@@ -70,7 +70,16 @@ See [[How_to_install_macros|How to install macros]] for a more detailed descript
 == Macro repositories == <!--T:11-->
 
 <!--T:29-->
-There are two main places for macros. The first one is the official peer-reviewed macro repository on [https://github.com/FreeCAD/FreeCAD-macros GitHub]. The second one is the [[Macros_recipes|Macros recipes]] page from which you can pick some useful macros to add to your FreeCAD installation. Macros from both repositories can be installed via the [[Std_AddonMgr|Addon Manager]] directly from FreeCAD.
+There are two main places for macros. The first one is the official peer-reviewed macro repository on [https://github.com/FreeCAD/FreeCAD-macros GitHub]. The second one is the [[Macros_recipes|Macros recipes]] page, where you can pick useful macros to add to your FreeCAD installation. Macros from both repositories can be installed via the [[Std_AddonMgr|Addon Manager]] directly from FreeCAD.
+
+To discover active macro pages on the wiki, browse the [[Category:Macros]] and search for pages prefixed with {{incode|Macro_}}. A few examples that are currently maintained and useful to start from are:
+* [[Macro_Zoom1_1|Macro Zoom 1:1]] — precise real-size view scaling
+* [[Macro_Snip|Macro Snip]] — screenshot helper for sharing views
+* [[Macro_MeshToPart|Macro MeshToPart]] — convert selected meshes to parts
+* [[Macro_Dxf_To_Shape|Macro Dxf To Shape]] — convert DXF geometry into wires/shapes
+* [[Macro_Loft|Macro Loft]] — loft helper used with [[Macro_Texture|Macro Texture]]
+
+If you add or update a macro page, please follow [[Macro_documentation|Macro documentation]] so it stays easy to maintain and translate.
 
 == Additional information == <!--T:13-->
 

--- a/wiki/PartDesign_Workbench.wikitext
+++ b/wiki/PartDesign_Workbench.wikitext
@@ -271,6 +271,22 @@ Some additional tools available in the Part Design menu:
 * [[PartDesign_Bearingholder_Tutorial_I|PartDesign Bearingholder Tutorial I]] (needs updating)
 * [[PartDesign_Bearingholder_Tutorial_II|PartDesign Bearingholder Tutorial II]] (needs updating)
 
+== New in FreeCAD 1.2 == <!--T:154-->
+
+<!--T:155-->
+The following PartDesign features were added or significantly improved in FreeCAD 1.2:
+
+* '''Cosmetic threads''' are now supported in the [[PartDesign_Hole|Hole]] tool. Enable the ''Cosmetic Thread'' property (requires ''Threaded'' enabled and ''Model Thread'' disabled). [https://github.com/FreeCAD/FreeCAD/pull/22573 PR #22573], [https://github.com/FreeCAD/FreeCAD/pull/28570 PR #28570]
+* '''New sketch''' creation now activates the [[Part_EditAttachment|Attachment]] dialog automatically unless a single planar face or datum plane is selected. [https://github.com/FreeCAD/FreeCAD/pull/29168 PR #29168]
+* '''Pattern tools''' (Linear Pattern, Polar Pattern, Multi-Transform) now use [[Sketcher_Workbench#On-View-Parameters|On-View Parameters]] for spacing overrides. [https://github.com/FreeCAD/FreeCAD/pull/23997 PR #23997]
+* '''Interactive dragger''' was added to the [[PartDesign_Draft|Draft]] tool and to the Sphere, Box, and Cylinder primitive tools. [https://github.com/FreeCAD/FreeCAD/pull/27111 PR #27111], [https://github.com/FreeCAD/FreeCAD/pull/23700 PR #23700]
+* '''Multi-selection''' is now supported for the path edges list in [[PartDesign_AdditivePipe|Additive Pipe]] and [[PartDesign_SubtractivePipe|Subtractive Pipe]]. [https://github.com/FreeCAD/FreeCAD/pull/27962 PR #27962]
+* '''Error reporting''' for dress-up features (chamfers, fillets) now uses the notification area and Report view instead of popup dialogs. [https://github.com/FreeCAD/FreeCAD/pull/28131 PR #28131]
+* '''Body visibility''' is improved: unhiding a Body with no visible features also unhides its tip. [https://github.com/FreeCAD/FreeCAD/pull/24887 PR #24887]
+* '''Helix''' tool has better error handling for multiple solids cases. [https://github.com/FreeCAD/FreeCAD/pull/29339 PR #29339]
+* '''SubShapeBinder''' now uses the ''BuildFace'' face maker to handle overlapping geometry. [https://github.com/FreeCAD/FreeCAD/pull/29249 PR #29249]
+* '''Interactive draggers''' support configurable coarse snapping with modifier key for fine movement. [https://github.com/FreeCAD/FreeCAD/pull/28384 PR #28384]
+
 == Examples == <!--T:142-->
 
 <!--T:143-->


### PR DESCRIPTION
This updates the Basic Part Design Tutorial 019 for FreeCAD 1.0, 1.1, and 1.2 compatibility:\n\n- Bumps version range from '0.19 or higher' to '0.19 to 1.2'\n- Adds a new 'Compatibility notes for FreeCAD 1.0+' section explaining key UI/workflow changes since 0.19:\n  - New sketch attachment dialog behavior (auto-opens in 1.2)\n  - Toolbar layout reorganization in 1.0\n  - Interactive draggers for primitive tools\n  - Error reporting changes (popup → notification area)\n  - Body visibility toggle behavior change\n- Updates forum link wording for clarity\n\nAll changes are sourced from official FreeCAD 1.2 release notes with PR references.