### PR TITLE
Clarify several macro recipe descriptions

### DIFF
--- a/wiki/Macros_recipes.wikitext
+++ b/wiki/Macros_recipes.wikitext
@@ -347,7 +347,7 @@ If you have written a macro and want to include it in one of the categories on t
 * {{MacroLink|Icon=Macro_FCInfoGlass.png|Macro_FCInfoGlass|Macro FCInfoGlass}}: Gives a series of information about the selected shape and displayed in screen 3D.
 
 <!--T:246-->
-* {{MacroLink|Icon=FCInfoToMouse.png|Macro_FCInfoToMouse|Macro FCInfoToMouse}}: Provides informations coordinates, length and angles in real time on the mouse in a bubble annotation displayed in the 3D screen.
+* {{MacroLink|Icon=FCInfoToMouse.png|Macro_FCInfoToMouse|Macro FCInfoToMouse}}: Provides coordinate, length, and angle information in real time in an annotation next to the mouse pointer in the 3D view.
 
 <!--T:247-->
 * {{MacroLink|Icon=Macro_FCTreeView.png|Macro_FCTreeView|Macro FCTreeView}}: Macro for list all objects in the project in one list without hierarchy, options sort by name, label, visibility, group, by length option search by name, label... without case sensitive or with case sensitive and select all objects displayed in the macro window.
@@ -533,7 +533,7 @@ If you have written a macro and want to include it in one of the categories on t
 * {{MacroLink|Icon=Applications-python.svg|Macro_TimingGear|Macro TimingGear}}: This macro creates GT2/GT3/GT5 timing gears to be used with timing belts.
 
 <!--T:288-->
-* {{MacroLink|Icon=Macro_Triangle_AH.png|Macro_Triangle_AH|Macro Triangle AH}}: This macro creates a triangle by giving the head angle and the height of the triangle (the head of the  triangle is positioned to the xyz coordinates 0.0).
+* {{MacroLink|Icon=Macro_Triangle_AH.png|Macro_Triangle_AH|Macro Triangle AH}}: This macro creates a triangle by giving the head angle and the height of the triangle (the head of the triangle is positioned to the xyz coordinates 0.0).
 
 <!--T:289-->
 * {{MacroLink|Icon=Macro_WireXYZ.png|Macro_WireXYZ|Macro WireXYZ}}: This macro creates a Wire with the coordinates extracted from a file. The coordinates X Y Z are separated by a space.
@@ -773,7 +773,7 @@ If you have written a macro and want to include it in one of the categories on t
 * {{MacroLink|Icon=SpreadsheetDependencyInspector.png|Macro_Spreadsheet_Dependency_Inspector|Macro Spreadsheet Dependency Inspector}}: Displays, for a selection of spreadsheet cells, all dependencies between spreadsheet cells and even between cells and object properties.
 
 <!--T:332-->
-* {{MacroLink|Icon=Macro_SpreadsheetTools.png|Macro_SpreadsheetTools|Macro Spreadsheet Tools}}: This macro helps managing cells inside FreeCAD Spreadsheet workbench.
+* {{MacroLink|Icon=Macro_SpreadsheetTools.png|Macro_SpreadsheetTools|Macro Spreadsheet Tools}}: This macro helps manage cells in the FreeCAD Spreadsheet Workbench.
 
 <!--T:333-->
 * {{MacroLink|Icon=Applications-python.svg|Macro_Spreadsheet2html|Macro Spreadsheet2html}}: Exports a spreadsheet as styled html. Intended as support in transfering data to office suits.
@@ -809,7 +809,7 @@ If you have written a macro and want to include it in one of the categories on t
 <translate>
 
 <!--T:335-->
-* {{MacroLink|Icon=Macro_Arch_Axis_System_Repartition.png|Macro_Arch_Axis_System_Repartition|Macro Arch Axis System Repartition}}: This macro help you to create an Arch Axis System along a line with a set of parameters.
+* {{MacroLink|Icon=Macro_Arch_Axis_System_Repartition.png|Macro_Arch_Axis_System_Repartition|Macro Arch Axis System Repartition}}: This macro helps you create an Arch Axis System along a line with a set of parameters.
 
 <!--T:398-->
 * {{MacroLink|Icon=Applications-python.svg|Macro_Convert_021|Macro Convert 021}}: Converts a FreeCAD file saved with a post-0.21 version back to 0.21 format.


### PR DESCRIPTION
This cleans up four descriptions in the macro catalog: FCInfoToMouse, Triangle AH, Spreadsheet Tools, and Arch Axis System Repartition. The edits improve grammar and terminology without changing installation instructions or macro behavior.

The page retains all 261 translation markers. Prepared with Codex assistance; this does not claim to complete the broader issue or assume a reward.