### PR TITLE
Fix wording in Sketcher tool descriptions

### DIFF
--- a/wiki/Sketcher_Workbench.wikitext
+++ b/wiki/Sketcher_Workbench.wikitext
@@ -235,7 +235,7 @@ These are tools for creating objects.
 * <span id="Sketcher_CompCreateRegularPolygon">[[Image:Sketcher_CreateHexagon.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]] Create Polygon:</span><!--Do not edit span id: the Sketcher_CompCreateRegularPolygon pages redirect here-->
 
 <!--T:44-->
-:* [[Image:Sketcher_CreateTriangle.svg|32px]] [[Sketcher_CreateTriangle|Triangle]]: creates an equilateral triangle. {{Version|1.0}}: This is the same tool as [[Sketcher_CreateRegularPolygon|Polygon]] but with the number of sides preset to a specif value.
+:* [[Image:Sketcher_CreateTriangle.svg|32px]] [[Sketcher_CreateTriangle|Triangle]]: Creates an equilateral triangle. {{Version|1.0}}: This is the same tool as [[Sketcher_CreateRegularPolygon|Polygon]] but with the number of sides preset to a specific value.
 
 <!--T:45-->
 :* [[Image:Sketcher_CreateSquare.svg|32px]] [[Sketcher_CreateSquare|Square]]: Creates a square. Idem.
@@ -333,7 +333,7 @@ These are tools for creating [[#Constraints|constraints]]. Some constraints requ
 * <span id="Sketcher_CompHorVer">[[Image:Sketcher_ConstrainHorVer.svg|x32px]][[Image:Toolbar_flyout_arrow_blue_background.svg|x32px]]Horizontal/Vertical Constraints:</span><!--Do not edit span id: the Sketcher_CompHorVer pages redirect here-->
 
 <!--T:190-->
-:* [[File:Sketcher_ConstrainHorVer.svg|32px]] [[Sketcher_ConstrainHorVer|Horizontal/Vertical Constraint]]: Constrains lines or pairs of points to be horizontal or vertical, whichever is closest to the current alignment. It combines the [[Sketcher_ConstrainHorizontal|Horizontal Constrain]] and [[Sketcher_ConstrainVertical|Vertical Constrain]] tools. {{Version|1.0}}
+:* [[File:Sketcher_ConstrainHorVer.svg|32px]] [[Sketcher_ConstrainHorVer|Horizontal/Vertical Constraint]]: Constrains lines or pairs of points to be horizontal or vertical, whichever is closest to the current alignment. It combines the [[Sketcher_ConstrainHorizontal|Horizontal Constraint]] and [[Sketcher_ConstrainVertical|Vertical Constrain]] tools. {{Version|1.0}}
 
 <!--T:61-->
 :* [[File:Sketcher_ConstrainHorizontal.svg|32px]] [[Sketcher_ConstrainHorizontal|Horizontal Constraint]]: Constrains lines or pairs of points to be horizontal.


### PR DESCRIPTION
This corrects three wording errors in the Sketcher tool list: sentence capitalization, “specific”, and the Horizontal Constraint label. Translation markers and technical content are unchanged.

The final page was compared with the current `main` source and retains all 248 translation markers. Prepared with Codex assistance; this does not claim to complete the broader issue or assume a reward.