### PR TITLE
doc: document missing 1.2 release notes information (fixes #30)

### DIFF
--- a/wiki/Release_notes_26.3.wikitext
+++ b/wiki/Release_notes_26.3.wikitext
@@ -284,6 +284,10 @@ ToDo (last check: 20260528, #30358)
 
 <!--T:87-->
 * [[Draft_Trimex|Trimex]] now reports unsupported sketch selections before opening the task panel, avoiding a misleading no-op workflow. [https://github.com/FreeCAD/FreeCAD/pull/29845 Pull request #29845]
+* Base-less walls created in the BIM workbench are now directly Draft-editable, allowing their endpoints to be modified dynamically using Draft edit handles. [https://github.com/FreeCAD/FreeCAD/pull/29860 Pull request #29860]
+* Saving annotation styles now guarantees that the file has a {{FileName|.json}} extension. [https://github.com/FreeCAD/FreeCAD/pull/30358 Pull request #30358]
+* In the Draft ShapeString tool, point coordinates entered manually in the task panel are no longer reset or overwritten by subsequent mouse movements in the 3D view. [https://github.com/FreeCAD/FreeCAD/pull/29762 Pull request #29762]
+* Added on-screen hints for Draft annotation tools to guide user input. [https://github.com/FreeCAD/FreeCAD/pull/29649 Pull request #29649]
 
 == FEM Workbench == <!--T:29-->
 
@@ -420,6 +424,9 @@ ToDo (last check: 20260528, #30358)
 * Errors from Part Design dress-up features such as chamfers and fillets are now shown in the notification area and Report view instead of a popup dialog, allowing users to stay in the task panel. [https://github.com/FreeCAD/FreeCAD/pull/28131 Pull request #28131]
 * Now unhiding a Body with no visible features also unhides its tip. [https://github.com/FreeCAD/FreeCAD/pull/24887 Pull request #24887]
 * Changing a [[PartDesign_Pad|Pad]] to the ''Up To Face'' type no longer crashes if the feature is not inside a [[PartDesign_Body|Body]]; an error is reported instead. [https://github.com/FreeCAD/FreeCAD/pull/30022 Pull request #30022]
+* The Chamfer tool now automatically activates selection mode immediately upon GUI initialization to streamline the user workflow. [https://github.com/FreeCAD/FreeCAD/pull/29313 Pull request #29313]
+* Expression migration handling for Length and Length2 parameters in TwoLengths pads has been improved to ensure backwards compatibility when opening legacy files. [https://github.com/FreeCAD/FreeCAD/pull/29247 Pull request #29247]
+* Extrusion pocket and pad calculations when using the UpToShape option against complex geometric bodies have been made more robust. [https://github.com/FreeCAD/FreeCAD/pull/29686 Pull request #29686]
 * Pressing {{KEY|Space}} on an element selected from the 3D view (e.g. from selecting a face) now toggles the visibility of the entire [[PartDesign_Body|PartDesign Body]] instead of the last feature, making it easier to show or hide bodies in assemblies or files with multiple bodies. Selection in the Tree view still toggles the selected object. [https://github.com/FreeCAD/FreeCAD/pull/29110 Pull request #29110] and [https://github.com/FreeCAD/FreeCAD/pull/30231 Pull request #30231]
 * Input hints were implemented for the interactive control draggers. [https://github.com/FreeCAD/FreeCAD/pull/29631 Pull request #29631]
 * [[PartDesign_SubShapeBinder|SubShapeBinder]] now uses the ''BuildFace'' face maker to handle overlapping geometry. [https://github.com/FreeCAD/FreeCAD/pull/29249 Pull request #29249]
@@ -503,6 +510,9 @@ ToDo (last check: 20260528, #30358)
 * Sketcher geometry now updates correctly after removing part of a constraint from a fully constrained sketch. [https://github.com/FreeCAD/FreeCAD/pull/29812 Pull request #29812]
 * [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] lines are now positioned better. [https://github.com/FreeCAD/FreeCAD/pull/29630 Pull request #29630]
 * Arcs can now be selected directly while the [[Image:Sketcher_ConstrainAngle.svg|24px]] [[Sketcher_ConstrainAngle|Angle dimension]] tool is active, making it possible to create arc angle dimensions without first preselecting the arc. [https://github.com/FreeCAD/FreeCAD/pull/29679 Pull request #29679]
+* User interface hints have been re-added for the new Polyline tool to improve tool usability. [https://github.com/FreeCAD/FreeCAD/pull/30344 Pull request #30344]
+* The traditional Polyline keyboard shortcut has been restored for the new Polyline tool, and shortcut hijacking conflicts with the new Text tool have been resolved. [https://github.com/FreeCAD/FreeCAD/pull/30395 Pull request #30395], [https://github.com/FreeCAD/FreeCAD/pull/29721 Pull request #29721]
+* Labeling in the task panel has been made more consistent by changing "Change Value" to "Edit Value". [https://github.com/FreeCAD/FreeCAD/pull/29556 Pull request #29556]
 * The [[Sketcher_Dialog#Constraints|Sketcher Dialog]] has two new commands - to delete all constraints and to delete filtered constraints. [https://github.com/FreeCAD/FreeCAD/pull/29993 Pull request #29993]
 * The [[Sketcher_Dimension|Dimension]] tool now uses input hints. [https://github.com/FreeCAD/FreeCAD/pull/30630 Pull request #30630]
 * The [[Sketcher_ConstrainPointOnObject|Point-On-Object]] constraint now supports autoconstraints along the line. Helper lines are displayed for it. [https://github.com/FreeCAD/FreeCAD/pull/30332 Pull request #30332]


### PR DESCRIPTION
This PR implements the documentation updates for issue #30 (1.2 release notes missing details updates).

All updates are restricted strictly to English wiki root files, with no translation files/directories modified, and each new user-facing feature or change has been cited with its upstream FreeCAD pull request source.

PayPal: https://paypal.me/sureshc26