### PR TITLE
Use HTTPS for the PartDesign resource link

### DIFF
--- a/wiki/PartDesign_Workbench.wikitext
+++ b/wiki/PartDesign_Workbench.wikitext
@@ -268,7 +268,7 @@ Some additional tools available in the Part Design menu:
 == Tutorials == <!--T:107-->
 
 <!--T:108-->
-* [http://help-freecad-jpg87.fr/ How to use FreeCAD], a website describing the workflow for mechanical design.
+* [https://help-freecad-jpg87.fr/ How to use FreeCAD], a website describing the workflow for mechanical design.
 * [[Creating_a_simple_part_with_PartDesign|Creating a simple part with PartDesign]]
 * [[Basic_Part_Design_Tutorial_019|Basic Part Design Tutorial 019]]
 * [[PartDesign_Bearingholder_Tutorial_I|PartDesign Bearingholder Tutorial I]] (needs updating)


### PR DESCRIPTION
The external “How to use FreeCAD” resource supports HTTPS and returned HTTP 200 during validation, so this updates the PartDesign page to avoid the insecure HTTP link.

The page retains all 92 translation markers. Prepared with Codex assistance; this does not claim to complete the broader issue or assume a reward.