### PR TITLE
Use “laser cutters” in the CAM overview

### DIFF
--- a/wiki/CAM_Workbench.wikitext
+++ b/wiki/CAM_Workbench.wikitext
@@ -19,7 +19,7 @@
 == Introduction == <!--T:1-->
 
 <!--T:2-->
-The [[Image:Workbench_CAM.svg|24px]] [[CAM_Workbench|CAM Workbench]] is used to produce machine instructions for [https://en.wikipedia.org/wiki/CNC_router CNC machines] from a FreeCAD 3D model. These produce real-world 3D objects on CNC machines such as mills, lathes, lasercutters, or similar. Typically, instructions are a [https://en.wikipedia.org/wiki/G-code G-code] dialect. A [https://www.ange-softs.com/SIMULCNCHTML/index.html general CNC lathe tool path sequence simulation example] is presented here.
+The [[Image:Workbench_CAM.svg|24px]] [[CAM_Workbench|CAM Workbench]] is used to produce machine instructions for [https://en.wikipedia.org/wiki/CNC_router CNC machines] from a FreeCAD 3D model. These produce real-world 3D objects on CNC machines such as mills, lathes, laser cutters, or similar. Typically, instructions are a [https://en.wikipedia.org/wiki/G-code G-code] dialect. A [https://www.ange-softs.com/SIMULCNCHTML/index.html general CNC lathe tool path sequence simulation example] is presented here.
 
 </translate>
 [[Image:pathwb.png|600px]]


### PR DESCRIPTION
This changes “lasercutters” to the standard two-word term in the CAM overview; no translation markers or technical behavior are changed.

I verified the final diff is one line against the current `main` page. Prepared with Codex assistance; this PR does not claim to complete the broader issue or assume a reward.