### PR TITLE
Improve macro discoverability — add link to Category:Macros

### DIFF
--- a/wiki/Macros.wikitext
+++ b/wiki/Macros.wikitext
@@ -70,7 +70,7 @@ See [[How_to_install_macros|How to install macros]] for a more detailed descript
 == Macro repositories == <!--T:11-->
 
 <!--T:29-->
-There are two main places for macros. The first one is the official peer-reviewed macro repository on [https://github.com/FreeCAD/FreeCAD-macros GitHub]. The second one is the [[Macros_recipes|Macros recipes]] page from which you can pick some useful macros to add to your FreeCAD installation. Macros from both repositories can be installed via the [[Std_AddonMgr|Addon Manager]] directly from FreeCAD.
+There are two main places for macros. The first one is the official peer-reviewed macro repository on [https://github.com/FreeCAD/FreeCAD-macros GitHub]. The second one is the [[Macros_recipes|Macros recipes]] page from which you can pick some useful macros to add to your FreeCAD installation. Macros from both repositories can be installed via the [[Std_AddonMgr|Addon Manager]] directly from FreeCAD. You can also browse [[Category:Macros|all macro pages]] and search for pages prefixed with {{incode|Macro_}}.
 
 == Additional information == <!--T:13-->
 


### PR DESCRIPTION
Small, targeted edit to the 'Macro repositories' section: adds a link to [[Category:Macros]] and search guidance. Does not add new translatable sections or T tags — only modifies existing section text.\n\nAddresses maintainer feedback on PR #382.