### PR TITLE
doc: document missing BIM workbench features (fixes #26)

### DIFF
--- a/wiki/Release_notes_26.3.wikitext
+++ b/wiki/Release_notes_26.3.wikitext
@@ -182,6 +182,9 @@ Previous FreeCAD release notes can be found in the [[Feature_list#Release_notes|
 * [[BIM_DrawingView|DrawingView]] cut lines now use the default line width and cut areas line thickness ratio preferences for thicker cut-line output. [https://github.com/FreeCAD/FreeCAD/pull/30149 Pull request #30149]
 * IFC import now treats a multicore preference value of 0 as disabled before creating the IfcOpenShell geometry iterator, avoiding invalid worker counts when multicore processing is turned off. [https://github.com/FreeCAD/FreeCAD/pull/30201 Pull request #30201]
 * The classification systems download URL was updated. [https://github.com/FreeCAD/FreeCAD/pull/30247 Pull request #30247]
+* The BIM Project Manager removed reference to the obsolete NorthDeviation property. [https://github.com/FreeCAD/FreeCAD/pull/28913 Pull request #28913]
+* Fixed Arch CutPlane deselection issue in BIM workbench. [https://github.com/FreeCAD/FreeCAD/pull/29699 Pull request #29699]
+* Fixed an issue where unsupported base objects for ArchWalls were not managed properly. [https://github.com/FreeCAD/FreeCAD/pull/29810 Pull request #29810]
 
 == CAM Workbench == <!--T:25-->
 


### PR DESCRIPTION
This PR implements the documentation updates for issue #26 (BIM Workbench documentation updates).

All updates are restricted strictly to English wiki root files, with no translation files/directories modified, and each new user-facing feature or change has been cited with its upstream FreeCAD pull request source.

PayPal: https://paypal.me/sureshc26