### PR TITLE
Update CAM_Preferences.wikitext

### DIFF
--- a/wiki/CAM_Preferences.wikitext
+++ b/wiki/CAM_Preferences.wikitext
@@ -18,7 +18,7 @@
 ==Overview== <!--T:16-->
 
 <!--T:1-->
-The preferences screen of the [[CAM_Workbench|CAM Workbench]] are found in the [[Preferences_Editor|Preferences Editor]], {{MenuCommand|Edit → Preferences → CAM}}.
+After selecting the [[CAM_Workbench|CAM Workbench]] the preferences screen is found in the [[Preferences_Editor|Preferences Editor]], {{MenuCommand|Edit → Preferences → CAM}}.
 
 <!--T:8-->
 There are five pages: [[#GUI|GUI]], [[#Assets|Assets]], [[#Job_preferences|Job preferences]], [[#Dressups|Dressups]], and [[#Advanced|Advanced]].


### PR DESCRIPTION
If you're in another workbench, like Part Design, only the GUI options are shown for the CAM Workbench if you try to change the preferences. Note this here in the documentation. Also fix "are" into "is" as it's referring to the "preferences screen", which is singular.


<!-- 

    🚨 𝗡𝗼𝘁𝗶𝗰𝗲
    Please be aware that translations 
    cannot be changed via pull requests.

    Head over to the wiki at:
    https://wiki.freecad.org
    
-->