### PR TITLE
Document external geometry for CAM Engrave and Vcarve

### DIFF
--- a/wiki/CAM_Engrave.wikitext
+++ b/wiki/CAM_Engrave.wikitext
@@ -29,9 +29,10 @@ The [[Image:CAM_Engrave.svg|24px]] [[CAM_Engrave|CAM Engrave]] command is primar
 # There are several ways to invoke the command:
 #* Press the {{Button|[[Image:CAM_Engrave.svg|16px]] [[CAM_Engrave|Engrave]]}} button.
 #* Select the {{MenuCommand|CAM → [[Image:CAM_Engrave.svg|16px]] Engrave}} option from the menu.
-# In the {{MenuCommand|Base Geometry}} section, select the geometry to engrave.
+# In the {{MenuCommand|Base Geometry}} section, select the geometry to engrave and press {{Button|Add}}.
 #* A [[Image:Draft_ShapeString.svg|16px]] [[Draft_ShapeString|Draft ShapeString]] can be used.
 #* Other flat 2D geometry, such as imported SVG-based shapes, can also be used.
+#* {{Version|26.3}}: The drawing geometry can be selected directly from the same document even if it is outside the [[CAM_Job|Job]]'s {{MenuCommand|Model}} group. For example, imported SVG shapes do not need to be added as Job models before adding them to {{MenuCommand|Base Geometry}}.
 #* When possible, select the whole flat shape instead of selecting many individual edges in the [[3D_View|3D View]].
 # In the {{MenuCommand|Depths}} section, check and adjust the depth settings as required.
 # Confirm the operation.

--- a/wiki/CAM_Vcarve.wikitext
+++ b/wiki/CAM_Vcarve.wikitext
@@ -71,9 +71,10 @@ The V-carve algorithm calculates a path down the center-line of a region using a
 <!--T:27-->
 * Switch to the {{Button|[[File:Workbench_CAM.svg|16px]] [[CAM_Workbench|CAM Workbench]]}} in the [[Std_Workbench|workbench dropdown menu]]
 * Add a job, use the objects named {{incode|Face<number>}} (or the ShapeString) as a base, add a v-bit tool controller, set feeds, speeds, etc.
+* {{Version|26.3}}: You can also use an existing [[CAM_Job|Job]] whose {{MenuCommand|Model}} group does not contain the drawing geometry. ShapeStrings and prepared 2D faces can be selected directly from elsewhere in the same document and added to the operation's {{MenuCommand|Base Geometry}}.
 * The operation only supports one object (either a single Face object, or a ShapeString) so for each object:
 ** Select {{MenuCommand|CAM → [[Image:CAM_Vcarve.svg|16px]] Vcarve}} from the top menu. This opens the configuration panel.
-** Open the {{KEY|Base Geometry}} tab and add all faces of the ShapeString, or the face of a single Face object obtained above
+** Open the {{MenuCommand|Base Geometry}} tab, select all faces of the ShapeString or the face of a single Face object obtained above, and press {{Button|Add}}
 ** Press {{Button|Apply}} and inspect the generated path; if necessary, adjust operation parameters (Threshold can be set higher in most situations)
 ** Press {{Button|OK}} to finish
 


### PR DESCRIPTION
Engrave and Vcarve can now use drawing geometry outside a Job's Model group. The operation pages explain this FreeCAD 26.3 workflow and make the Base Geometry → Add step explicit.

Related to #25. The feature was merged in [FreeCAD/FreeCAD#31371](https://github.com/FreeCAD/FreeCAD/pull/31371).

- **CAM_Engrave:** Explain that imported SVG or other drawing geometry in the same document can be used directly, without adding it as a Job model. The [current Engrave base-geometry handler](https://github.com/FreeCAD/FreeCAD/blob/c6f9f3ffd42cea1663f002ac473bac81afc0130b/src/Mod/CAM/Path/Op/Gui/Engrave.py#L51-L92) accepts whole flat shapes and their selected elements.
- **CAM_Vcarve:** Explain how prepared 2D faces or ShapeStrings can be added to an existing Job's operation while remaining outside its Model group. The [current Vcarve handler](https://github.com/FreeCAD/FreeCAD/blob/c6f9f3ffd42cea1663f002ac473bac81afc0130b/src/Mod/CAM/Path/Op/Gui/Vcarve.py#L57-L90) accepts these objects and delegates other face selections to the [base-geometry handler](https://github.com/FreeCAD/FreeCAD/blob/c6f9f3ffd42cea1663f002ac473bac81afc0130b/src/Mod/CAM/Path/Op/Gui/Base.py#L878-L918). The Add button's label and purpose are defined in [PageBaseGeometryEdit.ui](https://github.com/FreeCAD/FreeCAD/blob/c6f9f3ffd42cea1663f002ac473bac81afc0130b/src/Mod/CAM/Gui/Resources/panels/PageBaseGeometryEdit.ui#L67-L73).

Validation used the official macOS arm64 weekly build dated 2026-09-09, reporting FreeCAD 26.3.0 at `306259d7aa3e7f3b40a22232eb60973deb39ca20`. A fixture created a Job from a solid workpiece, then used the actual CAM operation factories, GUI base-geometry panels and GUI selection objects to add external whole 2D geometry, an Engrave edge and a Vcarve face. All four selections retained direct references to the external objects, and the Job's Model group remained unchanged. Toolpath generation, machine motion and mouse-event interaction were not tested.

Both edited wiki-root pages preserve all 56 existing translation markers. Added links, translation boundaries, template/link delimiter counts and `git diff --check` passed. No open documentation PR touched these pages when checked.
