### PR TITLE
doc: document missing CAM workbench features (fixes #25)

### DIFF
--- a/wiki/Release_notes_26.3.wikitext
+++ b/wiki/Release_notes_26.3.wikitext
@@ -255,6 +255,9 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * CAM drilling cycle expansion now uses MachineState for more accurate machine state tracking while expanding drilling cycles. [https://github.com/FreeCAD/FreeCAD/pull/30112 Pull request #30112]
 * The [[CAM_Profile|Profile]] and [[CAM_Pocket_Shape|Pocket]] linking options now include collision-avoidance strategies for using retract height, clearance height, line-of-sight checks, tool diameter, or tool shape. [https://github.com/FreeCAD/FreeCAD/pull/29983 Pull request #29983]
 * The Linking generator was added to the [[CAM_Engrave|Engrave]] and [[CAM_Deburr|Deburr]] operations to use the safe height instead of clearance height for linking moves. The Linking Mode and Safety Margin options were added to the task panels, also for [[CAM_Drilling|Drilling]] and [[CAM_Helix|Helix]] operations. [https://github.com/FreeCAD/FreeCAD/pull/29959 Pull request #29959]
+* Job visibility toggling has been optimized to improve responsiveness in the CAM workbench. [https://github.com/FreeCAD/FreeCAD/pull/30240 Pull request #30240]
+* Comment serialization in G-code generation has been improved to ensure custom annotations are correctly preserved during save/load round-trips. [https://github.com/FreeCAD/FreeCAD/pull/30317 Pull request #30317]
+* Path loop selection (SelectLoop) and DressupTag operations have been made more reliable, particularly when handling tag ordering across multiple closed loops and copy operations. [https://github.com/FreeCAD/FreeCAD/pull/30271 Pull request #30271], [https://github.com/FreeCAD/FreeCAD/pull/29877 Pull request #29877], [https://github.com/FreeCAD/FreeCAD/pull/30267 Pull request #30267]
 * The [[CAM_SelectLoop|loop selection]] tool can now handle horizontal faces. [https://github.com/FreeCAD/FreeCAD/pull/26786 Pull request #26786]
 
 == Draft Workbench == <!--T:27-->


### PR DESCRIPTION
This PR implements the documentation updates for issue #25 (CAM Workbench documentation updates).

All updates are restricted strictly to English wiki root files, with no translation files/directories modified, and each new user-facing feature or change has been cited with its upstream FreeCAD pull request source.

PayPal: https://paypal.me/sureshc26