### PR TITLE
Refresh developer and scripting documentation entry points

### DIFF
--- a/wiki/Developer_hub.wikitext
+++ b/wiki/Developer_hub.wikitext
@@ -14,7 +14,7 @@
 This is the place to come if you want to contribute to the development of the FreeCAD software. Many of the following pages might be outdated. Check the official FreeCAD Developers Handbook for more up to date information: https://freecad.github.io/DevelopersHandbook/
 
 <!--T:3-->
-These pages are in the early stage of development. If you can't find the information you are looking for, or have found useful information somewhere we have not linked to, then please leave a comment on the [https://forum.freecad.org/index.php?sid=5f84150e79db8842e277b042077097ff forum] and someone will look into it.
+For help finding development information, or to suggest a resource for this hub, use the [https://forum.freecad.org/ FreeCAD forum].
 
 == Developer Documentation == <!--T:32-->
 
@@ -22,6 +22,8 @@ These pages are in the early stage of development. If you can't find the informa
 The developer documentation comprises the following sections:
 
 === Compiling FreeCAD === <!--T:33-->
+
+Start with the Developers Handbook's [https://freecad.github.io/DevelopersHandbook/gettingstarted/ build-environment guide], which covers dependencies, Pixi, source checkout, configuration and running a development build. The platform-specific wiki pages below provide additional details.
 
 <!--T:5-->
 * [https://github.com/FreeCAD/FreeCAD GitHub repo]: If you are new to git, read [[Source_code_management|Source code management]]
@@ -56,15 +58,18 @@ The developer documentation comprises the following sections:
 * The [[FreeCAD_Build_Tool|FreeCAD Build Tool]]
 ** [[Workbench_creation|Adding an application module]] to FreeCAD
 * [[Debugging|Debugging]] FreeCAD
-* [[Testing|Testing]] FreeCAD
-* [[Compiling_(Speeding_up)|Compiling (Speeding up)]] FreeCAD
+* [https://freecad.github.io/DevelopersHandbook/technical/automated_testing Automated testing]: Python tests integrated with the Test Workbench and standalone C++ tests. See also [[Testing|Testing FreeCAD]].
+* [https://freecad.github.io/DevelopersHandbook/gettingstarted/#pixi Building with Pixi], including limiting parallel compiler jobs.
+* [https://freecad.github.io/DevelopersHandbook/technical/Profiling-Python Profiling Python code] to investigate runtime performance.
 * [[Continuous_Integration|Continuous Integration]]
 
 === Modifying FreeCAD === <!--T:35-->
 
 <!--T:7-->
-* Understanding [[The_FreeCAD_source_code|The FreeCAD source code]]
-* [[Tracker#Submitting_patches|Submitting patches]]
+* The [https://freecad.github.io/DevelopersHandbook/technical/ technical guide] introduces the source tree, application objects, property changes and other internals. See also [[The_FreeCAD_source_code|The FreeCAD source code]].
+* [https://freecad.github.io/DevelopersHandbook/gettingstarted/#submitting-a-pr Submitting a pull request] and [https://freecad.github.io/DevelopersHandbook/gettingstarted/#pr-review-process the review process].
+* [https://freecad.github.io/DevelopersHandbook/codeformatting/ Code formatting] and [https://freecad.github.io/DevelopersHandbook/bestpractices/ code and review practices].
+* [https://freecad.github.io/DevelopersHandbook/designguide/ Design guidance] for interface and interaction changes.
 * Add [[Gui_Command|Features]] or a [[Workbench_creation|Workbench]] to FreeCAD
 * [[Branding|Branding]] or ''how to give FreeCAD a unique look''
 * [[Artwork|Artwork]] we made for FreeCAD, that you can freely reuse.
@@ -78,6 +83,20 @@ The developer documentation comprises the following sections:
 
 <!--T:16-->
 * [[Translating_an_external_workbench|Translating an external workbench]]
+
+=== Addon development ===
+
+The [https://freecad.github.io/Addon-Academy/ Addon Academy] provides guides and examples for creating and maintaining addons:
+* [https://freecad.github.io/Addon-Academy/Guides/Creating/ Create an addon] from the GitHub template or the cookiecutter generator.
+* [https://freecad.github.io/Addon-Academy/Topics/Structuring/ Organize the addon] using a namespaced layout and its manifest; the guide also explains the older layout.
+* [https://freecad.github.io/Addon-Academy/Guides/Code/ Write addon code], including workbench registration, commands, custom objects and preferences.
+* [https://freecad.github.io/Addon-Academy/Guides/Developing/ Develop locally], with installation, debugging and testing guides.
+* [https://freecad.github.io/Addon-Academy/Guides/Publishing/ Publish the addon] as an archive, by repository URL or through the Addon Index.
+* [https://freecad.github.io/Addon-Academy/Demos/ Runnable examples] for workbenches, commands, parametric features, preference pages and macros.
+
+=== Related project: Lens ===
+
+[https://freecad.github.io/lens-docs/ Lens documentation] covers running an instance of this collaboration and product data management system, managing projects in its web app, and using its FreeCAD addon. Its source-code section links to the FreeCAD-managed repositories for the headless runner, web app and addon.
 
 === Module developer's guide === <!--T:36-->
 
@@ -108,10 +127,8 @@ Latest PDF preview can be downloaded from [https://github.com/qingfengxia/FreeCA
 OpenCascade is a software development platform for 3D surface and solid modeling, CAD data exchange, and visualization, mostly in the form of C++ libraries.
 
 <!--T:18-->
-* [http://opencascade.wikidot.com/romansarticles Roman Lygin's tutorials]
-* [https://dev.opencascade.org/cdoc/overview/html/index.html Full Online Documentation]
-* [https://dev.opencascade.org/doc/refman/html/index.html Reference Manual]
-* [http://opencascade.wikidot.com The openCascade wiki] (currently containing ?? Chinese spam)
+* [https://occt3d.com/dev/doc/overview/html/index.html Open CASCADE Technology guides]
+* [https://occt3d.com/dev/doc/refman/html/index.html Open CASCADE Technology reference manual]
 * [[Compile_with_OCCT|Compiling with a custom OCCT]]
 
 ==== File format ==== <!--T:27-->
@@ -135,16 +152,16 @@ The development of a new solver architecture could improve the way the solver is
 == Roadmap == <!--T:37-->
 
 <!--T:9-->
-FreeCAD, though usable in certain areas, is at the beginning of a long way into the CAD mainstream. There is still a lot to do to reach a state where we can compete with commercial software.
+The Developers Handbook's [https://freecad.github.io/DevelopersHandbook/roadmap/ roadmap] describes broad objectives for FreeCAD development. The [https://github.com/FreeCAD/FreeCAD/milestones GitHub milestones] track issues against release targets.
 
 <!--T:39-->
-[[FreeCAD_1.0_Development_Cycle|FreeCAD 1.0 Development Cycle]]
+For historical context, see [[FreeCAD_1.0_Development_Cycle|FreeCAD 1.0 Development Cycle]].
 
 == Community == <!--T:30-->
 
 <!--T:31-->
-* [ircs://irc.libera.chat:6697/freecad IRC channel] ,synchronized with [https://gitter.im/FreeCAD/FreeCAD gitter channel]
-* [https://forum.freecad.org/viewforum.php?f=6 Development forum]
+* [https://freecad.github.io/DevelopersHandbook/gettingstarted/#collaborating-with-others Development communication channels and meetings]: the handbook links to GitHub issues, Discord, the forum and development meetings.
+* [https://forum.freecad.org/ FreeCAD forum]
 
 <!--T:10-->
 * [[Development_roadmap|Development roadmap]]

--- a/wiki/Development_roadmap.wikitext
+++ b/wiki/Development_roadmap.wikitext
@@ -4,7 +4,7 @@
 == Introduction == <!--T:17-->
 
 <!--T:18-->
-There is no roadmap for the whole FreeCAD project. If you want to get involved it is best to ask in the [https://forum.freecad.org/viewforum.php?f=10 Developer section] of the [https://forum.freecad.org/index.php FreeCAD forum].
+The [https://freecad.github.io/DevelopersHandbook/roadmap/ Developers Handbook roadmap] describes broad objectives for the FreeCAD project. For release-specific issue lists and targets, consult the [https://github.com/FreeCAD/FreeCAD/milestones GitHub milestones]. See the [[Developer_hub|Developer hub]] for development guides and ways to get involved.
 
 <!--T:19-->
 The following links may help you get started:

--- a/wiki/Power_users_hub.wikitext
+++ b/wiki/Power_users_hub.wikitext
@@ -42,6 +42,15 @@ If you'd like to contribute content to these pages, request a wiki account with 
 * [[Debugging#Python Debugging|Debugging]] the Python code
 *[[Python_Development_Environment|Python Development Environment]] - A simplistic development environment for Python within FreeCAD
 
+=== Creating addons ===
+
+The [https://freecad.github.io/Addon-Academy/ Addon Academy] guides you through turning Python code into an addon:
+* [https://freecad.github.io/Addon-Academy/Guides/Creating/ Create an addon] using a template or generator.
+* [https://freecad.github.io/Addon-Academy/Topics/Structuring/ Organize its files] with a namespaced layout and manifest.
+* [https://freecad.github.io/Addon-Academy/Guides/Code/ Write the addon code], including workbenches, GUI commands, preferences and document objects.
+* [https://freecad.github.io/Addon-Academy/Guides/Developing/ Develop locally], with guides to installation, debugging and testing.
+* [https://freecad.github.io/Addon-Academy/Guides/Publishing/ Publish the addon] for other FreeCAD users.
+
 === Modules === <!--T:28-->
 
 <!--T:29-->
@@ -83,10 +92,12 @@ The functionality of FreeCAD is separated in Modules which deal with special dat
 ** [[Scripted_objects_with_attachment|Scripted objects with attachment]]: how to make scripted objects attachable to other objects.
 ** [[Scripted_objects_saving_attributes|Scripted objects saving attributes]]: how to save and restore attributes of the proxy class with {{incode|dumps}} and {{incode|loads}}.
 ** [[Scripted_objects_migration|Scripted objects migration]]: how to migrate old scripted objects to a new class.
+* [https://freecad.github.io/Addon-Academy/Guides/Code/Document-Objects/ Custom document objects in addons]: FeaturePython objects, proxy classes and serialization.
 
 ===Examples=== <!--T:44-->
 
 <!--T:14-->
+* [https://freecad.github.io/Addon-Academy/Demos/ Addon Academy demos]: runnable examples of workbenches, commands, parametric features, preference pages and macros.
 * [[Code snippets|Code snippets]] : A collection of pieces of FreeCAD Python code, to serve as ingredients in your scripts...
 * [[Line drawing function|Line drawing function]]: How to build a simple tool to draw lines
 * [[Dialog creation|Dialog creation]]: How to construct dialogs with Qt designer, and use them in FreeCAD
@@ -97,7 +108,7 @@ The functionality of FreeCAD is separated in Modules which deal with special dat
 == API Functions == <!--T:15-->
 
 <!--T:16-->
-The complete API documentation of FreeCAD is located at https://freecad.org/api/ . It contains both C++ and Python APIs, and is not totally well formatted yet, which can be confusing when looking for python-only code. An easier to browse version can be found [[:Category:API|here]]. Note that it can be incomplete, since it is updated manually. For more accurate information, browse the modules directly from FreeCAD's Python console.
+The [https://freecad.github.io/SourceDoc/ generated source reference] documents FreeCAD's C++ and Python components. It describes a particular source snapshot: check the build date and revision on its front page before relying on it for the version you are using. The [[:Category:API|API pages on this wiki]] are maintained manually and may be incomplete. For information about the installed version, inspect modules directly in FreeCAD's [[Python_console|Python console]].
 
 <!--T:34-->
 Related: [[Exposing_C%2B%2B_to_Python|Exposing C++ to Python]]
@@ -105,6 +116,7 @@ Related: [[Exposing_C%2B%2B_to_Python|Exposing C++ to Python]]
 == Advanced modification == <!--T:17-->
 
 <!--T:18-->
+* [[Developer_hub|Developer hub]]: Development environment setup, contribution guidance and FreeCAD internals
 * [[Start_up_and_Configuration|Start up and Configuration]]: Startup and command line options
 * [[Installing_on_Windows|Installing on Windows]]: Using the windows installer
 * [[Compile_on_Windows|Compiling FreeCAD on Windows]] and [[Compile_on_Linux|Compiling FreeCAD on Linux]]
@@ -124,12 +136,9 @@ These are good generic tutorials, not specific to FreeCAD, that might interest y
 
 <!--T:22-->
 '''PySide''' - How to create and manage FreeCAD's Qt UI interface from python
-* [http://zetcode.com/gui/pysidetutorial/ PySide tutorial] : A platform-agnostic tutorial showing the usage of PySide with examples
-* [http://www.pythoncentral.io/series/python-pyside-pyqt-tutorial/ PySide/PyQt tutorial] : A easy to read tutorial that covers PySide and PyQt with examples
-* [http://qt-project.org/wiki/PySideDocumentation PySide documentation] : from the Qt Project (the people who wrote it all)
-* [http://qt-project.org/wiki/QtCreator_and_PySide Using QtCreator in PySide] : also from the Qt Project
-* [http://srinikom.github.io/pyside-docs/index.html PySide reference] : endless detail on the minutiae of PySide and Qt, a reliable reference source
-* [http://nullege.com/codes/search?cq=PySide PySide code snippets] : a searchable database of PySide code snippets
+* [[PySide|PySide in FreeCAD]]: Check your installation's Qt version and use FreeCAD's compatibility imports.
+* [https://freecad.github.io/Addon-Academy/Guides/Code/Qt/ Qt and PySide in addons]: Loading Qt Designer forms, parenting widgets to FreeCAD's main window, task panels and GUI threading.
+* [https://doc.qt.io/qtforpython-6/ Qt for Python]: Official PySide6 tutorials and API reference for installations using Qt6.
 
 <!--T:31-->
 The following two references are PyQt specific (not PySide) but may offer some information of use:


### PR DESCRIPTION
The Developer Hub and Power Users Hub omit direct routes to several maintained development guides, and `Development_roadmap` says there is no project-wide roadmap even though the Developers Handbook publishes one. This refresh links contributors to build, contribution, addon and Lens documentation, clarifies the source reference's snapshot limits, and makes the roadmap entries consistent.

Related to #329. This complements @Cauho's #448: its introductory resource list, SourceDoc snapshot note and two link corrections remain separate. A three-way merge against #448 at `03af11b4fdf4b66a3db13424be16c43f50a19d35` succeeds without conflicts.

Changes and sources:

| Location | Change and reason | Source |
| --- | --- | --- |
| Developer Hub introduction | Replace the old “early stage” message and forum URL containing a session ID with a direct route for development questions and resource suggestions. | [Handbook communication guidance](https://freecad.github.io/DevelopersHandbook/gettingstarted/#collaborating-with-others) |
| Compiling FreeCAD | Put build-environment setup before the platform-specific wiki links so contributors can find dependencies, Pixi, checkout, configuration and running a development build. | [Getting Started](https://freecad.github.io/DevelopersHandbook/gettingstarted/) |
| Support Tools: testing | Link the handbook's Python/Test Workbench and standalone C++ testing guidance while retaining the wiki testing page. | [Automated Testing](https://freecad.github.io/DevelopersHandbook/technical/automated_testing) |
| Support Tools: build performance | Replace the archived `Compiling_(Speeding_up)` entry with Pixi guidance, including compiler job limits. The archived page itself directs readers to this source. | [Building with Pixi](https://freecad.github.io/DevelopersHandbook/gettingstarted/#pixi) |
| Support Tools: runtime performance | Add the handbook's Python profiling guide so runtime investigation is discoverable separately from build configuration. | [Profiling Python Code](https://freecad.github.io/DevelopersHandbook/technical/Profiling-Python) |
| Modifying FreeCAD: internals | Add the technical guide as an entry point to the source tree, application objects and property changes, alongside the existing source-code article. | [Technical Guide](https://freecad.github.io/DevelopersHandbook/technical/) |
| Modifying FreeCAD: contributions | Replace the old patch-submission entry with the handbook's pull-request and review workflow, and add formatting, review-practice and interface-design guidance. | [Submitting a PR](https://freecad.github.io/DevelopersHandbook/gettingstarted/#submitting-a-pr), [review process](https://freecad.github.io/DevelopersHandbook/gettingstarted/#pr-review-process), [formatting](https://freecad.github.io/DevelopersHandbook/codeformatting/), [practices](https://freecad.github.io/DevelopersHandbook/bestpractices/), [design](https://freecad.github.io/DevelopersHandbook/designguide/) |
| New Addon development section | Add a route through addon creation, structure, code, local development, publication and runnable examples. Retain the existing module guide as additional material. | [Addon Academy](https://freecad.github.io/Addon-Academy/), with direct chapter links in the page |
| New related-project section | Explain where Lens documentation fits: instance administration, project management, the FreeCAD addon and component source repositories. | [Lens documentation](https://freecad.github.io/lens-docs/) |
| OpenCascade documentation | Replace the Wikidot entries and old overview URL with the verified official guides and reference manual. Both Wikidot destinations returned redirect-loop errors during checking; the existing hub already flagged the wiki as containing spam. | [OCCT guides](https://occt3d.com/dev/doc/overview/html/index.html), [OCCT reference manual](https://occt3d.com/dev/doc/refman/html/index.html) |
| Hub roadmap and `Development_roadmap` introduction | Point to broad project objectives and GitHub milestones for release targets; identify the 1.0 development-cycle page as historical context. The handbook's separate “Next Release” chapter still describes 1.0, so it is not used as the current release plan. | [Roadmap](https://freecad.github.io/DevelopersHandbook/roadmap/), [milestones](https://github.com/FreeCAD/FreeCAD/milestones) |
| Community | Replace the IRC/Gitter synchronization statement with the handbook's maintained list of development channels and meetings, plus the forum. | [Collaborating with others](https://freecad.github.io/DevelopersHandbook/gettingstarted/#collaborating-with-others) |
| Power Users Hub: addon development | Add the creation-to-publication route for Python users who want to package their scripts as an addon. | [Addon Academy](https://freecad.github.io/Addon-Academy/), with direct chapter links in the page |
| Power Users Hub: parametric objects and examples | Connect the existing scripting articles to the Academy's FeaturePython/proxy/serialization guide and runnable addon examples. | [Custom document objects](https://freecad.github.io/Addon-Academy/Guides/Code/Document-Objects/), [demos](https://freecad.github.io/Addon-Academy/Demos/) |
| Power Users Hub: API functions | Replace the assertion that the external reference is complete with a link to the generated source snapshot and guidance to check its build date and revision. Retain the manual wiki reference and direct readers to their installed Python modules for version-specific information. | [SourceDoc](https://freecad.github.io/SourceDoc/), whose front page identifies its source revision and omitted content |
| Power Users Hub: advanced modification | Add a route back to the Developer Hub so scripting users can find core build and contribution guidance. | The updated `Developer_hub.wikitext` in this PR |
| Power Users Hub: Qt resources | Replace the old collection with FreeCAD-specific compatibility guidance, the Academy's UI integration guide and the official PySide6 reference. The Qt6 link is explicitly scoped to installations using Qt6. | Existing `PySide.wikitext`, [Qt in addons](https://freecad.github.io/Addon-Academy/Guides/Code/Qt/), [Qt for Python](https://doc.qt.io/qtforpython-6/) |

Validation: all three changed wiki-root pages parse with Pandoc; all 28 added external URLs and fragment targets resolve, and all seven added internal-link occurrences point to existing pages. The existing API category reference is preserved. All 78 existing translation markers and all original EOF styles are preserved; no translation files change. `git diff --check` passes. The three source pages remain unchanged in the latest upstream revision checked on 10 September 2026.

This is a targeted update to the two hubs and roadmap entry. It does not claim that every linked legacy guide has been rewritten or audited in full.
