### PR TITLE
Document BIM pipe tees with different branch profiles

### DIFF
--- a/wiki/Arch_Pipe.wikitext
+++ b/wiki/Arch_Pipe.wikitext
@@ -112,6 +112,8 @@ FreeCAD.ActiveDocument.Equipment.SnapPoints=[FreeCAD.Vector(0,0,100)]
 <!--T:22-->
 * We can now create connections by selecting 2 or 3 coincident tubes, and press the [[Arch_PipeConnector|Arch PipeConnector]] button. If 3 pipes are selected, two of them must be aligned in order to create a tee element:
 
+The aligned pipes should have matching profiles. The branch can have a different profile ({{VersionPlus|26.3}}), for example a smaller diameter. See [[Arch_PipeConnector#Scripting|Arch PipeConnector]] for an example with two 100 mm main pipes and a 50 mm branch.
+
 <!--T:23-->
 [[Image:Arch_pipe_example_07.jpg]]
 

--- a/wiki/Arch_PipeConnector.wikitext
+++ b/wiki/Arch_PipeConnector.wikitext
@@ -32,10 +32,12 @@ The '''Arch PipeConnector''' tool allows to create corner or tee connection betw
 # Select 2 or 3 [[Arch_Pipe|Arch Pipes]]. If you are selecting 3 pipes, two of them must be exactly aligned.
 # Press the {{Button|[[Image:Arch_PipeConnector.svg|16px]] [[Arch_PipeConnector|Connector]]}} button, or press {{KEY|P}} then {{KEY|C}} keys.
 
+For a tee connection, the base wires of all three pipes must share an endpoint. The two aligned pipes form the main run and should have matching profiles. The third pipe forms the branch and can have a different profile ({{VersionPlus|26.3}}). For example, two circular pipes with a diameter of 100 mm can be connected to a branch with a diameter of 50 mm.
+
 == Properties == <!--T:6-->
 
 <!--T:7-->
-* {{PropertyData|Radius}}: The curvature radius of this connector
+* {{PropertyData|Radius}}: The curvature radius of this connector. For a tee, this is the distance from the shared endpoint to each end of the connector. The default at creation is the largest of these dimensions across all connected pipes: {{PropertyData|Diameter}} for circular profiles, and {{PropertyData|Height}} and {{PropertyData|Width}} for other profile types ({{VersionPlus|26.3}}). This value can be changed after creation.
 
 == Typical workflow == <!--T:8-->
 
@@ -94,6 +96,30 @@ FreeCAD.ActiveDocument.recompute()
 
 Conn3 = Arch.makePipeConnector([Pipe4, Pipe5], radius=400)
 FreeCAD.ActiveDocument.recompute()
+}}
+<translate>
+
+This example creates a tee with a 50 mm branch and two aligned 100 mm main pipes in a new document ({{VersionPlus|26.3}}). The pipes have a wall thickness of 5 mm. The connector's initial {{PropertyData|Radius}} is 100 mm; an explicit {{incode|radius}} argument can be used to choose another value.
+
+</translate>
+{{Code|code=
+import FreeCAD, Draft, Arch
+
+doc = FreeCAD.newDocument("ReducingTeeExample")
+origin = FreeCAD.Vector(0, 0, 0)
+left_line = Draft.make_wire([FreeCAD.Vector(-1000, 0, 0), origin])
+right_line = Draft.make_wire([origin, FreeCAD.Vector(1000, 0, 0)])
+branch_line = Draft.make_wire([origin, FreeCAD.Vector(0, 1000, 0)])
+
+left_pipe = Arch.makePipe(left_line, 100)
+right_pipe = Arch.makePipe(right_line, 100)
+branch_pipe = Arch.makePipe(branch_line, 50)
+for pipe in (left_pipe, right_pipe, branch_pipe):
+    pipe.WallThickness = 5
+doc.recompute()
+
+tee = Arch.makePipeConnector([left_pipe, right_pipe, branch_pipe])
+doc.recompute()
 }}
 <translate>
 


### PR DESCRIPTION
The 26.3 release notes mention that a pipe tee can use a different branch profile, but the connector page and pipe workflow do not explain how to use it. This adds the setup requirements, radius behavior, and a complete example with two 100 mm main pipes and a 50 mm branch.


Changes and sources:

- **Connector usage:** explain the shared endpoint, aligned main pipes with matching profiles, and independently sized branch. This documents the new capability in [FreeCAD/FreeCAD#29504](https://github.com/FreeCAD/FreeCAD/pull/29504), which implements the request in [#22351](https://github.com/FreeCAD/FreeCAD/issues/22351).
- **Radius property:** explain its meaning for a tee and that the initial default considers the dimensions of every connected pipe. The calculation is in [`makePipeConnector` at the merged feature revision](https://github.com/FreeCAD/FreeCAD/blob/e13f1c0f10c776f4a0e6cf23255ebf81c21d09c3/src/Mod/BIM/Arch.py); the tee offsets are set in [`ArchPipe.py`](https://github.com/FreeCAD/FreeCAD/blob/e13f1c0f10c776f4a0e6cf23255ebf81c21d09c3/src/Mod/BIM/ArchPipe.py).
- **Scripting example:** show the feature with three wires sharing an endpoint, 5 mm pipe walls, and a recompute before creating the connector. The existing examples only create two-pipe corner connectors. The new example demonstrates the branch-profile support from [#29504](https://github.com/FreeCAD/FreeCAD/pull/29504).
- **Pipe workflow:** add a brief explanation and link to the example at the existing tee-creation step. The 26.3 version marker agrees with the [existing release-note entry](https://github.com/Reqrefusion/FreeCAD-Documentation-Project/blob/902edf1cb389183056eb51aa3d9d50b70bf07a05/wiki/Release_notes_26.3.wikitext).

Validation: executed the exact new example in FreeCAD 26.3.0devR20260908 (306259d7a); it creates one valid solid with 100 mm main ports, a 50 mm branch port, and initial Radius 100 mm. Changing Radius to 200 mm updates all three pipe offsets. Eleven additional geometry cases passed, covering all six selection orders, hollow pipes, a larger branch, rectangular and mixed profiles, and an explicit radius. These were headless geometry checks; GUI interaction was not tested.

Checked against current main (902edf1c) and all seven open PRs: none changes either page. Only two English wiki-root files change, existing translation markers are preserved, Python snippets compile, and `git diff --check` passes.
