### PR TITLE
Document Draft grid persistence and forced projection updates

### DIFF
--- a/wiki/Draft_Preferences.wikitext
+++ b/wiki/Draft_Preferences.wikitext
@@ -280,7 +280,7 @@ On this page you can specify the following:
 <translate>
 
 <!--T:146-->
-Note that several grid preferences can also be changed with the [[Draft_SelectPlane|Draft SelectPlane]] command.
+Several grid settings can also be changed in the [[Draft_SelectPlane#Options|Working Plane Setup]] task panel. {{Version|26.3}}: Changes to {{MenuCommand|Grid spacing}}, {{MenuCommand|Major lines every}} and {{MenuCommand|Grid size}} in that panel are saved with the active document. For these three settings, the preferences below supply the default when no document value is stored. Changing these preferences does not replace values already stored in a document.
 
 <!--T:158-->
 On this page you can specify the following:

--- a/wiki/Draft_SelectPlane.wikitext
+++ b/wiki/Draft_SelectPlane.wikitext
@@ -97,6 +97,7 @@ The [[Image:Draft_tray_button_plane.png]] button in the [[Draft_Tray|Draft Tray]
 * The {{MenuCommand|Grid spacing}} defines the distance between grid lines.
 * The {{MenuCommand|Major lines every}} value determines where major grid lines are drawn. Major grid lines are slightly thicker than minor grid lines. For example if the grid spacing is {{Value|0.5 m}} and there is a main line every {{Value|10 squares}}, such a line will occur every {{Value|5 m}}.
 * The {{MenuCommand|Grid size}} value determines the number of squares in the X and Y direction of the grid.
+* {{Version|26.3}}: Changes to {{MenuCommand|Grid spacing}}, {{MenuCommand|Major lines every}} and {{MenuCommand|Grid size}} are stored in the active document. Save the document to retain these values when reopening it. Documents without a stored value use the corresponding [[Draft_Preferences#Grid_and_Snapping|Draft preference]]. These changes do not alter the defaults for other documents.
 * The {{MenuCommand|Snapping radius}} is the maximum distance at which [[Draft_Snap_Grid|Draft Snap Grid]] detects the intersections of grid lines.
 * Press the {{Button|[[Image:view-fullscreen.svg|16px]] Center View}} button to align the [[3D_View|3D View]] with the current working plane.
 * Press the {{Button|[[Image:sel-back.svg|16px]] Previous}} button to reset the working plane to its previous position.
@@ -116,7 +117,7 @@ The [[Image:Draft_tray_button_plane.png]] button in the [[Draft_Tray|Draft Tray]
 See also: [[Preferences_Editor|Preferences Editor]] and [[Draft_Preferences|Draft Preferences]].
 
 <!--T:40-->
-* The grid settings in the task panel as well as several other grid settings are available as preferences: {{MenuCommand|Edit → Preferences → Draft → Grid and Snapping}}.
+* Grid preferences are available at {{MenuCommand|Edit → Preferences → Draft → Grid and Snapping}}. {{Version|26.3}}: The spacing, major line interval and size preferences provide defaults for documents without their own values; change a document's values in this task panel. Grid color and snapping radius remain global preferences.
 * The Snapping radius can also be changed on-the-fly (see [[Draft_Snap#Preferences|Draft Snap]]) or by changing: {{MenuCommand|Tools → Edit Parameters → BaseApp → Preferences → Mod → Draft → snapRange}}.
 
 ==Scripting== <!--T:41-->

--- a/wiki/Draft_Shape2DView.wikitext
+++ b/wiki/Draft_Shape2DView.wikitext
@@ -44,6 +44,17 @@ Draft Shape2DView projections can be displayed on a [[TechDraw_Workbench|TechDra
 # If you have not yet selected an object: select an object in the [[3D_View|3D View]].
 # The projected objects are created on the XY-plane.
 
+===Updating projections===
+
+{{Version|26.3}}: The {{MenuCommand|Force 2D View Update}} command updates projections even when their {{PropertyData|Auto Update}} property is {{False}}, without changing that property.
+
+# Activate the [[Draft_Workbench|Draft]] or [[BIM_Workbench|BIM]] workbench.
+# Select one or more Draft Shape2DView objects in the [[Tree_View|Tree View]].
+# Choose {{MenuCommand|Force 2D View Update}} from the context menu, or use the keyboard shortcut {{KEY|V}} then {{KEY|T}}.
+# The selected projections are updated from their base objects.
+
+To update all Draft Shape2DViews in the active document, clear the selection and use {{KEY|V}} then {{KEY|T}}.
+
 ==How to produce plans and sections with different linewidths== <!--T:31-->
 
 <!--T:32-->
@@ -66,7 +77,7 @@ A Draft Shape2DView object is derived from a [[Part_Part2DObject|Part Part2DObje
 {{TitleProperty|Draft}}
 
 <!--T:9-->
-* {{PropertyData|Auto Update|Bool}}: specifies if the projection should be automatically recomputed if the {{PropertyData|Base}} object changes. Selecting {{False}} can be useful if there are many Draft Shape2DViews in a document or if they are complex. If set to {{False}} the [[Std_Refresh|Std Refresh]] command must be used to update the projection.
+* {{PropertyData|Auto Update|Bool}}: specifies if the projection should be automatically recomputed if the {{PropertyData|Base}} object changes. Selecting {{False}} can be useful if there are many Draft Shape2DViews in a document or if they are complex. {{Version|26.3}}: Use [[#Updating_projections|Force 2D View Update]] to update a projection while this property is {{False}}.
 * {{PropertyData|Base|Link}}: specifies the object to be projected.
 * {{PropertyData|Clip|Bool}}: if this is True, the contents are clipped to the borders of the section plane, if applicable. This overrides the base object's Clip property.
 * {{PropertyData|Face Numbers|IntegerList}}: specifies the indices of the faces to be projected. Only works if {{PropertyData|Projection Mode}} is {{Value|Individual Faces}}.


### PR DESCRIPTION
Draft's working-plane pages do not explain which grid settings are saved with a document, and the Shape2DView page still directs users to ordinary Refresh when automatic updates are disabled. This documents the new grid behavior and the dedicated Force 2D View Update workflow in FreeCAD 26.3.

Related to #27.

- **Draft_SelectPlane:** Explain that grid spacing, major-line interval and grid size are stored in the active document and survive saving/reopening. Distinguish these values from global color and snapping-radius preferences. The feature was added in [FreeCAD/FreeCAD#30696](https://github.com/FreeCAD/FreeCAD/pull/30696); the [current task-panel handlers](https://github.com/FreeCAD/FreeCAD/blob/7f4be93f8570f57ed30ef778bedb0527abb7a64d/src/Mod/Draft/draftguitools/gui_selectplane.py#L274-L305) show which settings are document-specific.
- **Draft_Preferences:** Explain why changing global grid defaults does not replace values already saved in a document, and link to Working Plane Setup for changing those values. The [grid preference lookup and storage](https://github.com/FreeCAD/FreeCAD/blob/7f4be93f8570f57ed30ef778bedb0527abb7a64d/src/Mod/Draft/draftutils/params.py#L848-L907) define the per-setting fallback. The existing release-note entry for #30696 is retained without duplication.
- **Draft_Shape2DView:** Add the selected-view context-menu workflow and the `V`, then `T` shortcut; explain that an empty selection updates every Shape2DView in the active document and that Auto Update is unchanged. This command was added in [FreeCAD/FreeCAD#30130](https://github.com/FreeCAD/FreeCAD/pull/30130). The wording follows the [current command name and behavior](https://github.com/FreeCAD/FreeCAD/blob/7f4be93f8570f57ed30ef778bedb0527abb7a64d/src/Mod/Draft/draftguitools/gui_shape2dview.py#L133-L164), with context-menu registration in [Draft](https://github.com/FreeCAD/FreeCAD/blob/7f4be93f8570f57ed30ef778bedb0527abb7a64d/src/Mod/Draft/InitGui.py#L235-L242) and [BIM](https://github.com/FreeCAD/FreeCAD/blob/7f4be93f8570f57ed30ef778bedb0527abb7a64d/src/Mod/BIM/InitGui.py#L785-L790).

Validation used the official macOS arm64 weekly build dated 2026-09-09, reporting FreeCAD 26.3.0 at `306259d7aa3e7f3b40a22232eb60973deb39ca20`:

- All five bundled `DraftGridSettings` tests passed. A separate two-document fixture confirmed independent values, unchanged global defaults and persistence after saving/reopening.
- With two projections and Auto Update disabled, changing a box from 10 mm to 20 mm left both projections at 10 mm after ordinary recompute. GUI command dispatch with an active 3D view updated only the selected projection; dispatch with no selection updated both. Auto Update remained false on both objects.
- Menu registration and shortcut text were checked against source; mouse menu interaction and keyboard-event delivery were not exercised.
- The three edited wiki-root pages preserve all 162 existing translation markers. Added internal links/anchors, translation boundaries, template/link delimiter counts and `git diff --check` passed. No translation files were edited.
