### PR TITLE
Fix Developer Hub source and GitHub links

### DIFF
--- a/wiki/Developer_hub.wikitext
+++ b/wiki/Developer_hub.wikitext
@@ -19,13 +19,7 @@ These pages are in the early stage of development. If you can't find the informa
 == Developer Documentation == <!--T:32-->
 
 <!--T:4-->
-For development guidance, start with these official resources:
-
-* [https://freecad.github.io/DevelopersHandbook/ Developers Handbook]: development setup, design guidelines, code style and contribution practices.
-* [https://freecad.github.io/Addon-Academy/ Addon Academy]: documentation, examples and guides for developing FreeCAD addons.
-* [https://freecad.github.io/SourceDoc/ Source documentation]: a generated source-reference snapshot. Check its build date against the FreeCAD version you are developing for.
-
-The wiki sections below provide additional topic-specific material. Some pages describe older versions of FreeCAD; check the version covered by each resource when instructions differ.
+The developer documentation comprises the following sections:
 
 === Compiling FreeCAD === <!--T:33-->
 

--- a/wiki/Developer_hub.wikitext
+++ b/wiki/Developer_hub.wikitext
@@ -19,7 +19,13 @@ These pages are in the early stage of development. If you can't find the informa
 == Developer Documentation == <!--T:32-->
 
 <!--T:4-->
-The developer documentation comprises the following sections:
+For development guidance, start with these official resources:
+
+* [https://freecad.github.io/DevelopersHandbook/ Developers Handbook]: development setup, design guidelines, code style and contribution practices.
+* [https://freecad.github.io/Addon-Academy/ Addon Academy]: documentation, examples and guides for developing FreeCAD addons.
+* [https://freecad.github.io/SourceDoc/ Source documentation]: a generated source-reference snapshot. Check its build date against the FreeCAD version you are developing for.
+
+The wiki sections below provide additional topic-specific material. Some pages describe older versions of FreeCAD; check the version covered by each resource when instructions differ.
 
 === Compiling FreeCAD === <!--T:33-->
 
@@ -34,8 +40,8 @@ The developer documentation comprises the following sections:
 * [[Third_Party_Libraries|Third Party Libraries]]
 * [[Third_Party_Tools|Third Party Tools]]
 * [[Start up and Configuration|Start up and Configuration]]
-* [[Start_up_and_Configuration|Source documentation]]
-* Use [[https://github.com/FreeCAD/FreeCAD/issues|GitHub]] when you have a problem or think you may have found a bug
+* [https://freecad.github.io/SourceDoc/ Source documentation]
+* Use [https://github.com/FreeCAD/FreeCAD/issues GitHub issues] when you have a problem or think you may have found a bug
 
 === Packaging === <!--T:19-->
 


### PR DESCRIPTION
This fixes two broken links in `wiki/Developer_hub.wikitext`:

- `Source documentation` currently points to `Start up and Configuration`. It now points to FreeCAD's generated [SourceDoc](https://freecad.github.io/SourceDoc/).
- The GitHub issues URL uses internal-link markup (`[[URL|label]]`), which renders incorrectly for an external URL. It now uses MediaWiki's documented [external-link syntax](https://www.mediawiki.org/wiki/Help:Links#External_links).

Validation: the final diff contains those two link replacements plus a final newline added by the GitHub editor (3 additions, 3 deletions). All 37 translation markers are retained, and no translation files change. This is a small first pass for #329; the wider legacy-hub audit remains open. Prepared with Codex assistance; no reward or payment is assumed.