### PR TITLE
Document PartDesign Thickness Recto Verso behavior

### DIFF
--- a/wiki/PartDesign_Thickness.wikitext
+++ b/wiki/PartDesign_Thickness.wikitext
@@ -70,16 +70,16 @@ The [[Image:PartDesign_Thickness.svg|24px]] '''PartDesign Thickness''' tool tran
 * {{MenuCommand|Remove face}}: Choose a way to remove faces from the selection:
 ** Select one or more faces in the list and press the {{KEY|Del}} key or right-click the list and select {{MenuCommand|Remove}} from the context menu.
 ** Press the {{Button|Remove face}} button. All previously selected faces are highlighted in purple. Select each face to be removed.
-* {{MenuCommand|Thickness}}: Set the wall thickness either by editing the value or by clicking the up/down arrows.
+* {{MenuCommand|Thickness}}: Set the wall thickness either by editing the value or by clicking the up/down arrows. {{VersionPlus|26.3}}: In ''Recto Verso'' mode this is the total wall thickness, with half applied to each side of the faces that remain after the selected faces are removed. For example, a thickness of {{value|2 mm}} applies {{value|1 mm}} inward and {{value|1 mm}} outward.
 * {{MenuCommand|Mode}}:
-** {{MenuCommand|Skin}}: Select this option if you want to get an item like a vase, headless but with the bottom. Only this option can be selected.
+** {{MenuCommand|Skin}}: Select this option if you want to get an item like a vase, headless but with the bottom.
 ** {{MenuCommand|Pipe}}: Not implemented. See [https://forum.freecad.org/viewtopic.php?p=484495#p484495 this forum topic]. {{VersionPlus|26.3}}: Not shown in FreeCAD.
-** {{MenuCommand|Recto Verso}}: {{VersionMinus|1.1}}: Not implemented. See [https://forum.freecad.org/viewtopic.php?p=484495#p484495 this forum topic]. {{VersionPlus|26.3}}: Implemented independently of OCC.
+** {{MenuCommand|Recto Verso}}: {{VersionMinus|1.1}}: Not implemented. See [https://forum.freecad.org/viewtopic.php?p=484495#p484495 this forum topic]. {{VersionPlus|26.3}}: Creates walls centered on the remaining faces by applying half the thickness inward and half outward, then fusing the results. See [https://github.com/FreeCAD/FreeCAD/pull/32333 Pull request #32333].
 * {{MenuCommand|Join Type}}:
 ** {{MenuCommand|Arc}}: When non-tangential faces are offset, new faces that do not intersect are joined by a fillet with a radius equal to the defined thickness.
 ** {{MenuCommand|Intersection}}: When non-tangential faces are offset, new faces that do not intersect are extended to meet at their virtual intersection.
 * {{MenuCommand|Intersection}}: When checked, self-intersections in certain models are avoided. This option is not recommended as it relies on an incomplete [https://dev.opencascade.org/doc/refman/html/class_b_rep_offset_a_p_i___make_thick_solid.html#af78f35025a31e2ce8bd96c82fb33a981 OpenCASCADE method].
-* {{MenuCommand|Make thickness inwards}}: When checked, faces are offset inward.
+* {{MenuCommand|Make thickness inwards}}: When checked, faces are offset inward. {{VersionPlus|26.3}}: Disabled in ''Recto Verso'' mode, which always applies the thickness equally in both directions.
 
 == Notes == <!--T:28-->
 
@@ -122,9 +122,9 @@ A PartDesign Thickness object is derived from a [[Part_Feature|Part Feature]] ob
 
 <!--T:38-->
 * {{PropertyData|Value|Length}}: Thickness value. Default: {{value|1 mm}}.
-* {{PropertyData|Mode|Enumeration}}: Mode. {{value|Skin}} (default), {{value|Pipe}} or {{Value|Recto verso}}. Only {{value|Skin}} is implemented.
+* {{PropertyData|Mode|Enumeration}}: Mode. {{value|Skin}} (default), {{value|Pipe}} or {{Value|Recto verso}}. {{VersionMinus|1.1}}: Only {{value|Skin}} is implemented. {{VersionPlus|26.3}}: {{Value|Recto verso}} is also implemented; {{value|Pipe}} remains unimplemented and is hidden from the task panel's mode selector.
 * {{PropertyData|Join|Enumeration}}: Join type. {{value|Arc}} (default) or {{Value|Intersection}}.
-* {{PropertyData|Reversed|Bool}}: Apply the thickness towards the solids interior. Default: {{FALSE}}.
+* {{PropertyData|Reversed|Bool}}: Apply the thickness towards the solids interior. Default: {{FALSE}}. {{VersionPlus|26.3}}: Has no effect in ''Recto Verso'' mode.
 * {{PropertyData|Intersection|Bool}}: Enable intersection-handling. Default: {{FALSE}}.
 
 


### PR DESCRIPTION
The Thickness page acknowledges Recto Verso in FreeCAD 26.3, but its Skin and Mode descriptions still say only Skin is available. The page also does not explain how to size a centered wall or why the inward-direction control is disabled. This change documents those behaviors from the merged implementation.

Related to #79. This is a focused update to the Thickness page; it does not close the ongoing workbench documentation issue.

- **Thickness value and Recto Verso description:** explain total wall thickness, half on each side of the remaining faces, with a 2 mm example. Source: [`makeRectoVersoThickness` in FreeCAD PR #32333](https://github.com/FreeCAD/FreeCAD/pull/32333/files), which uses `abs(thickness) / 2.0`; its planar-shell test also checks the 2 mm example. Replace the implementation-detail-only description with the behavior a user needs.
- **Skin and Mode descriptions:** remove the contradictory claim that Skin is the only selectable mode, retain the older-version limitation, and document Pipe's continued absence from the task-panel selector. Source: the same PR's `TaskThicknessParameters::addContainerWidget` and mode handling.
- **Make thickness inwards and Reversed:** explain that the control is disabled and the property has no effect in Recto Verso mode. Source: the same PR's `updateModeControls`, symmetric offsets, and `testReversedDoesNotChangeRectoVersoResult`.

Validation: compared these statements with the merged diff and current upstream source; checked the existing 26.3 release notes to avoid duplicating their entry. Only the wiki-root Thickness file changes. All 27 existing translation markers and translate boundaries are preserved; template/link delimiters are balanced; `git diff --check` passes. This is a documentation change; FreeCAD was not built or run.
